### PR TITLE
feat(desktop): design system overhaul + repo dashboard view

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -12,6 +12,7 @@ import FileHistoryViewer from "./components/FileHistoryViewer.vue";
 import CommitGraph from "./components/CommitGraph.vue";
 import SettingsPanel from "./components/SettingsPanel.vue";
 import PrDetailView from "./components/PrDetailView.vue";
+import DashboardView from "./components/DashboardView.vue";
 import EditCommitOverlay from "./components/EditCommitOverlay.vue";
 import { usePrPanel, PR_PANEL_KEY } from "./composables/usePrPanel";
 import type { GitLogEntry } from "./utils/backend";
@@ -696,8 +697,19 @@ onUnmounted(() => {
             </button>
           </div>
 
+          <!-- Dashboard view (default when opening a repo) -->
+          <DashboardView
+            v-if="viewMode === 'dashboard'"
+            :cwd="repoFolderPath ?? ''"
+            :branch="branchDisplay"
+            :status="repoStats"
+            :ahead="aheadCount"
+            :behind="behindCount"
+            @change-view="onViewModeChange"
+          />
+
           <!-- Changes view: conflict editor, file history, or diff viewer -->
-          <template v-if="viewMode === 'changes'">
+          <template v-else-if="viewMode === 'changes'">
             <MergeEditor
               v-if="showingMergeEditor && mergeSelectedFile"
               :file="mergeSelectedFile"

--- a/apps/desktop/src/assets/main.css
+++ b/apps/desktop/src/assets/main.css
@@ -1,20 +1,110 @@
-/* ─── GitWand Desktop — Global Styles ──────────────────────────── */
+/* ─── GitWand Desktop — Global Styles ───────────────────────────
+   Design System v1.0  —  see docs/design-system.md
+   Tokens: colors, typography, spacing, radius, shadows, motion
+   + primitives: .btn, .input, .card, .badge, .popover, .segmented
+   ──────────────────────────────────────────────────────────── */
 
-/* ─── Dark theme (default) ─────────────────────────────────────── */
+/* ─── Shared tokens (theme-agnostic) ───────────────────────── */
+:root {
+  /* Typography */
+  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
+  --font-sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif;
+
+  --font-size-xs: 10px;
+  --font-size-sm: 11px;
+  --font-size-base: 12px;
+  --font-size-md: 13px;
+  --font-size-lg: 14px;
+  --font-size-xl: 16px;
+  --font-size-2xl: 20px;
+  --font-size-3xl: 26px;
+
+  --font-weight-regular: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  --line-height-tight: 1.2;
+  --line-height-snug: 1.35;
+  --line-height-normal: 1.5;
+
+  /* Spacing scale (4px base) */
+  --space-1: 2px;
+  --space-2: 4px;
+  --space-3: 6px;
+  --space-4: 8px;
+  --space-5: 12px;
+  --space-6: 16px;
+  --space-7: 20px;
+  --space-8: 24px;
+  --space-9: 32px;
+  --space-10: 40px;
+  --space-11: 48px;
+  --space-12: 64px;
+
+  /* Radius scale */
+  --radius-xs: 3px;
+  --radius-sm: 6px;
+  --radius-md: 8px;
+  --radius-lg: 10px;
+  --radius-xl: 14px;
+  --radius-2xl: 20px;
+  --radius-pill: 9999px;
+
+  /* Motion */
+  --ease-out: cubic-bezier(.2, .8, .2, 1);
+  --transition-fast: 100ms var(--ease-out);
+  --transition-base: 160ms var(--ease-out);
+  --transition-slow: 240ms var(--ease-out);
+
+  /* Layout */
+  --sidebar-width: 340px;
+  --header-height: 56px;
+  --tabbar-height: 40px;
+
+  /* Code */
+  --code-font-size: 12px;
+  --code-tab-size: 4;
+}
+
+/* ─── Dark theme (default) ─────────────────────────────────── */
 :root,
 [data-theme="dark"] {
-  --color-bg: #0f0f14;
-  --color-bg-secondary: #1a1a24;
-  --color-bg-tertiary: #24243a;
-  --color-border: #2e2e48;
-  --color-text: #e4e4ef;
-  --color-text-muted: #8888a8;
+  /* Surfaces */
+  --color-bg: #0d0d13;
+  --color-bg-secondary: #15151f;
+  --color-bg-tertiary: #1f1f2d;
+  --color-surface-inverse: #f4f4f8;
+  --color-surface-inverse-text: #15151f;
+  --color-surface-inverse-muted: #5b5b78;
+
+  /* Borders */
+  --color-border: #262638;
+  --color-border-strong: #353550;
+
+  /* Text */
+  --color-text: #ebebf5;
+  --color-text-muted: #8a8aa8;
+  --color-text-subtle: #5d5d78;
+
+  /* Accent (identité GitWand) */
   --color-accent: #8b5cf6;
   --color-accent-hover: #a78bfa;
+  --color-accent-soft: rgba(139, 92, 246, 0.16);
+  --color-accent-text: #ffffff;
+
+  /* Severity — fort + soft (pour fonds tintés) */
   --color-success: #22c55e;
+  --color-success-soft: rgba(34, 197, 94, 0.14);
   --color-warning: #f59e0b;
+  --color-warning-soft: rgba(245, 158, 11, 0.16);
   --color-danger: #ef4444;
-  --color-danger-bg: rgba(239, 68, 68, 0.15);
+  --color-danger-soft: rgba(239, 68, 68, 0.16);
+  --color-danger-bg: rgba(239, 68, 68, 0.15); /* legacy alias */
+  --color-info: #60a5fa;
+  --color-info-soft: rgba(96, 165, 250, 0.16);
+
+  /* Merge lanes */
   --color-ours: #3b82f6;
   --color-ours-bg: rgba(59, 130, 246, 0.1);
   --color-theirs: #a855f7;
@@ -22,38 +112,77 @@
   --color-resolved-bg: rgba(34, 197, 94, 0.08);
   --color-overlay: rgba(0, 0, 0, 0.6);
 
-  --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", monospace;
-  --font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  /* Focus */
+  --color-focus-ring: rgba(139, 92, 246, 0.55);
 
-  --sidebar-width: 340px;
-  --header-height: 48px;
+  /* Legacy aliases (kept so older components keep working) */
+  --color-bg-hover: var(--color-bg-tertiary);
+  --color-text-secondary: var(--color-text-muted);
 
-  --code-font-size: 12px;
-  --code-tab-size: 4;
+  /* Shadows */
+  --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.35);
+  --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.35);
+  --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 16px 40px rgba(0, 0, 0, 0.55);
+  --shadow-xl: 0 24px 60px rgba(0, 0, 0, 0.6);
 }
 
-/* ─── Light theme ──────────────────────────────────────────────── */
+/* ─── Light theme ──────────────────────────────────────────── */
 [data-theme="light"] {
-  --color-bg: #f8f8fc;
+  /* Surfaces */
+  --color-bg: #f4f4f8;
   --color-bg-secondary: #ffffff;
-  --color-bg-tertiary: #eeeef5;
-  --color-border: #d4d4e0;
-  --color-text: #1e1e2e;
-  --color-text-muted: #6b6b88;
+  --color-bg-tertiary: #eceef4;
+  --color-surface-inverse: #15151f;
+  --color-surface-inverse-text: #f4f4f8;
+  --color-surface-inverse-muted: #9a9ab0;
+
+  /* Borders */
+  --color-border: #e4e4ed;
+  --color-border-strong: #cccfda;
+
+  /* Text */
+  --color-text: #15151f;
+  --color-text-muted: #5b5b78;
+  --color-text-subtle: #9a9ab0;
+
+  /* Accent */
   --color-accent: #7c3aed;
   --color-accent-hover: #6d28d9;
+  --color-accent-soft: rgba(124, 58, 237, 0.12);
+  --color-accent-text: #ffffff;
+
+  /* Severity */
   --color-success: #16a34a;
+  --color-success-soft: rgba(22, 163, 74, 0.12);
   --color-warning: #d97706;
+  --color-warning-soft: rgba(217, 119, 6, 0.14);
   --color-danger: #dc2626;
+  --color-danger-soft: rgba(220, 38, 38, 0.1);
   --color-danger-bg: rgba(220, 38, 38, 0.1);
+  --color-info: #2563eb;
+  --color-info-soft: rgba(37, 99, 235, 0.12);
+
+  /* Merge lanes */
   --color-ours: #2563eb;
   --color-ours-bg: rgba(37, 99, 235, 0.08);
   --color-theirs: #9333ea;
   --color-theirs-bg: rgba(147, 51, 234, 0.08);
   --color-resolved-bg: rgba(22, 163, 74, 0.06);
-  --color-overlay: rgba(0, 0, 0, 0.3);
+  --color-overlay: rgba(20, 20, 35, 0.35);
+
+  /* Focus */
+  --color-focus-ring: rgba(124, 58, 237, 0.4);
+
+  /* Shadows */
+  --shadow-xs: 0 1px 2px rgba(20, 20, 35, 0.04);
+  --shadow-sm: 0 2px 8px rgba(20, 20, 35, 0.06);
+  --shadow-md: 0 10px 30px rgba(20, 20, 35, 0.1);
+  --shadow-lg: 0 16px 40px rgba(20, 20, 35, 0.14);
+  --shadow-xl: 0 24px 60px rgba(20, 20, 35, 0.18);
 }
 
+/* ─── Reset ────────────────────────────────────────────────── */
 * {
   margin: 0;
   padding: 0;
@@ -67,47 +196,37 @@ html, body, #app {
 
 body {
   font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-normal);
   background: var(--color-bg);
   color: var(--color-text);
   -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
-/* ─── Scrollbar ──────────────────────────────────────────────── */
-
+/* ─── Scrollbar ─────────────────────────────────────────────── */
 ::-webkit-scrollbar {
   width: 8px;
   height: 8px;
 }
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
   background: var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-pill);
 }
+::-webkit-scrollbar-thumb:hover { background: var(--color-text-subtle); }
 
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-text-muted);
-}
-
-/* ─── Utilities ──────────────────────────────────────────────── */
-
+/* ─── Typography utilities ─────────────────────────────────── */
 .mono {
   font-family: var(--font-mono);
   tab-size: var(--code-tab-size);
   -moz-tab-size: var(--code-tab-size);
 }
 
-/* Applied to code/diff content areas — uses configurable font size */
-.line-content {
-  font-size: var(--code-font-size) !important;
-}
+.line-content { font-size: var(--code-font-size) !important; }
 
-.muted {
-  color: var(--color-text-muted);
-}
+.muted    { color: var(--color-text-muted); }
+.subtle   { color: var(--color-text-subtle); }
 
 .truncate {
   overflow: hidden;
@@ -115,40 +234,225 @@ body {
   white-space: nowrap;
 }
 
+/* ─── Buttons (primitives) ─────────────────────────────────── */
 button {
-  font-family: var(--font-sans);
+  font-family: inherit;
+  font-size: inherit;
   cursor: pointer;
   border: none;
   outline: none;
+  background: none;
+  color: inherit;
 }
 
-button:focus-visible {
-  outline: 2px solid var(--color-accent);
+button:focus-visible,
+.input:focus-visible,
+[tabindex]:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: 2px;
 }
 
-/* ─── Word-level diff highlighting ────────────────────── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text);
+  background: transparent;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base), transform var(--transition-fast);
+  white-space: nowrap;
+  user-select: none;
+}
+.btn:active:not(:disabled) { transform: translateY(1px); }
+.btn:disabled,
+.btn--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.btn--primary {
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+}
+.btn--primary:hover:not(:disabled) { background: var(--color-accent-hover); }
+
+.btn--secondary {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+.btn--secondary:hover:not(:disabled) { background: var(--color-border); }
+
+.btn--ghost {
+  background: transparent;
+  color: var(--color-text-muted);
+}
+.btn--ghost:hover:not(:disabled) {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+
+.btn--danger {
+  background: var(--color-danger);
+  color: #fff;
+}
+.btn--danger:hover:not(:disabled) { filter: brightness(1.08); }
+
+.btn--success {
+  background: var(--color-success);
+  color: #fff;
+}
+.btn--success:hover:not(:disabled) { filter: brightness(1.08); }
+
+.btn--pill { border-radius: var(--radius-pill); padding-inline: var(--space-6); }
+
+.btn--icon {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border-radius: var(--radius-md);
+  color: var(--color-text-muted);
+}
+.btn--icon:hover:not(:disabled) {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+
+.btn--sm { padding: var(--space-2) var(--space-4); font-size: var(--font-size-base); border-radius: var(--radius-sm); }
+.btn--lg { padding: var(--space-5) var(--space-7); font-size: var(--font-size-lg); }
+
+/* ─── Inputs ───────────────────────────────────────────────── */
+.input {
+  width: 100%;
+  padding: var(--space-3) var(--space-4);
+  font-family: inherit;
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+.input:hover { border-color: var(--color-border-strong); }
+.input:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+.input--pill { border-radius: var(--radius-pill); padding-inline: var(--space-5); }
+
+/* ─── Surfaces ─────────────────────────────────────────────── */
+.card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-xs);
+}
+.card--hero {
+  background: var(--color-surface-inverse);
+  color: var(--color-surface-inverse-text);
+  border-color: transparent;
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-md);
+}
+.card--hero .muted { color: var(--color-surface-inverse-muted); }
+
+.popover {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  animation: popoverSlide var(--transition-slow);
+}
+@keyframes popoverSlide {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ─── Badges / pills ───────────────────────────────────────── */
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+.badge--accent  { background: var(--color-accent-soft);  color: var(--color-accent); }
+.badge--success { background: var(--color-success-soft); color: var(--color-success); }
+.badge--warning { background: var(--color-warning-soft); color: var(--color-warning); }
+.badge--danger  { background: var(--color-danger-soft);  color: var(--color-danger); }
+.badge--info    { background: var(--color-info-soft);    color: var(--color-info); }
+.badge--solid   { background: var(--color-accent); color: var(--color-accent-text); }
+
+.stat-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  flex-shrink: 0;
+}
+.stat-dot--success { background: var(--color-success); }
+.stat-dot--warning { background: var(--color-warning); }
+.stat-dot--danger  { background: var(--color-danger); }
+.stat-dot--info    { background: var(--color-info); }
+.stat-dot--muted   { background: var(--color-text-muted); }
+
+/* ─── Segmented control (tabs in pill group) ───────────────── */
+.segmented {
+  display: inline-flex;
+  padding: var(--space-1);
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-pill);
+}
+.segmented__item {
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-muted);
+  transition: background var(--transition-base), color var(--transition-base);
+}
+.segmented__item:hover { color: var(--color-text); }
+.segmented__item--active {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  box-shadow: var(--shadow-xs);
+}
+
+/* ─── Spinner ──────────────────────────────────────────────── */
+.spinner {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: var(--radius-pill);
+  animation: spin 0.7s linear infinite;
+}
+@keyframes spin { to { transform: rotate(360deg); } }
+
+/* ─── Word-level diff highlighting ─────────────────────────── */
 .wd-del {
   background: rgba(239, 68, 68, 0.3);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   padding: 0 1px;
 }
-
 .wd-ins {
   background: rgba(34, 197, 94, 0.3);
-  border-radius: 2px;
+  border-radius: var(--radius-xs);
   padding: 0 1px;
 }
+[data-theme="light"] .wd-del { background: rgba(239, 68, 68, 0.2); }
+[data-theme="light"] .wd-ins { background: rgba(34, 197, 94, 0.2); }
 
-[data-theme="light"] .wd-del {
-  background: rgba(239, 68, 68, 0.2);
-}
-
-[data-theme="light"] .wd-ins {
-  background: rgba(34, 197, 94, 0.2);
-}
-
-/* ─── Highlight.js syntax tokens (dark theme) ────────── */
+/* ─── Highlight.js syntax tokens (dark theme) ──────────────── */
 .hljs-keyword,
 .hljs-selector-tag,
 .hljs-built_in,
@@ -190,7 +494,7 @@ button:focus-visible {
 
 .hljs-property { color: #82aaff; }
 
-/* ─── Light theme syntax tokens ──────────────────────── */
+/* ─── Light theme syntax tokens ────────────────────────────── */
 [data-theme="light"] .hljs-keyword,
 [data-theme="light"] .hljs-selector-tag,
 [data-theme="light"] .hljs-built_in,

--- a/apps/desktop/src/components/AppHeader.vue
+++ b/apps/desktop/src/components/AppHeader.vue
@@ -611,17 +611,17 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   align-items: center;
   justify-content: space-between;
   height: var(--header-height);
-  padding: 0 16px;
+  padding: 0 var(--space-6);
   background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border);
-  gap: 16px;
+  gap: var(--space-6);
   flex-shrink: 0;
 }
 
 .header-left {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 
 .logo {
@@ -629,8 +629,8 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 }
 
 .title {
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: -0.01em;
 }
 
@@ -643,17 +643,17 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .branch-trigger {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  border-radius: 6px;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-pill);
   color: var(--color-text);
-  background: none;
-  transition: background 0.12s;
+  background: var(--color-bg-tertiary);
+  transition: background var(--transition-base), color var(--transition-base);
   cursor: pointer;
 }
 
 .branch-trigger:hover {
-  background: var(--color-bg-tertiary);
+  background: var(--color-border);
 }
 
 .branch-trigger--loading {
@@ -662,12 +662,12 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 }
 
 .branch-name {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
 }
 
 .branch-chevron {
-  transition: transform 0.15s;
+  transition: transform var(--transition-base);
   opacity: 0.5;
 }
 
@@ -679,19 +679,20 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .branch-popover {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + var(--space-3));
   left: 50%;
   transform: translateX(-50%);
   width: 340px;
   max-height: 520px;
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
-  border-radius: 10px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
   z-index: 50;
-  animation: bpSlide 0.15s ease-out;
+  animation: bpSlide var(--transition-slow);
+  overflow: hidden;
 }
 
 @keyframes bpSlide {
@@ -702,36 +703,38 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .bp-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
 }
 
 .bp-filter {
   flex: 1;
-  padding: 5px 8px;
-  font-size: 12px;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 5px;
+  border-radius: var(--radius-pill);
   outline: none;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .bp-filter:focus {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .bp-action-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 5px;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-pill);
   color: var(--color-text-muted);
   background: none;
-  transition: background 0.1s, color 0.1s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .bp-action-btn:hover {
@@ -741,33 +744,34 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .bp-create {
   display: flex;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
 }
 
 .bp-create-input {
   flex: 1;
-  padding: 5px 8px;
-  font-size: 12px;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 5px;
+  border-radius: var(--radius-pill);
   outline: none;
 }
 
 .bp-create-input:focus {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .bp-create-btn {
-  padding: 5px 10px;
-  font-size: 11px;
-  font-weight: 600;
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
   background: var(--color-accent);
-  color: #fff;
-  border-radius: 5px;
+  color: var(--color-accent-text);
+  border-radius: var(--radius-pill);
 }
 
 .bp-create-btn:disabled {
@@ -786,7 +790,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   height: 16px;
   border: 2px solid var(--color-border);
   border-top-color: var(--color-accent);
-  border-radius: 50%;
+  border-radius: var(--radius-pill);
   animation: spin 0.7s linear infinite;
 }
 
@@ -805,9 +809,9 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 }
 
 .bp-section-label {
-  padding: 5px 12px;
-  font-size: 10px;
-  font-weight: 600;
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
@@ -821,11 +825,11 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .bp-item {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 5px 12px;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
   cursor: pointer;
-  transition: background 0.1s;
-  font-size: 12px;
+  transition: background var(--transition-fast);
+  font-size: var(--font-size-base);
 }
 
 .bp-item:hover {
@@ -840,7 +844,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .bp-current-dot {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  border-radius: var(--radius-pill);
   background: var(--color-accent);
   flex-shrink: 0;
 }
@@ -850,7 +854,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .bp-item--remote .bp-item-name {
@@ -858,7 +862,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 }
 
 .bp-item-meta {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   flex-shrink: 0;
 }
 
@@ -867,13 +871,13 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-pill);
   color: var(--color-text-muted);
   background: none;
   opacity: 0;
-  transition: opacity 0.1s, color 0.1s, background 0.1s;
+  transition: opacity var(--transition-fast), color var(--transition-fast), background var(--transition-fast);
 }
 
 .bp-item:hover .bp-item-preview,
@@ -883,13 +887,13 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .bp-item-preview:hover {
   opacity: 1 !important;
-  color: var(--color-accent, #89b4fa);
+  color: var(--color-accent);
 }
 
 .bp-item-preview--active {
   opacity: 1 !important;
-  color: var(--color-accent, #89b4fa);
-  background: var(--color-accent-bg, #89b4fa20);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .bp-item-delete:hover {
@@ -899,36 +903,41 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .bp-preview-row {
   list-style: none;
-  padding: 4px 8px 6px;
+  padding: var(--space-2) var(--space-4) var(--space-3);
 }
 
 .bp-empty {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
-  font-size: 12px;
+  padding: var(--space-7);
+  font-size: var(--font-size-base);
 }
 
 .repo-stat-group {
   display: flex;
   align-items: center;
-  gap: 12px;
-  margin-left: 16px;
+  gap: var(--space-2);
+  margin-left: var(--space-5);
 }
 
 .repo-stat {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 5px;
-  font-size: 11px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-tertiary);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .repo-stat-dot {
   width: 6px;
   height: 6px;
-  border-radius: 50%;
+  border-radius: var(--radius-pill);
   flex-shrink: 0;
 }
 
@@ -937,29 +946,29 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 8px;
+  gap: var(--space-4);
 }
 
 /* Folder trigger */
 .folder-trigger {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 4px 10px;
-  margin-left: 8px;
-  border-left: 1px solid var(--color-border);
-  padding-left: 16px;
-  border-radius: 0;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  margin-left: var(--space-2);
+  border-radius: var(--radius-pill);
   color: var(--color-text-muted);
-  background: none;
-  font-size: 12px;
-  transition: background 0.12s, color 0.12s;
+  background: transparent;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-base), color var(--transition-base);
   cursor: pointer;
-  max-width: 200px;
+  max-width: 220px;
 }
 
 .folder-trigger:hover {
   color: var(--color-text);
+  background: var(--color-bg-tertiary);
 }
 
 .folder-name {
@@ -972,7 +981,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .header-right {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-3);
 }
 
 .header-separator {
@@ -980,36 +989,37 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   height: 20px;
   background: var(--color-border);
   flex-shrink: 0;
+  margin-inline: var(--space-2);
 }
 
+/* Local button override — pill-style header buttons.
+   Note: global .btn lives in main.css; these scoped rules refine the
+   header variants (sync / merge / icon) to match the design system. */
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 500;
-  transition: background 0.15s, color 0.15s;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
+  transition: background var(--transition-base), color var(--transition-base), transform var(--transition-fast);
+  white-space: nowrap;
 }
+
+.btn:active:not(:disabled) { transform: translateY(1px); }
 
 .btn--secondary {
   background: var(--color-bg-tertiary);
   color: var(--color-text);
 }
-
-.btn--secondary:hover {
-  background: var(--color-border);
-}
+.btn--secondary:hover:not(:disabled) { background: var(--color-border); }
 
 .btn--primary {
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
-
-.btn--primary:hover {
-  background: var(--color-accent-hover);
-}
+.btn--primary:hover:not(:disabled) { background: var(--color-accent-hover); }
 
 /* Sync buttons (Push/Pull) */
 .btn--sync {
@@ -1018,86 +1028,75 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   color: var(--color-text);
 }
 
-.btn--sync:hover:not(:disabled) {
-  background: var(--color-border);
-}
+.btn--sync:hover:not(:disabled) { background: var(--color-border); }
 
 .btn--sync-active {
-  background: var(--color-bg-tertiary);
-  color: var(--color-text);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
 }
 
 .btn--push.btn--sync-active {
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
 
-.btn--push.btn--sync-active:hover:not(:disabled) {
-  background: var(--color-accent-hover);
-}
+.btn--push.btn--sync-active:hover:not(:disabled) { background: var(--color-accent-hover); }
 
 .sync-badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-width: 18px;
-  padding: 2px 5px;
-  border-radius: 9px;
-  font-size: 10px;
-  font-weight: 700;
+  min-width: 20px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
   font-variant-numeric: tabular-nums;
   line-height: 1;
 }
 
 .sync-badge--push {
-  background: rgba(255, 255, 255, 0.25);
-  color: #fff;
+  background: rgba(255, 255, 255, 0.22);
+  color: var(--color-accent-text);
 }
 
 .sync-badge--pull {
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
 
 .btn--save {
   background: var(--color-success);
-  color: #fff;
+  color: var(--color-accent-text);
 }
-
-.btn--save:hover {
-  filter: brightness(1.1);
-}
+.btn--save:hover { filter: brightness(1.08); }
 
 .btn--icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
-  height: 28px;
+  width: 32px;
+  height: 32px;
   padding: 0;
-  border-radius: 6px;
-  background: none;
+  border-radius: var(--radius-pill);
+  background: transparent;
   color: var(--color-text-muted);
-  transition: color 0.12s;
+  transition: background var(--transition-base), color var(--transition-base);
 }
-
 .btn--icon:hover:not(:disabled) {
+  background: var(--color-bg-tertiary);
   color: var(--color-text);
 }
 
 .btn--icon:disabled,
 .btn--disabled {
-  opacity: 0.3;
+  opacity: 0.35;
   cursor: not-allowed;
 }
 
-.btn-spinner {
-  animation: spin 0.7s linear infinite;
-}
+.btn-spinner { animation: spin 0.7s linear infinite; }
 
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
+@keyframes spin { to { transform: rotate(360deg); } }
 
 /* ─── Merge Popover ──────────────────────────────────── */
 
@@ -1107,39 +1106,42 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .merge-popover {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + var(--space-3));
   right: 0;
   width: 300px;
   max-height: 360px;
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
-  border-radius: 10px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
   z-index: 50;
-  animation: bpSlide 0.15s ease-out;
+  animation: bpSlide var(--transition-slow);
+  overflow: hidden;
 }
 
 .mp-header {
-  padding: 8px 10px;
+  padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
 }
 
 .mp-filter {
   width: 100%;
-  padding: 5px 8px;
-  font-size: 12px;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--font-size-base);
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 5px;
+  border-radius: var(--radius-pill);
   outline: none;
   box-sizing: border-box;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 
 .mp-filter:focus {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .mp-loading {
@@ -1154,7 +1156,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   height: 16px;
   border: 2px solid var(--color-border);
   border-top-color: var(--color-accent);
-  border-radius: 50%;
+  border-radius: var(--radius-pill);
   animation: spin 0.7s linear infinite;
 }
 
@@ -1164,45 +1166,39 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   max-height: 280px;
 }
 
-.mp-list {
-  list-style: none;
-}
+.mp-list { list-style: none; }
 
 .mp-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-5);
   cursor: pointer;
-  transition: background 0.1s;
-  font-size: 12px;
+  transition: background var(--transition-fast);
+  font-size: var(--font-size-base);
   color: var(--color-text);
 }
 
-.mp-item:hover {
-  background: var(--color-bg-tertiary);
-}
+.mp-item:hover { background: var(--color-bg-tertiary); }
 
-.mp-item--remote {
-  opacity: 0.7;
-}
+.mp-item--remote { opacity: 0.7; }
 
 .mp-item-name {
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-weight: 500;
+  font-weight: var(--font-weight-medium);
 }
 
 .mp-item-tag {
-  font-size: 9px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: var(--color-bg);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-tertiary);
   color: var(--color-text-muted);
   flex-shrink: 0;
 }
@@ -1211,8 +1207,8 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 20px;
-  font-size: 12px;
+  padding: var(--space-7);
+  font-size: var(--font-size-base);
 }
 
 /* ─── Recent Repos Popover (Phase 8.4) ──────────────── */
@@ -1222,49 +1218,45 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 }
 
 .folder-chevron {
-  transition: transform 0.15s;
+  transition: transform var(--transition-base);
   opacity: 0.4;
-  margin-left: 2px;
+  margin-left: var(--space-1);
 }
 
-.folder-chevron--open {
-  transform: rotate(180deg);
-}
+.folder-chevron--open { transform: rotate(180deg); }
 
 .recent-popover {
   position: absolute;
-  top: calc(100% + 6px);
+  top: calc(100% + var(--space-3));
   left: 0;
   width: 280px;
   max-height: 380px;
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
-  border-radius: 10px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
   z-index: 50;
-  animation: bpSlide 0.15s ease-out;
+  animation: bpSlide var(--transition-slow);
   overflow: hidden;
 }
 
 .rp-open-btn {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-4);
   width: 100%;
-  padding: 10px 12px;
-  font-size: 12px;
-  font-weight: 500;
+  padding: var(--space-5) var(--space-5);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text);
   background: none;
   text-align: left;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
 }
 
-.rp-open-btn:hover {
-  background: var(--color-bg-tertiary);
-}
+.rp-open-btn:hover { background: var(--color-bg-tertiary); }
 
 .rp-divider {
   height: 1px;
@@ -1278,29 +1270,24 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 }
 
 .rp-label {
-  padding: 6px 12px 4px;
-  font-size: 10px;
-  font-weight: 600;
+  padding: var(--space-4) var(--space-5) var(--space-2);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
 
-.rp-list ul {
-  list-style: none;
-}
+.rp-list ul { list-style: none; }
 
 .rp-item {
   display: flex;
   align-items: center;
-  padding: 0 6px 0 0;
-  transition: background 0.1s;
+  padding: 0 var(--space-3) 0 0;
+  transition: background var(--transition-fast);
 }
 
-.rp-item:hover {
-  background: var(--color-bg-tertiary);
-}
-
+.rp-item:hover,
 .rp-item--active {
   background: var(--color-bg-tertiary);
 }
@@ -1309,10 +1296,10 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
   flex: 1;
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text);
   background: none;
   text-align: left;
@@ -1322,7 +1309,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .rp-pin-icon {
   flex-shrink: 0;
-  color: var(--color-accent, #89b4fa);
+  color: var(--color-accent);
 }
 
 .rp-item-repo-name {
@@ -1333,33 +1320,33 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 
 .rp-item-actions {
   display: flex;
-  gap: 2px;
+  gap: var(--space-1);
   opacity: 0;
-  transition: opacity 0.1s;
+  transition: opacity var(--transition-fast);
   flex-shrink: 0;
 }
 
-.rp-item:hover .rp-item-actions {
-  opacity: 1;
-}
+.rp-item:hover .rp-item-actions { opacity: 1; }
 
 .rp-action {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 4px;
+  width: 22px;
+  height: 22px;
+  border-radius: var(--radius-pill);
   color: var(--color-text-muted);
   background: none;
-  transition: color 0.1s;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .rp-action:hover {
-  color: var(--color-accent, #89b4fa);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .rp-action--remove:hover {
   color: var(--color-danger);
+  background: var(--color-danger-soft);
 }
 </style>

--- a/apps/desktop/src/components/CherryPickPanel.vue
+++ b/apps/desktop/src/components/CherryPickPanel.vue
@@ -195,11 +195,11 @@ loadBranches();
 .cherry-pick-panel {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  background: var(--bg-secondary, #1e1e2e);
-  border-radius: 8px;
-  border: 1px solid var(--border-color, #313244);
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
   max-height: 450px;
 }
 
@@ -211,51 +211,51 @@ loadBranches();
 
 .cp-header h3 {
   margin: 0;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
 }
 
 .cp-error {
-  color: var(--color-error, #f38ba8);
-  font-size: 12px;
-  padding: 6px 8px;
-  background: rgba(243, 139, 168, 0.1);
-  border-radius: 4px;
+  color: var(--color-danger);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-danger-soft);
+  border-radius: var(--radius-sm);
 }
 
 .cp-success {
-  color: var(--color-success, #a6e3a1);
-  font-size: 12px;
-  padding: 6px 8px;
-  background: rgba(166, 227, 161, 0.1);
-  border-radius: 4px;
+  color: var(--color-success);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-success-soft);
+  border-radius: var(--radius-sm);
 }
 
 .cp-conflict-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .cp-branch-select {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .cp-branch-select label {
-  font-size: 12px;
-  color: var(--text-muted, #6c7086);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 
 .cp-branch-select select {
   flex: 1;
-  background: var(--bg-tertiary, #11111b);
-  border: 1px solid var(--border-color, #313244);
-  border-radius: 4px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   color: inherit;
-  padding: 4px 8px;
-  font-size: 12px;
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
 }
 
 .cp-commits {
@@ -268,28 +268,28 @@ loadBranches();
 
 .cp-loading {
   text-align: center;
-  font-size: 13px;
-  color: var(--text-muted, #6c7086);
-  padding: 12px;
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
+  padding: var(--space-3);
 }
 
 .cp-commit {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 8px;
-  border-radius: 4px;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: 12px;
-  transition: background 0.15s;
+  font-size: var(--font-size-xs);
+  transition: background var(--transition-base);
 }
 
 .cp-commit:hover {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+  background: var(--color-bg-hover);
 }
 
 .cp-commit.selected {
-  background: rgba(203, 166, 247, 0.1);
+  background: var(--color-accent-soft);
 }
 
 .cp-check {
@@ -299,7 +299,7 @@ loadBranches();
 
 .cp-hash {
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  color: var(--color-accent, #cba6f7);
+  color: var(--color-accent);
   flex-shrink: 0;
 }
 
@@ -311,15 +311,15 @@ loadBranches();
 }
 
 .cp-date {
-  color: var(--text-muted, #6c7086);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   flex-shrink: 0;
 }
 
 .cp-footer {
   display: flex;
   justify-content: flex-end;
-  padding-top: 4px;
+  padding-top: var(--space-1);
 }
 
 /* Button styles */
@@ -327,21 +327,21 @@ loadBranches();
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border-color, #313244);
-  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   background: transparent;
   color: inherit;
   cursor: pointer;
-  font-size: 12px;
-  padding: 5px 12px;
-  transition: all 0.15s;
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-3);
+  transition: all var(--transition-base);
 }
 
-.btn:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.08)); }
+.btn:hover { background: var(--color-bg-hover); }
 .btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-sm { font-size: 12px; padding: 3px 8px; }
-.btn-primary { background: var(--color-accent, #cba6f7); color: #1e1e2e; border-color: transparent; }
+.btn-sm { font-size: var(--font-size-xs); padding: var(--space-1) var(--space-2); }
+.btn-primary { background: var(--color-accent); color: var(--color-accent-text); border-color: transparent; }
 .btn-primary:hover { filter: brightness(1.1); }
-.btn-danger { background: var(--color-error, #f38ba8); color: #1e1e2e; border-color: transparent; }
+.btn-danger { background: var(--color-danger); color: var(--color-accent-text); border-color: transparent; }
 .btn-ghost { border-color: transparent; }
 </style>

--- a/apps/desktop/src/components/CommitDiffViewer.vue
+++ b/apps/desktop/src/components/CommitDiffViewer.vue
@@ -552,8 +552,8 @@ function onContentScroll(e: Event) {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--text-lg);
+  font-weight: var(--font-bold);
   color: #fff;
   flex-shrink: 0;
 }
@@ -564,8 +564,8 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-commit-subject {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   color: var(--color-text);
   line-height: 1.4;
 }
@@ -575,7 +575,7 @@ function onContentScroll(e: Event) {
   align-items: center;
   gap: 6px;
   margin-top: 4px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
 }
 
@@ -584,20 +584,20 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-author {
-  font-weight: 500;
+  font-weight: var(--font-medium);
 }
 
 .cdv-hash {
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--color-accent);
   background: var(--color-bg-tertiary);
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .cdv-commit-body {
-  font-size: 12px;
-  font-weight: 400;
+  font-size: var(--text-base);
+  font-weight: var(--font-normal);
   color: var(--color-text-muted);
   line-height: 1.5;
   padding-left: 44px;
@@ -612,13 +612,13 @@ function onContentScroll(e: Event) {
 
 .cdv-body-toggle {
   align-self: flex-start;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-accent);
   background: none;
   padding: 0;
   cursor: pointer;
   opacity: 0.8;
-  transition: opacity 0.1s;
+  transition: opacity var(--transition-fast);
 }
 
 .cdv-body-toggle:hover {
@@ -633,10 +633,10 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-badge {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
   padding: 2px 8px;
-  border-radius: 10px;
+  border-radius: var(--radius-pill);
 }
 
 .cdv-badge--files {
@@ -645,29 +645,29 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-badge--add {
-  background: rgba(63, 185, 80, 0.15);
+  background: var(--color-success-soft);
   color: var(--color-success);
 }
 
 .cdv-badge--del {
-  background: rgba(248, 81, 73, 0.15);
+  background: var(--color-danger-soft);
   color: var(--color-danger);
 }
 
 .cdv-summary {
-  font-size: 12px;
+  font-size: var(--text-base);
   color: var(--color-text-muted);
 }
 
 .cdv-large-diff-hint {
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
   opacity: 0.6;
 }
 
 .cdv-stat {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
   font-family: var(--font-mono);
 }
 
@@ -706,11 +706,11 @@ function onContentScroll(e: Event) {
 
 .cdv-filelist-title {
   padding: 8px 12px;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--color-text-muted);
+  color: var(--color-text-subtle);
   border-bottom: 1px solid var(--color-border);
   flex-shrink: 0;
 }
@@ -728,9 +728,9 @@ function onContentScroll(e: Event) {
   align-items: center;
   gap: 6px;
   padding: 5px 12px;
-  font-size: 12px;
+  font-size: var(--text-base);
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
   border-left: 2px solid transparent;
 }
 
@@ -744,8 +744,8 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-filelist-icon {
-  font-size: 10px;
-  font-weight: 700;
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
   width: 16px;
   text-align: center;
   flex-shrink: 0;
@@ -764,7 +764,7 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-filelist-item--active .cdv-filelist-name {
-  font-weight: 600;
+  font-weight: var(--font-semibold);
 }
 
 .cdv-filelist-stats {
@@ -795,7 +795,7 @@ function onContentScroll(e: Event) {
   z-index: 2;
   cursor: pointer;
   user-select: none;
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
 }
 
 .cdv-file-header:hover {
@@ -803,9 +803,9 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-collapse-icon {
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
-  transition: transform 0.15s ease;
+  transition: transform var(--transition-base);
   flex-shrink: 0;
   width: 14px;
   text-align: center;
@@ -816,13 +816,13 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-file-name {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   flex-shrink: 0;
 }
 
 .cdv-file-path {
-  font-size: 11px;
+  font-size: var(--text-xs);
   flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -837,8 +837,8 @@ function onContentScroll(e: Event) {
 
 .cdv-hunk-header {
   padding: 4px 16px;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   background: var(--color-bg-tertiary);
   border-bottom: 1px solid var(--color-border);
 }
@@ -854,16 +854,16 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-line--context { background: var(--color-bg); }
-.cdv-line--add { background: rgba(34, 197, 94, 0.1); }
-.cdv-line--delete { background: rgba(239, 68, 68, 0.1); }
+.cdv-line--add { background: var(--color-success-soft); }
+.cdv-line--delete { background: var(--color-danger-soft); }
 
 .cdv-line-no {
   width: 44px;
   min-width: 44px;
   padding: 0 6px;
   text-align: right;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   opacity: 0.5;
   user-select: none;
   border-right: 1px solid var(--color-border);
@@ -874,17 +874,17 @@ function onContentScroll(e: Event) {
   min-width: 18px;
   padding: 0 3px;
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-base);
   color: var(--color-text-muted);
   user-select: none;
 }
 
-.cdv-line--add .cdv-line-marker { color: var(--color-success); font-weight: 700; }
-.cdv-line--delete .cdv-line-marker { color: var(--color-danger); font-weight: 700; }
+.cdv-line--add .cdv-line-marker { color: var(--color-success); font-weight: var(--font-bold); }
+.cdv-line--delete .cdv-line-marker { color: var(--color-danger); font-weight: var(--font-bold); }
 
 .cdv-line-content {
   padding: 0 10px;
-  font-size: 12px;
+  font-size: var(--text-base);
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -917,12 +917,12 @@ function onContentScroll(e: Event) {
 }
 
 .cdv-sbs--context { background: var(--color-bg); }
-.cdv-sbs--delete { background: rgba(239, 68, 68, 0.1); }
-.cdv-sbs--add { background: rgba(34, 197, 94, 0.1); }
+.cdv-sbs--delete { background: var(--color-danger-soft); }
+.cdv-sbs--add { background: var(--color-success-soft); }
 .cdv-sbs--empty { background: var(--color-bg-tertiary); opacity: 0.5; }
 
-.cdv-sbs--delete.cdv-line-marker { color: var(--color-danger); font-weight: 700; }
-.cdv-sbs--add.cdv-line-marker { color: var(--color-success); font-weight: 700; }
+.cdv-sbs--delete.cdv-line-marker { color: var(--color-danger); font-weight: var(--font-bold); }
+.cdv-sbs--add.cdv-line-marker { color: var(--color-success); font-weight: var(--font-bold); }
 .cdv-sbs--delete.cdv-line-no { color: var(--color-danger); opacity: 0.7; }
 .cdv-sbs--add.cdv-line-no { color: var(--color-success); opacity: 0.7; }
 
@@ -931,7 +931,7 @@ function onContentScroll(e: Event) {
   display: flex;
   gap: 2px;
   background: var(--color-bg-tertiary);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   padding: 2px;
   margin-left: auto;
 }
@@ -943,11 +943,11 @@ function onContentScroll(e: Event) {
   width: 26px;
   height: 24px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .cdv-mode-btn:hover {
@@ -957,12 +957,12 @@ function onContentScroll(e: Event) {
 .cdv-mode-btn--active {
   background: var(--color-bg-secondary);
   color: var(--color-accent);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-xs);
 }
 
 .cdv-truncated {
   padding: 8px 16px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
   background: var(--color-bg-tertiary);
   text-align: center;
@@ -971,7 +971,7 @@ function onContentScroll(e: Event) {
 
 .cdv-load-more {
   padding: 12px 16px;
-  font-size: 12px;
+  font-size: var(--text-base);
   color: var(--color-text-muted);
   text-align: center;
 }

--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -33,20 +33,20 @@ const graphWidth = computed(() => {
 
 const totalHeight = computed(() => props.commits.length * ROW_H);
 
-// ─── Lane colours ────────────────────────────────────
-const LANE_COLORS = [
-  "#3b82f6", // blue
-  "#22c55e", // green
-  "#f59e0b", // amber
-  "#ef4444", // red
-  "#a855f7", // purple
-  "#06b6d4", // cyan
-  "#ec4899", // pink
-  "#84cc16", // lime
+// ─── Lane colours (use CSS tokens via computed) ────────
+const LANE_COLORS_TOKENS = [
+  "var(--color-info)",       // blue
+  "var(--color-success)",    // green
+  "var(--color-warning)",    // amber
+  "var(--color-danger)",     // red
+  "var(--color-accent)",     // purple
+  "var(--color-info)",       // cyan (reuse info)
+  "var(--color-accent)",     // pink (reuse accent)
+  "var(--color-success)",    // lime (reuse success)
 ];
 
 function laneColor(lane: number): string {
-  return LANE_COLORS[lane % LANE_COLORS.length];
+  return LANE_COLORS_TOKENS[lane % LANE_COLORS_TOKENS.length];
 }
 
 // ─── SVG path helpers ────────────────────────────────
@@ -249,7 +249,7 @@ function commitRefs(entry: GitLogEntry) {
 .cg-ref--branch,
 .cg-ref--head {
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
 
 .cg-ref--remote {
@@ -259,8 +259,8 @@ function commitRefs(entry: GitLogEntry) {
 }
 
 .cg-ref--tag {
-  background: #f59e0b;
-  color: #fff;
+  background: var(--color-warning);
+  color: var(--color-accent-text);
 }
 
 .cg-msg {

--- a/apps/desktop/src/components/CommitLog.vue
+++ b/apps/desktop/src/components/CommitLog.vue
@@ -134,8 +134,8 @@ function authorColor(name: string): string {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 10px;
-  padding: 30px;
+  gap: var(--space-2);
+  padding: var(--space-8);
 }
 
 .loading-spinner {
@@ -162,10 +162,10 @@ function authorColor(name: string): string {
 .log-section-label {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 16px;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-4);
   font-size: 10px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   border-bottom: 1px solid var(--color-border);
@@ -175,9 +175,9 @@ function authorColor(name: string): string {
 }
 
 .log-section-label--unpushed {
-  color: #f59e0b;
+  color: var(--color-warning);
   background: var(--color-bg-secondary);
-  border-left: 3px solid #f59e0b;
+  border-left: 3px solid var(--color-warning);
 }
 
 .log-section-label--pushed {
@@ -190,34 +190,35 @@ function authorColor(name: string): string {
 
 .commit-item {
   display: flex;
-  gap: 10px;
-  padding: 10px 16px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
   border-bottom: 1px solid var(--color-border);
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
   border-left: 3px solid transparent;
 }
 
 .commit-item--unpushed {
-  border-left-color: #f59e0b;
-  background: rgba(245, 158, 11, 0.04);
+  border-left-color: var(--color-warning);
+  background: var(--color-warning-soft);
 }
 
 .commit-item--unpushed:hover {
-  background: rgba(245, 158, 11, 0.08);
+  background: var(--color-warning-soft);
+  opacity: 0.9;
 }
 
 .unpushed-badge {
   display: inline-block;
   font-size: 9px;
-  font-weight: 700;
+  font-weight: var(--font-weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   padding: 1px 5px;
-  border-radius: 3px;
-  background: rgba(245, 158, 11, 0.15);
-  color: #f59e0b;
-  margin-left: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--color-warning-soft);
+  color: var(--color-warning);
+  margin-left: var(--space-1);
   vertical-align: middle;
 }
 
@@ -246,11 +247,11 @@ function authorColor(name: string): string {
   justify-content: center;
   width: 22px;
   height: 22px;
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   color: var(--color-text-muted);
   background: none;
   opacity: 0;
-  transition: opacity 0.12s, color 0.12s, background 0.12s;
+  transition: opacity var(--transition-fast), color var(--transition-fast), background var(--transition-fast);
   align-self: center;
 }
 
@@ -261,7 +262,7 @@ function authorColor(name: string): string {
 .commit-edit-btn:hover {
   opacity: 1 !important;
   color: var(--color-accent);
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg);
 }
 
 .commit-avatar {
@@ -272,8 +273,8 @@ function authorColor(name: string): string {
   align-items: center;
   justify-content: center;
   font-size: 10px;
-  font-weight: 700;
-  color: #fff;
+  font-weight: var(--font-weight-bold);
+  color: var(--color-accent-text);
   flex-shrink: 0;
   margin-top: 2px;
 }
@@ -284,8 +285,8 @@ function authorColor(name: string): string {
 }
 
 .commit-message {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   line-height: 1.4;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -295,14 +296,14 @@ function authorColor(name: string): string {
 .commit-meta {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: var(--space-1);
   margin-top: 3px;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-text-muted);
 }
 
 .commit-hash {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-accent);
 }
 
@@ -324,6 +325,6 @@ function authorColor(name: string): string {
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 40px;
+  padding: var(--space-10);
 }
 </style>

--- a/apps/desktop/src/components/ConflictAlert.vue
+++ b/apps/desktop/src/components/ConflictAlert.vue
@@ -55,31 +55,31 @@ watch(() => props.targetBranch, checkConflicts, { immediate: true });
 
 <style scoped>
 .conflict-alert {
-  padding: 10px 12px;
-  border-radius: 6px;
-  border: 1px solid var(--color-warning, #f9e2af);
-  background: rgba(249, 226, 175, 0.08);
-  font-size: 13px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-danger);
+  background: var(--color-danger-soft);
+  font-size: var(--font-size-md);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1);
 }
 
 .conflict-alert.warn {
-  border-color: var(--color-warning, #fab387);
-  background: rgba(250, 179, 135, 0.1);
+  border-color: var(--color-warning);
+  background: var(--color-warning-soft);
 }
 
 .conflict-alert.danger {
-  border-color: var(--color-error, #f38ba8);
-  background: rgba(243, 139, 168, 0.1);
+  border-color: var(--color-danger);
+  background: var(--color-danger-soft);
 }
 
 .conflict-alert-header {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-weight: 500;
+  gap: var(--space-1);
+  font-weight: var(--font-weight-medium);
 }
 
 .conflict-icon {
@@ -96,20 +96,20 @@ watch(() => props.targetBranch, checkConflicts, { immediate: true });
 }
 
 .conflict-file {
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  color: var(--text-secondary, #a6adc8);
+  color: var(--color-text-secondary);
 }
 
 .conflict-file::before {
   content: "·";
-  margin-right: 6px;
-  color: var(--text-muted, #6c7086);
+  margin-right: var(--space-1);
+  color: var(--color-text-muted);
 }
 
 .conflict-stats {
-  font-size: 11px;
-  color: var(--text-muted, #6c7086);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
   padding-left: 28px;
 }
 </style>

--- a/apps/desktop/src/components/DashboardView.vue
+++ b/apps/desktop/src/components/DashboardView.vue
@@ -1,0 +1,847 @@
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from "vue";
+import {
+  getGitLog,
+  getGitBranches,
+  gitRemoteInfo,
+  gitFileCount,
+  readFile,
+  ghListPrs,
+  type GitLogEntry,
+  type GitBranch,
+  type RemoteInfo,
+} from "../utils/backend";
+import type { ViewMode } from "../composables/useGitRepo";
+
+const props = defineProps<{
+  cwd: string;
+  branch: string;
+  status: {
+    staged: number;
+    unstaged: number;
+    untracked: number;
+    conflicted: number;
+  };
+  ahead: number;
+  behind: number;
+}>();
+
+const emit = defineEmits<{
+  changeView: [mode: ViewMode];
+}>();
+
+// ─── Dashboard data ────────────────────────────────────────
+const loading = ref(true);
+const recentCommits = ref<GitLogEntry[]>([]);
+const branches = ref<GitBranch[]>([]);
+const remoteInfo = ref<RemoteInfo | null>(null);
+const fileCount = ref(0);
+const openPrs = ref(0);
+const readmeContent = ref<string | null>(null);
+const readmeError = ref(false);
+const readmeTab = ref<"formatted" | "raw">("formatted");
+const contributorCount = ref(0);
+const lastCommitDate = ref("");
+const weeklyCommits = ref(0);
+
+// ─── Computed stats ────────────────────────────────────────
+const totalChanges = computed(
+  () => props.status.staged + props.status.unstaged + props.status.untracked
+);
+const localBranches = computed(
+  () => branches.value.filter((b) => !b.isRemote)
+);
+const remoteBranches = computed(
+  () => branches.value.filter((b) => b.isRemote)
+);
+
+// ─── Load dashboard data ───────────────────────────────────
+async function loadDashboard() {
+  if (!props.cwd) return;
+  loading.value = true;
+
+  const results = await Promise.allSettled([
+    getGitLog(props.cwd, 50),
+    getGitBranches(props.cwd),
+    gitRemoteInfo(props.cwd),
+    gitFileCount(props.cwd).catch(() => 0),
+    ghListPrs(props.cwd, "open").catch(() => []),
+    loadReadme(),
+  ]);
+
+  // Commits
+  if (results[0].status === "fulfilled") {
+    recentCommits.value = results[0].value;
+    // Unique authors
+    const authors = new Set(recentCommits.value.map((c) => c.email));
+    contributorCount.value = authors.size;
+    // Last commit date
+    if (recentCommits.value.length > 0) {
+      lastCommitDate.value = recentCommits.value[0].date;
+    }
+    // Commits in last 7 days
+    const oneWeekAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+    weeklyCommits.value = recentCommits.value.filter(
+      (c) => new Date(c.date).getTime() > oneWeekAgo
+    ).length;
+  }
+  // Branches
+  if (results[1].status === "fulfilled") {
+    branches.value = results[1].value;
+  }
+  // Remote
+  if (results[2].status === "fulfilled") {
+    remoteInfo.value = results[2].value;
+  }
+  // File count
+  if (results[3].status === "fulfilled") {
+    fileCount.value = results[3].value as number;
+  }
+  // PRs
+  if (results[4].status === "fulfilled") {
+    openPrs.value = (results[4].value as any[]).length;
+  }
+
+  loading.value = false;
+}
+
+async function loadReadme() {
+  readmeError.value = false;
+  // Try common README names
+  const candidates = ["README.md", "readme.md", "Readme.md", "README.MD"];
+  for (const name of candidates) {
+    try {
+      readmeContent.value = await readFile(props.cwd, name);
+      return;
+    } catch {
+      // try next
+    }
+  }
+  readmeContent.value = null;
+  readmeError.value = true;
+}
+
+function formatDate(dateStr: string): string {
+  if (!dateStr) return "—";
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - d.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  if (diffMins < 1) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  const diffHrs = Math.floor(diffMins / 60);
+  if (diffHrs < 24) return `${diffHrs}h ago`;
+  const diffDays = Math.floor(diffHrs / 24);
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+
+function formatNumber(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return n.toString();
+}
+
+// ─── Markdown → HTML (basic) ───────────────────────────────
+function renderMarkdown(md: string): string {
+  let html = md
+    // Code blocks (fenced)
+    .replace(/```(\w*)\n([\s\S]*?)```/g, (_m, _lang, code) => {
+      return `<pre class="md-code-block"><code>${escapeHtml(code.trimEnd())}</code></pre>`;
+    })
+    // Headings
+    .replace(/^######\s+(.+)$/gm, "<h6>$1</h6>")
+    .replace(/^#####\s+(.+)$/gm, "<h5>$1</h5>")
+    .replace(/^####\s+(.+)$/gm, "<h4>$1</h4>")
+    .replace(/^###\s+(.+)$/gm, "<h3>$1</h3>")
+    .replace(/^##\s+(.+)$/gm, "<h2>$1</h2>")
+    .replace(/^#\s+(.+)$/gm, "<h1>$1</h1>")
+    // Bold & italic
+    .replace(/\*\*\*(.+?)\*\*\*/g, "<strong><em>$1</em></strong>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/\*(.+?)\*/g, "<em>$1</em>")
+    // Inline code
+    .replace(/`([^`]+)`/g, '<code class="md-inline-code">$1</code>')
+    // Links
+    .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="md-link">$1</a>')
+    // Images (render as alt text)
+    .replace(/!\[([^\]]*)\]\([^)]+\)/g, '<span class="md-img-alt">[$1]</span>')
+    // Horizontal rules
+    .replace(/^---+$/gm, '<hr class="md-hr">')
+    // Unordered lists
+    .replace(/^[\s]*[-*]\s+(.+)$/gm, '<li>$1</li>')
+    // Ordered lists
+    .replace(/^[\s]*\d+\.\s+(.+)$/gm, '<li>$1</li>')
+    // Blockquote
+    .replace(/^>\s+(.+)$/gm, '<blockquote class="md-blockquote">$1</blockquote>');
+
+  // Wrap consecutive <li> in <ul>
+  html = html.replace(/((?:<li>.*<\/li>\s*)+)/g, "<ul>$1</ul>");
+
+  // Paragraphs — wrap standalone lines
+  html = html
+    .split("\n\n")
+    .map((block) => {
+      const trimmed = block.trim();
+      if (!trimmed) return "";
+      if (
+        trimmed.startsWith("<h") ||
+        trimmed.startsWith("<pre") ||
+        trimmed.startsWith("<ul") ||
+        trimmed.startsWith("<ol") ||
+        trimmed.startsWith("<blockquote") ||
+        trimmed.startsWith("<hr") ||
+        trimmed.startsWith("<li")
+      ) {
+        return trimmed;
+      }
+      return `<p>${trimmed.replace(/\n/g, "<br>")}</p>`;
+    })
+    .join("\n");
+
+  return html;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+onMounted(loadDashboard);
+watch(() => props.cwd, loadDashboard);
+</script>
+
+<template>
+  <div class="dashboard">
+    <!-- Loading skeleton -->
+    <div v-if="loading" class="dashboard-loading">
+      <div class="spinner"></div>
+      <span>Loading dashboard…</span>
+    </div>
+
+    <template v-else>
+      <!-- Stat cards grid -->
+      <div class="stats-grid">
+        <!-- Commits this week -->
+        <button class="stat-card" @click="emit('changeView', 'history')">
+          <div class="stat-icon stat-icon--accent">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <circle cx="9" cy="9" r="3" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M9 2v4M9 12v4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="stat-body">
+            <span class="stat-value">{{ weeklyCommits }}</span>
+            <span class="stat-label">Commits (7d)</span>
+          </div>
+        </button>
+
+        <!-- Branches -->
+        <button class="stat-card" @click="emit('changeView', 'graph')">
+          <div class="stat-icon stat-icon--info">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <circle cx="5" cy="5" r="2" stroke="currentColor" stroke-width="1.5"/>
+              <circle cx="13" cy="5" r="2" stroke="currentColor" stroke-width="1.5"/>
+              <circle cx="9" cy="14" r="2" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M5 7v3a4 4 0 004 4M13 7v3a4 4 0 01-4 4" stroke="currentColor" stroke-width="1.5"/>
+            </svg>
+          </div>
+          <div class="stat-body">
+            <span class="stat-value">{{ localBranches.length }}</span>
+            <span class="stat-label">Branches</span>
+          </div>
+        </button>
+
+        <!-- Contributors -->
+        <div class="stat-card">
+          <div class="stat-icon stat-icon--success">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <circle cx="9" cy="6" r="3" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M3 16c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="stat-body">
+            <span class="stat-value">{{ contributorCount }}</span>
+            <span class="stat-label">Contributors</span>
+          </div>
+        </div>
+
+        <!-- Working tree -->
+        <button class="stat-card" :class="{ 'stat-card--alert': totalChanges > 0 }" @click="emit('changeView', 'changes')">
+          <div class="stat-icon" :class="totalChanges > 0 ? 'stat-icon--warning' : 'stat-icon--muted'">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <path d="M10 2H5a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7l-5-5z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/>
+              <path d="M10 2v5h5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </div>
+          <div class="stat-body">
+            <span class="stat-value">{{ totalChanges }}</span>
+            <span class="stat-label">Changes</span>
+          </div>
+          <div v-if="totalChanges > 0" class="stat-breakdown">
+            <span v-if="status.staged > 0" class="stat-pill stat-pill--success">{{ status.staged }} staged</span>
+            <span v-if="status.unstaged > 0" class="stat-pill stat-pill--warning">{{ status.unstaged }} modified</span>
+            <span v-if="status.untracked > 0" class="stat-pill stat-pill--muted">{{ status.untracked }} new</span>
+          </div>
+        </button>
+
+        <!-- Tracked files -->
+        <div class="stat-card">
+          <div class="stat-icon stat-icon--muted">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <rect x="2" y="2" width="14" height="14" rx="2" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M5 6h8M5 9h6M5 12h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="stat-body">
+            <span class="stat-value">{{ formatNumber(fileCount) }}</span>
+            <span class="stat-label">Files tracked</span>
+          </div>
+        </div>
+
+        <!-- Open PRs -->
+        <button class="stat-card" @click="emit('changeView', 'prs')">
+          <div class="stat-icon" :class="openPrs > 0 ? 'stat-icon--accent' : 'stat-icon--muted'">
+            <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
+              <circle cx="6" cy="5" r="2" stroke="currentColor" stroke-width="1.5"/>
+              <circle cx="12" cy="13" r="2" stroke="currentColor" stroke-width="1.5"/>
+              <path d="M6 7v6M12 5v6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            </svg>
+          </div>
+          <div class="stat-body">
+            <span class="stat-value">{{ openPrs }}</span>
+            <span class="stat-label">Open PRs</span>
+          </div>
+        </button>
+      </div>
+
+      <!-- Sync status bar -->
+      <div class="sync-bar" v-if="ahead > 0 || behind > 0">
+        <span v-if="ahead > 0" class="sync-pill sync-pill--ahead">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M6 2v8M3 5l3-3 3 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          {{ ahead }} ahead
+        </span>
+        <span v-if="behind > 0" class="sync-pill sync-pill--behind">
+          <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+            <path d="M6 10V2M3 7l3 3 3-3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+          </svg>
+          {{ behind }} behind
+        </span>
+      </div>
+
+      <!-- Recent activity -->
+      <div class="section-row">
+        <!-- Recent commits -->
+        <div class="card recent-commits">
+          <div class="card-header">
+            <h3 class="card-title">Recent commits</h3>
+            <button class="card-link" @click="emit('changeView', 'history')">
+              View all
+              <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+                <path d="M4.5 2.5l4 3.5-4 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+            </button>
+          </div>
+          <ul class="commit-list">
+            <li
+              v-for="c in recentCommits.slice(0, 8)"
+              :key="c.hashFull"
+              class="commit-item"
+            >
+              <code class="commit-hash">{{ c.hash }}</code>
+              <span class="commit-msg">{{ c.message }}</span>
+              <span class="commit-meta">
+                <span class="commit-author">{{ c.author }}</span>
+                <span class="commit-date">{{ formatDate(c.date) }}</span>
+              </span>
+            </li>
+          </ul>
+        </div>
+      </div>
+
+      <!-- README card -->
+      <div class="card readme-card" v-if="readmeContent !== null">
+        <div class="card-header">
+          <h3 class="card-title">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M2 3h5l1 1h6v9H2V3z" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/>
+            </svg>
+            README.md
+          </h3>
+          <div class="readme-tabs">
+            <button
+              class="readme-tab"
+              :class="{ 'readme-tab--active': readmeTab === 'formatted' }"
+              @click="readmeTab = 'formatted'"
+            >
+              Formatted
+            </button>
+            <button
+              class="readme-tab"
+              :class="{ 'readme-tab--active': readmeTab === 'raw' }"
+              @click="readmeTab = 'raw'"
+            >
+              Raw
+            </button>
+          </div>
+        </div>
+        <div class="readme-body">
+          <div
+            v-if="readmeTab === 'formatted'"
+            class="readme-formatted"
+            v-html="renderMarkdown(readmeContent)"
+          />
+          <pre v-else class="readme-raw"><code>{{ readmeContent }}</code></pre>
+        </div>
+      </div>
+
+      <div class="card readme-empty" v-else-if="readmeError">
+        <div class="readme-empty-inner">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none">
+            <rect x="3" y="3" width="18" height="18" rx="3" stroke="currentColor" stroke-width="1.5" opacity="0.4"/>
+            <path d="M8 9h8M8 12h6M8 15h4" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.4"/>
+          </svg>
+          <span>No README.md found in this repository</span>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.dashboard {
+  padding: var(--space-8) var(--space-9);
+  overflow-y: auto;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-7);
+}
+
+.dashboard-loading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  height: 200px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+}
+
+/* ─── Stats grid ─────────────────────────────────────── */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+  gap: var(--space-5);
+}
+
+.stat-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  cursor: default;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  text-align: left;
+  font-family: inherit;
+  color: inherit;
+}
+
+button.stat-card {
+  cursor: pointer;
+}
+
+button.stat-card:hover {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
+}
+
+.stat-card--alert {
+  border-color: var(--color-warning);
+}
+
+.stat-icon {
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-lg);
+}
+
+.stat-icon--accent {
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.stat-icon--info {
+  background: var(--color-info-soft);
+  color: var(--color-info);
+}
+
+.stat-icon--success {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+
+.stat-icon--warning {
+  background: var(--color-warning-soft);
+  color: var(--color-warning);
+}
+
+.stat-icon--muted {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-muted);
+}
+
+.stat-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.stat-value {
+  font-size: var(--font-size-3xl);
+  font-weight: 700;
+  line-height: 1;
+  color: var(--color-text);
+}
+
+.stat-label {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.stat-breakdown {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.stat-pill {
+  font-size: var(--font-size-sm);
+  padding: 1px var(--space-3);
+  border-radius: var(--radius-pill);
+  font-weight: 500;
+}
+
+.stat-pill--success {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+
+.stat-pill--warning {
+  background: var(--color-warning-soft);
+  color: var(--color-warning);
+}
+
+.stat-pill--muted {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-muted);
+}
+
+/* ─── Sync bar ───────────────────────────────────────── */
+.sync-bar {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.sync-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-pill);
+}
+
+.sync-pill--ahead {
+  background: var(--color-success-soft);
+  color: var(--color-success);
+}
+
+.sync-pill--behind {
+  background: var(--color-warning-soft);
+  color: var(--color-warning);
+}
+
+/* ─── Cards ──────────────────────────────────────────── */
+.section-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-5);
+}
+
+.card {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  overflow: hidden;
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.card-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--color-text);
+  margin: 0;
+}
+
+.card-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  color: var(--color-accent);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  transition: background var(--transition-fast);
+}
+
+.card-link:hover {
+  background: var(--color-accent-soft);
+}
+
+/* ─── Recent commits ─────────────────────────────────── */
+.commit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.commit-item {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: var(--space-3);
+  align-items: center;
+  padding: var(--space-3) var(--space-6);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
+}
+
+.commit-item:last-child {
+  border-bottom: none;
+}
+
+.commit-hash {
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: var(--font-size-sm);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+}
+
+.commit-msg {
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.commit-meta {
+  display: flex;
+  gap: var(--space-3);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+.commit-author {
+  font-weight: 500;
+}
+
+/* ─── README card ────────────────────────────────────── */
+.readme-card {
+  flex: 1;
+  min-height: 200px;
+  display: flex;
+  flex-direction: column;
+}
+
+.readme-tabs {
+  display: flex;
+  background: var(--color-bg-tertiary);
+  border-radius: var(--radius-pill);
+  padding: 2px;
+}
+
+.readme-tab {
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-pill);
+  border: none;
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.readme-tab--active {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+  box-shadow: var(--shadow-xs);
+}
+
+.readme-body {
+  flex: 1;
+  overflow-y: auto;
+  max-height: 500px;
+}
+
+.readme-formatted {
+  padding: var(--space-6) var(--space-7);
+  font-size: var(--font-size-md);
+  line-height: 1.65;
+  color: var(--color-text);
+}
+
+.readme-formatted :deep(h1) {
+  font-size: var(--font-size-3xl);
+  font-weight: 700;
+  margin: 0 0 var(--space-5) 0;
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.readme-formatted :deep(h2) {
+  font-size: var(--font-size-xl);
+  font-weight: 600;
+  margin: var(--space-7) 0 var(--space-4) 0;
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.readme-formatted :deep(h3) {
+  font-size: var(--font-size-lg);
+  font-weight: 600;
+  margin: var(--space-6) 0 var(--space-3) 0;
+}
+
+.readme-formatted :deep(h4),
+.readme-formatted :deep(h5),
+.readme-formatted :deep(h6) {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  margin: var(--space-5) 0 var(--space-2) 0;
+}
+
+.readme-formatted :deep(p) {
+  margin: 0 0 var(--space-4) 0;
+}
+
+.readme-formatted :deep(ul),
+.readme-formatted :deep(ol) {
+  margin: 0 0 var(--space-4) 0;
+  padding-left: var(--space-7);
+}
+
+.readme-formatted :deep(li) {
+  margin-bottom: var(--space-2);
+}
+
+.readme-formatted :deep(.md-code-block) {
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-5);
+  overflow-x: auto;
+  margin: 0 0 var(--space-4) 0;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: var(--font-size-sm);
+  line-height: 1.5;
+}
+
+.readme-formatted :deep(.md-inline-code) {
+  background: var(--color-bg-tertiary);
+  padding: 1px var(--space-2);
+  border-radius: var(--radius-sm);
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: 0.9em;
+}
+
+.readme-formatted :deep(.md-link) {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+.readme-formatted :deep(.md-link:hover) {
+  text-decoration: underline;
+}
+
+.readme-formatted :deep(.md-blockquote) {
+  border-left: 3px solid var(--color-accent-soft);
+  padding-left: var(--space-5);
+  color: var(--color-text-muted);
+  margin: 0 0 var(--space-4) 0;
+}
+
+.readme-formatted :deep(.md-hr) {
+  border: none;
+  border-top: 1px solid var(--color-border);
+  margin: var(--space-6) 0;
+}
+
+.readme-formatted :deep(strong) {
+  font-weight: 600;
+}
+
+.readme-raw {
+  padding: var(--space-6) var(--space-7);
+  margin: 0;
+  font-family: "SF Mono", "Fira Code", monospace;
+  font-size: var(--font-size-sm);
+  line-height: 1.6;
+  color: var(--color-text-muted);
+  background: var(--color-bg);
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.readme-raw code {
+  font-family: inherit;
+}
+
+.readme-empty {
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+}
+
+.readme-empty-inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-7) var(--space-8);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-base);
+}
+</style>

--- a/apps/desktop/src/components/DiffViewer.vue
+++ b/apps/desktop/src/components/DiffViewer.vue
@@ -723,13 +723,13 @@ function onDiffScroll() {
 }
 
 .diff-file-name {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--text-md);
+  font-weight: var(--font-semibold);
   flex-shrink: 0;
 }
 
 .diff-file-path {
-  font-size: 11px;
+  font-size: var(--text-xs);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -749,8 +749,8 @@ function onDiffScroll() {
 }
 
 .diff-stat {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
 }
@@ -779,11 +779,11 @@ function onDiffScroll() {
   width: 26px;
   height: 24px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .diff-mode-btn:hover {
@@ -793,7 +793,7 @@ function onDiffScroll() {
 .diff-mode-btn--active {
   background: var(--color-bg-secondary);
   color: var(--color-accent);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-xs);
 }
 
 /* ─── Diff body (content + minimap) ───────────────────── */
@@ -831,8 +831,8 @@ function onDiffScroll() {
 
 .hunk-header {
   padding: 6px 16px;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   background: var(--color-bg-tertiary);
   border-bottom: 1px solid var(--color-border);
   position: sticky;
@@ -859,11 +859,11 @@ function onDiffScroll() {
 }
 
 .diff-line--add {
-  background: rgba(34, 197, 94, 0.1);
+  background: var(--color-success-soft);
 }
 
 .diff-line--delete {
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--color-danger-soft);
 }
 
 .line-no {
@@ -871,8 +871,8 @@ function onDiffScroll() {
   min-width: 48px;
   padding: 0 8px;
   text-align: right;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   opacity: 0.5;
   user-select: none;
   vertical-align: top;
@@ -894,7 +894,7 @@ function onDiffScroll() {
   min-width: 20px;
   padding: 0 4px;
   text-align: center;
-  font-size: 12px;
+  font-size: var(--text-base);
   color: var(--color-text-muted);
   user-select: none;
   vertical-align: top;
@@ -902,17 +902,17 @@ function onDiffScroll() {
 
 .diff-line--add .line-marker {
   color: var(--color-success);
-  font-weight: 700;
+  font-weight: var(--font-bold);
 }
 
 .diff-line--delete .line-marker {
   color: var(--color-danger);
-  font-weight: 700;
+  font-weight: var(--font-bold);
 }
 
 .line-content {
   padding: 0 12px;
-  font-size: 12px;
+  font-size: var(--text-base);
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -947,7 +947,7 @@ function onDiffScroll() {
 .diff-table--sbs .sbs-content {
   width: calc(50% - 60px);
   padding: 0 8px;
-  font-size: 12px;
+  font-size: var(--text-base);
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -965,11 +965,11 @@ function onDiffScroll() {
 }
 
 .sbs-cell--delete {
-  background: rgba(239, 68, 68, 0.1);
+  background: var(--color-danger-soft);
 }
 
 .sbs-cell--add {
-  background: rgba(34, 197, 94, 0.1);
+  background: var(--color-success-soft);
 }
 
 .sbs-cell--empty {
@@ -979,7 +979,7 @@ function onDiffScroll() {
 
 .sbs-cell--delete.line-marker,
 .sbs-cell--add.line-marker {
-  font-weight: 700;
+  font-weight: var(--font-bold);
 }
 
 .sbs-cell--delete.line-marker {
@@ -1008,11 +1008,11 @@ function onDiffScroll() {
   width: 26px;
   height: 24px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-bg-tertiary);
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .diff-history-btn:hover {
@@ -1034,11 +1034,11 @@ function onDiffScroll() {
   width: 22px;
   height: 22px;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-bg-tertiary);
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .diff-nav-btn:hover:not(:disabled) {
@@ -1052,7 +1052,7 @@ function onDiffScroll() {
 }
 
 .diff-nav-count {
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
   min-width: 28px;
   text-align: center;
@@ -1065,14 +1065,14 @@ function onDiffScroll() {
   justify-content: center;
   gap: 6px;
   padding: 4px 16px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   color: var(--color-accent);
   background: var(--color-bg-tertiary);
   cursor: pointer;
   user-select: none;
   border-top: 1px dashed var(--color-border);
   border-bottom: 1px dashed var(--color-border);
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
 }
 
 .diff-collapsed:hover {
@@ -1091,12 +1091,12 @@ function onDiffScroll() {
 }
 
 .diff-empty-text {
-  font-size: 14px;
+  font-size: var(--text-lg);
   color: var(--color-text-muted);
 }
 
 .diff-empty-hint {
-  font-size: 12px;
+  font-size: var(--text-base);
 }
 
 /* New directory listing */
@@ -1167,9 +1167,9 @@ function onDiffScroll() {
 }
 
 .diff-dir-badge {
-  font-size: 11px;
-  font-weight: 700;
-  color: #16a34a;
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
+  color: var(--color-success);
   width: 14px;
   text-align: center;
   flex-shrink: 0;
@@ -1185,8 +1185,8 @@ function onDiffScroll() {
 }
 
 .diff-dir-name {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
   color: var(--color-text);
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1194,7 +1194,7 @@ function onDiffScroll() {
 }
 
 .diff-dir-path {
-  font-size: 10px;
+  font-size: var(--text-xs);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1204,7 +1204,7 @@ function onDiffScroll() {
   color: var(--color-text-muted);
   flex-shrink: 0;
   opacity: 0;
-  transition: opacity 0.1s;
+  transition: opacity var(--transition-fast);
 }
 
 .diff-dir-file:hover .diff-dir-arrow,
@@ -1215,14 +1215,14 @@ function onDiffScroll() {
 /* ─── Partial staging controls ──────────────────────── */
 .diff-stage-btn {
   padding: 3px 10px;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
   cursor: pointer;
-  transition: opacity 0.12s;
+  transition: opacity var(--transition-fast);
   white-space: nowrap;
 }
 
@@ -1244,20 +1244,20 @@ function onDiffScroll() {
 
 .hunk-stage-btn {
   padding: 1px 8px;
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
   border: 1px solid var(--color-accent);
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
   background: transparent;
   color: var(--color-accent);
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .hunk-stage-btn:hover {
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
 
 .hunk-check {
@@ -1290,6 +1290,6 @@ function onDiffScroll() {
 }
 
 .diff-line--selected {
-  background: rgba(56, 132, 255, 0.1) !important;
+  background: var(--color-accent-soft) !important;
 }
 </style>

--- a/apps/desktop/src/components/EditCommitOverlay.vue
+++ b/apps/desktop/src/components/EditCommitOverlay.vue
@@ -121,7 +121,7 @@ function handleKeydown(e: KeyboardEvent) {
   align-items: center;
   justify-content: center;
   z-index: 200;
-  animation: eco-fade 0.12s ease-out;
+  animation: eco-fade var(--transition-fast) ease-out;
 }
 
 @keyframes eco-fade {
@@ -134,11 +134,11 @@ function handleKeydown(e: KeyboardEvent) {
   max-width: calc(100vw - 48px);
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
-  border-radius: 12px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-xl);
   display: flex;
   flex-direction: column;
-  animation: eco-slide 0.15s ease-out;
+  animation: eco-slide var(--transition-base) ease-out;
 }
 
 @keyframes eco-slide {
@@ -149,24 +149,24 @@ function handleKeydown(e: KeyboardEvent) {
 .eco-header {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 14px 16px 12px;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4) var(--space-3);
   border-bottom: 1px solid var(--color-border);
 }
 
 .eco-title {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text);
   flex: 1;
 }
 
 .eco-hash {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   color: var(--color-accent);
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg);
   padding: 2px 7px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 
 .eco-close {
@@ -175,37 +175,37 @@ function handleKeydown(e: KeyboardEvent) {
   justify-content: center;
   width: 22px;
   height: 22px;
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   color: var(--color-text-muted);
   background: none;
-  transition: color 0.1s, background 0.1s;
+  transition: color var(--transition-fast), background var(--transition-fast);
 }
 
 .eco-close:hover {
   color: var(--color-text);
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg);
 }
 
 .eco-body {
-  padding: 16px;
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-1);
 }
 
 .eco-label {
   display: flex;
   align-items: center;
-  gap: 6px;
-  font-size: 11px;
-  font-weight: 600;
+  gap: var(--space-1);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-text-muted);
 }
 
 .eco-label--optional {
-  margin-top: 10px;
+  margin-top: var(--space-2);
 }
 
 .eco-label-hint {
@@ -217,17 +217,17 @@ function handleKeydown(e: KeyboardEvent) {
 
 .eco-input {
   width: 100%;
-  padding: 8px 10px;
-  font-size: 13px;
+  padding: var(--space-2) var(--space-2);
+  font-size: var(--font-size-md);
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 7px;
+  border-radius: var(--radius-md);
   outline: none;
   resize: none;
   line-height: 1.5;
   box-sizing: border-box;
-  transition: border-color 0.12s;
+  transition: border-color var(--transition-fast);
   font-family: var(--font-sans);
 }
 
@@ -237,35 +237,36 @@ function handleKeydown(e: KeyboardEvent) {
 
 .eco-input:focus {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .eco-footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   border-top: 1px solid var(--color-border);
 }
 
 .eco-hint {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
 }
 
 .eco-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .eco-btn {
-  padding: 6px 14px;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  transition: background 0.12s, opacity 0.12s;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-sm);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  transition: background var(--transition-fast), opacity var(--transition-fast);
 }
 
 .eco-btn--cancel {
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg);
   color: var(--color-text);
 }
 
@@ -275,7 +276,7 @@ function handleKeydown(e: KeyboardEvent) {
 
 .eco-btn--confirm {
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
 
 .eco-btn--confirm:hover:not(:disabled) {

--- a/apps/desktop/src/components/EmptyState.vue
+++ b/apps/desktop/src/components/EmptyState.vue
@@ -95,54 +95,55 @@ const isMac = navigator.platform.toUpperCase().includes("MAC");
   align-items: center;
   justify-content: center;
   height: 100%;
-  gap: 16px;
-  padding: 40px;
+  gap: var(--space-6);
+  padding: var(--space-10);
   text-align: center;
 }
 
 .empty-visual {
-  margin-bottom: 8px;
+  margin-bottom: var(--space-4);
   animation: float 4s ease-in-out infinite;
 }
 
 @keyframes float {
   0%, 100% { transform: translateY(0); }
-  50% { transform: translateY(-6px); }
+  50%     { transform: translateY(-6px); }
 }
 
 .empty-title {
-  font-size: 18px;
-  font-weight: 600;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.01em;
 }
 
 .empty-desc {
-  font-size: 14px;
-  line-height: 1.6;
-  max-width: 320px;
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-normal);
+  max-width: 360px;
 }
 
 .empty-btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 24px;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 600;
+  gap: var(--space-4);
+  padding: var(--space-5) var(--space-8);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
   background: var(--color-accent);
-  color: #fff;
-  transition: background 0.15s, transform 0.1s;
-  margin-top: 8px;
+  color: var(--color-accent-text);
+  transition: background var(--transition-base), transform var(--transition-fast), box-shadow var(--transition-base);
+  margin-top: var(--space-4);
+  box-shadow: var(--shadow-sm);
 }
 
 .empty-btn:hover {
   background: var(--color-accent-hover);
   transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
 }
 
-.empty-btn:active {
-  transform: translateY(0);
-}
+.empty-btn:active { transform: translateY(0); box-shadow: var(--shadow-xs); }
 
 /* ─── Recent repos ───────────────────────────────────── */
 
@@ -150,13 +151,13 @@ const isMac = navigator.platform.toUpperCase().includes("MAC");
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
-  margin-top: 16px;
+  gap: var(--space-5);
+  margin-top: var(--space-6);
 }
 
 .recent-label {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.06em;
 }
@@ -164,29 +165,31 @@ const isMac = navigator.platform.toUpperCase().includes("MAC");
 .recent-cards {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: var(--space-3);
   justify-content: center;
+  max-width: 560px;
 }
 
 .recent-card {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 16px;
-  border-radius: 8px;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-6);
+  border-radius: var(--radius-pill);
   border: 1px solid var(--color-border);
-  background: var(--color-bg);
+  background: var(--color-bg-secondary);
   color: var(--color-text);
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s, box-shadow 0.15s;
+  transition: border-color var(--transition-base), background var(--transition-base), box-shadow var(--transition-base), transform var(--transition-fast);
 }
 
 .recent-card:hover {
   border-color: var(--color-accent);
-  background: var(--color-bg-secondary);
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  background: var(--color-accent-soft);
+  box-shadow: var(--shadow-xs);
+  transform: translateY(-1px);
 }
 
 .recent-card svg {
@@ -194,28 +197,25 @@ const isMac = navigator.platform.toUpperCase().includes("MAC");
   flex-shrink: 0;
 }
 
-.recent-card:hover svg {
-  color: var(--color-accent);
-}
+.recent-card:hover svg { color: var(--color-accent); }
+.recent-card:hover .recent-card-name { color: var(--color-accent); }
 
-.recent-card-name {
-  white-space: nowrap;
-}
+.recent-card-name { white-space: nowrap; }
 
 /* ─── Hint ────────────────────────────────────────────── */
 
 .empty-hint {
-  font-size: 12px;
-  margin-top: 8px;
+  font-size: var(--font-size-base);
+  margin-top: var(--space-4);
 }
 
 .empty-hint kbd {
   display: inline-block;
-  padding: 1px 6px;
-  font-size: 11px;
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--font-size-sm);
   font-family: var(--font-mono);
   background: var(--color-bg-tertiary);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
 }
 </style>

--- a/apps/desktop/src/components/FileHistoryViewer.vue
+++ b/apps/desktop/src/components/FileHistoryViewer.vue
@@ -404,13 +404,13 @@ function shortHash(hash: string): string {
 }
 
 .fhv-file-name {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--text-md);
+  font-weight: var(--font-semibold);
   flex-shrink: 0;
 }
 
 .fhv-file-path {
-  font-size: 11px;
+  font-size: var(--text-xs);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -427,14 +427,14 @@ function shortHash(hash: string): string {
 
 .fhv-tab {
   padding: 4px 12px;
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .fhv-tab:hover {
@@ -444,14 +444,14 @@ function shortHash(hash: string): string {
 .fhv-tab--active {
   background: var(--color-bg-secondary);
   color: var(--color-accent);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  box-shadow: var(--shadow-xs);
 }
 
 .fhv-close {
   display: flex;
   align-items: center;
   padding: 4px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: none;
   color: var(--color-text-muted);
   cursor: pointer;
@@ -501,7 +501,7 @@ function shortHash(hash: string): string {
   width: 200px;
   min-width: 200px;
   padding: 2px 8px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   vertical-align: top;
   border-right: 1px solid var(--color-border);
   background: var(--color-bg-secondary);
@@ -515,7 +515,7 @@ function shortHash(hash: string): string {
 }
 
 .fhv-blame-hash {
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--color-accent);
   cursor: pointer;
   margin-right: 6px;
@@ -527,12 +527,12 @@ function shortHash(hash: string): string {
 
 .fhv-blame-author {
   color: var(--color-text);
-  font-weight: 500;
+  font-weight: var(--font-medium);
   margin-right: 6px;
 }
 
 .fhv-blame-date {
-  font-size: 10px;
+  font-size: var(--text-xs);
 }
 
 .fhv-blame-lineno {
@@ -540,8 +540,8 @@ function shortHash(hash: string): string {
   min-width: 44px;
   padding: 0 6px;
   text-align: right;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   opacity: 0.5;
   user-select: none;
   border-right: 1px solid var(--color-border);
@@ -549,7 +549,7 @@ function shortHash(hash: string): string {
 
 .fhv-blame-content {
   padding: 0 10px;
-  font-size: 12px;
+  font-size: var(--text-base);
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -565,7 +565,7 @@ function shortHash(hash: string): string {
 .fhv-log-entry {
   padding: 10px 16px;
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -586,8 +586,8 @@ function shortHash(hash: string): string {
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--text-base);
+  font-weight: var(--font-bold);
   color: #fff;
   flex-shrink: 0;
 }
@@ -598,8 +598,8 @@ function shortHash(hash: string): string {
 }
 
 .fhv-log-message {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   color: var(--color-text);
   line-height: 1.3;
 }
@@ -608,7 +608,7 @@ function shortHash(hash: string): string {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   margin-top: 3px;
 }
 
@@ -617,7 +617,7 @@ function shortHash(hash: string): string {
 }
 
 .fhv-log-hash {
-  font-size: 10px;
+  font-size: var(--text-xs);
   color: var(--color-accent);
 }
 
@@ -630,7 +630,7 @@ function shortHash(hash: string): string {
 /* ─── Compare hint ──────────────────────────────────── */
 .fhv-compare-hint {
   padding: 8px 16px;
-  font-size: 12px;
+  font-size: var(--text-base);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -638,15 +638,15 @@ function shortHash(hash: string): string {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--color-accent-bg, rgba(56, 132, 255, 0.08));
+  background: var(--color-accent-soft);
   color: var(--color-accent);
 }
 
 .fhv-compare-clear {
   padding: 2px 8px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-bg-secondary);
   color: var(--color-text-muted);
   cursor: pointer;
@@ -664,29 +664,29 @@ function shortHash(hash: string): string {
   width: 24px;
   height: 24px;
   border: 1px solid var(--color-border);
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   background: var(--color-bg-secondary);
   color: var(--color-text-muted);
   cursor: pointer;
   flex-shrink: 0;
-  transition: background 0.12s, color 0.12s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .fhv-compare-btn:hover {
   color: var(--color-accent);
   border-color: var(--color-accent);
-  background: var(--color-accent-bg, rgba(56, 132, 255, 0.08));
+  background: var(--color-accent-soft);
 }
 
 /* Selected log entries */
 .fhv-log-entry--from {
-  background: rgba(56, 132, 255, 0.08);
+  background: var(--color-accent-soft);
   border-left: 3px solid var(--color-accent);
 }
 
 .fhv-log-entry--to {
-  background: rgba(80, 200, 120, 0.08);
-  border-left: 3px solid var(--color-success, #50c878);
+  background: var(--color-success-soft);
+  border-left: 3px solid var(--color-success);
 }
 
 /* ─── Compare tab ───────────────────────────────────── */
@@ -707,14 +707,14 @@ function shortHash(hash: string): string {
 
 .fhv-compare-go-log {
   padding: 6px 16px;
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   background: var(--color-bg-secondary);
   color: var(--color-accent);
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
 }
 
 .fhv-compare-go-log:hover {
@@ -731,19 +731,19 @@ function shortHash(hash: string): string {
   align-items: center;
   gap: 8px;
   padding: 8px 16px;
-  font-size: 12px;
+  font-size: var(--text-base);
   background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border);
 }
 
 .fhv-compare-label--from {
   color: var(--color-accent);
-  font-weight: 600;
+  font-weight: var(--font-semibold);
 }
 
 .fhv-compare-label--to {
-  color: var(--color-success, #50c878);
-  font-weight: 600;
+  color: var(--color-success);
+  font-weight: var(--font-semibold);
 }
 
 .fhv-compare-diff {
@@ -757,8 +757,8 @@ function shortHash(hash: string): string {
 /* ─── Diff table styles (replicated from DiffViewer) ── */
 .hunk-header {
   padding: 4px 10px;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   background: var(--color-bg-tertiary);
   border-bottom: 1px solid var(--color-border);
 }
@@ -783,8 +783,8 @@ function shortHash(hash: string): string {
   min-width: 44px;
   padding: 0 6px;
   text-align: right;
-  font-size: 11px;
-  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   opacity: 0.5;
   user-select: none;
   border-right: 1px solid var(--color-border);
@@ -792,7 +792,7 @@ function shortHash(hash: string): string {
 
 .line-content {
   padding: 0 10px;
-  font-size: var(--code-font-size, 12px);
+  font-size: var(--text-base);
   white-space: pre;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -813,11 +813,11 @@ function shortHash(hash: string): string {
 }
 
 .sbs-cell--delete {
-  background: var(--color-diff-del-bg, rgba(255, 0, 0, 0.06));
+  background: var(--color-danger-soft);
 }
 
 .sbs-cell--add {
-  background: var(--color-diff-add-bg, rgba(0, 180, 0, 0.06));
+  background: var(--color-success-soft);
 }
 
 .sbs-cell--empty {

--- a/apps/desktop/src/components/FileList.vue
+++ b/apps/desktop/src/components/FileList.vue
@@ -87,25 +87,25 @@ function statusLabel(file: ConflictFile): string {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 16px;
+  padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--color-border);
 }
 
 .file-list-title {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   color: var(--color-text-muted);
 }
 
 .file-list-count {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg);
   padding: 1px 6px;
-  border-radius: 10px;
+  border-radius: var(--radius-pill);
   font-variant-numeric: tabular-nums;
 }
 
@@ -118,15 +118,15 @@ function statusLabel(file: ConflictFile): string {
 .file-item {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 10px 16px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
   cursor: pointer;
-  transition: background 0.12s;
+  transition: background var(--transition-fast);
   border-left: 3px solid transparent;
 }
 
 .file-item:hover {
-  background: var(--color-bg-tertiary);
+  background: var(--color-bg-hover);
 }
 
 .file-item--selected {
@@ -172,28 +172,28 @@ function statusLabel(file: ConflictFile): string {
 }
 
 .file-name {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .file-dir {
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .file-badge {
-  font-size: 11px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   font-variant-numeric: tabular-nums;
   color: var(--color-text-muted);
   background: var(--color-bg);
   padding: 1px 7px;
-  border-radius: 10px;
+  border-radius: var(--radius-pill);
   flex-shrink: 0;
 }
 </style>

--- a/apps/desktop/src/components/FolderPicker.vue
+++ b/apps/desktop/src/components/FolderPicker.vue
@@ -241,157 +241,146 @@ onUnmounted(() => {
 }
 
 .folder-picker {
-  background: var(--color-bg-secondary, #1e1e2e);
-  border: 1px solid var(--color-border, #333);
-  border-radius: 12px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-2xl);
   width: min(600px, 90vw);
   max-height: 80vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-  animation: fpSlideIn 0.2s ease-out;
+  box-shadow: var(--shadow-xl);
+  animation: fpSlideIn var(--transition-slow);
+  overflow: hidden;
 }
 
 @keyframes fpSlideIn {
   from { opacity: 0; transform: translateY(-10px) scale(0.98); }
-  to { opacity: 1; transform: translateY(0) scale(1); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
 }
 
 .fp-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px 12px;
-  border-bottom: 1px solid var(--color-border, #333);
+  padding: var(--space-6) var(--space-7) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .fp-title {
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: -0.01em;
   margin: 0;
-  color: var(--color-text, #e0e0e0);
+  color: var(--color-text);
 }
 
 .fp-close {
-  background: none;
-  border: none;
-  color: var(--color-text-muted, #888);
-  cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-muted);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
-.fp-close:hover { color: var(--color-text, #e0e0e0); background: rgba(255,255,255,0.06); }
+.fp-close:hover { color: var(--color-text); background: var(--color-bg-tertiary); }
 
 /* Path bar */
 .fp-pathbar {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--color-border, #333);
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .fp-nav-btn {
   flex-shrink: 0;
-  background: none;
-  border: 1px solid transparent;
-  color: var(--color-text-muted, #888);
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 6px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  transition: all 0.15s;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-muted);
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 .fp-nav-btn:hover:not(:disabled) {
-  color: var(--color-text, #e0e0e0);
-  background: rgba(255,255,255,0.06);
-  border-color: var(--color-border, #444);
+  color: var(--color-text);
+  background: var(--color-bg-tertiary);
 }
 .fp-nav-btn:disabled { opacity: 0.3; cursor: default; }
 
 .fp-path-input {
   flex: 1;
-  background: var(--color-bg, #0f0f14);
-  border: 1px solid var(--color-border, #333);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font-size: 13px;
-  font-family: "SF Mono", "Fira Code", monospace;
-  color: var(--color-text, #e0e0e0);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-md);
+  font-family: var(--font-mono);
+  color: var(--color-text);
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
 }
 .fp-path-input:focus {
-  border-color: var(--color-accent, #6366f1);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 /* ─── History / Favorites ─────────────────────────────── */
 
 .fp-history {
-  border-bottom: 1px solid var(--color-border, #333);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg);
 }
 
-.fp-history-header {
-  padding: 8px 16px 4px;
-}
+.fp-history-header { padding: var(--space-4) var(--space-6) var(--space-2); }
 
 .fp-history-title {
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  color: var(--color-text-muted, #888);
+  color: var(--color-text-muted);
 }
 
 .fp-history-list {
   list-style: none;
   margin: 0;
-  padding: 0 8px 8px;
+  padding: 0 var(--space-3) var(--space-3);
 }
 
 .fp-history-entry {
   display: flex;
   align-items: center;
-  gap: 4px;
-  border-radius: 6px;
-  transition: background 0.12s;
+  gap: var(--space-2);
+  border-radius: var(--radius-md);
+  transition: background var(--transition-fast);
 }
 
-.fp-history-entry:hover {
-  background: rgba(255, 255, 255, 0.04);
-}
-
-.fp-history-entry--pinned {
-  background: rgba(251, 191, 36, 0.05);
-}
+.fp-history-entry:hover { background: var(--color-bg-tertiary); }
+.fp-history-entry--pinned { background: var(--color-warning-soft); }
 
 .fp-history-pin {
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 4px;
-  background: none;
-  border: none;
-  color: var(--color-text-muted, #666);
-  cursor: pointer;
+  width: 28px;
+  height: 28px;
+  border-radius: var(--radius-pill);
+  color: var(--color-text-muted);
   opacity: 0.4;
-  transition: opacity 0.15s, color 0.15s;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
 }
 
 .fp-history-pin:hover,
-.fp-history-pin--active {
-  opacity: 1;
-}
-
-.fp-history-pin--active {
-  color: #fbbf24;
-}
+.fp-history-pin--active { opacity: 1; }
+.fp-history-pin--active { color: var(--color-warning); }
 
 .fp-history-select {
   flex: 1;
@@ -399,26 +388,23 @@ onUnmounted(() => {
   display: flex;
   flex-direction: column;
   gap: 1px;
-  padding: 6px 4px;
-  background: none;
-  border: none;
+  padding: var(--space-3) var(--space-2);
   text-align: left;
-  cursor: pointer;
-  color: var(--color-text, #e0e0e0);
+  color: var(--color-text);
 }
 
 .fp-history-name {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .fp-history-path {
-  font-size: 11px;
-  font-family: "SF Mono", "Fira Code", monospace;
-  color: var(--color-text-muted, #888);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -429,24 +415,20 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 4px;
-  background: none;
-  border: none;
-  color: var(--color-text-muted, #666);
-  cursor: pointer;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--radius-pill);
+  color: var(--color-text-muted);
   opacity: 0;
-  transition: opacity 0.15s, color 0.15s;
+  transition: opacity var(--transition-fast), color var(--transition-fast), background var(--transition-fast);
 }
 
-.fp-history-entry:hover .fp-history-remove {
-  opacity: 0.5;
-}
+.fp-history-entry:hover .fp-history-remove { opacity: 0.5; }
 
 .fp-history-remove:hover {
   opacity: 1 !important;
-  color: var(--color-danger, #ef4444);
+  color: var(--color-danger);
+  background: var(--color-danger-soft);
 }
 
 /* Directory listing */
@@ -458,44 +440,43 @@ onUnmounted(() => {
 }
 
 .fp-loading, .fp-error, .fp-empty {
-  padding: 40px 20px;
+  padding: var(--space-10) var(--space-7);
   text-align: center;
-  font-size: 13px;
-  color: var(--color-text-muted, #888);
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
 }
-.fp-error { color: var(--color-danger, #ef4444); }
+.fp-error { color: var(--color-danger); }
 
 .fp-list {
   list-style: none;
   margin: 0;
-  padding: 4px;
+  padding: var(--space-2);
 }
 
 .fp-entry {
   display: flex;
   align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  border-radius: 6px;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: 13px;
-  color: var(--color-text, #e0e0e0);
-  transition: background 0.12s;
+  font-size: var(--font-size-md);
+  color: var(--color-text);
+  transition: background var(--transition-fast);
   user-select: none;
 }
-.fp-entry:hover {
-  background: rgba(255, 255, 255, 0.05);
-}
+.fp-entry:hover { background: var(--color-bg-tertiary); }
 .fp-entry:focus-visible {
-  outline: 2px solid var(--color-accent, #6366f1);
+  outline: 2px solid var(--color-focus-ring);
   outline-offset: -2px;
 }
 
 .fp-entry--git {
-  background: rgba(99, 102, 241, 0.06);
+  background: var(--color-accent-soft);
 }
 .fp-entry--git:hover {
-  background: rgba(99, 102, 241, 0.12);
+  background: var(--color-accent-soft);
+  filter: brightness(1.1);
 }
 
 .fp-entry-icon {
@@ -503,8 +484,8 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
 }
-.icon-folder { color: var(--color-text-muted, #888); }
-.icon-git { color: #f97316; }
+.icon-folder { color: var(--color-text-muted); }
+.icon-git    { color: var(--color-accent); }
 
 .fp-entry-name {
   flex: 1;
@@ -515,14 +496,14 @@ onUnmounted(() => {
 
 .fp-entry-badge {
   flex-shrink: 0;
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
-  letter-spacing: 0.5px;
-  padding: 2px 6px;
-  border-radius: 4px;
-  background: rgba(249, 115, 22, 0.15);
-  color: #f97316;
+  letter-spacing: 0.04em;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
 }
 
 /* Footer */
@@ -530,15 +511,16 @@ onUnmounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  padding: 12px 16px;
-  border-top: 1px solid var(--color-border, #333);
+  gap: var(--space-5);
+  padding: var(--space-5) var(--space-6);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg);
 }
 
 .fp-current-path {
-  font-size: 11px;
-  font-family: "SF Mono", "Fira Code", monospace;
-  color: var(--color-text-muted, #888);
+  font-size: var(--font-size-sm);
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -548,37 +530,37 @@ onUnmounted(() => {
 
 .fp-actions {
   display: flex;
-  gap: 8px;
+  gap: var(--space-3);
   flex-shrink: 0;
 }
 
 .fp-btn {
-  padding: 7px 16px;
-  border-radius: 6px;
-  font-size: 13px;
-  font-weight: 500;
+  padding: var(--space-3) var(--space-6);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   cursor: pointer;
   border: 1px solid transparent;
-  transition: all 0.15s;
+  transition: background var(--transition-base), color var(--transition-base), border-color var(--transition-base);
 }
 
 .fp-btn--cancel {
-  background: none;
-  color: var(--color-text-muted, #888);
-  border-color: var(--color-border, #444);
+  background: transparent;
+  color: var(--color-text-muted);
+  border-color: var(--color-border);
 }
 .fp-btn--cancel:hover {
-  color: var(--color-text, #e0e0e0);
-  background: rgba(255,255,255,0.04);
+  color: var(--color-text);
+  background: var(--color-bg-tertiary);
 }
 
 .fp-btn--select {
-  background: var(--color-accent, #6366f1);
-  color: white;
-  border-color: var(--color-accent, #6366f1);
+  background: var(--color-accent);
+  color: var(--color-accent-text);
+  border-color: var(--color-accent);
 }
 .fp-btn--select:hover {
-  background: #5855eb;
-  border-color: #5855eb;
+  background: var(--color-accent-hover);
+  border-color: var(--color-accent-hover);
 }
 </style>

--- a/apps/desktop/src/components/GitTerminal.vue
+++ b/apps/desktop/src/components/GitTerminal.vue
@@ -220,11 +220,11 @@ onMounted(() => {
 .git-terminal {
   display: flex;
   flex-direction: column;
-  background: var(--bg-terminal, #11111b);
-  border-radius: 8px;
-  border: 1px solid var(--border-color, #313244);
+  background: var(--color-bg);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
   font-family: "JetBrains Mono", "Fira Code", "Consolas", monospace;
-  font-size: 12px;
+  font-size: var(--font-size-xs);
   height: 300px;
   overflow: hidden;
 }
@@ -233,34 +233,34 @@ onMounted(() => {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 6px 10px;
-  background: var(--bg-secondary, #1e1e2e);
-  border-bottom: 1px solid var(--border-color, #313244);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .terminal-title {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
   font-family: inherit;
 }
 
 .terminal-output {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 10px;
+  padding: var(--space-2) var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .terminal-welcome {
-  color: var(--text-muted, #6c7086);
-  font-size: 12px;
-  padding: 12px 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  padding: var(--space-3) 0;
 }
 
 .terminal-welcome code {
-  background: var(--bg-secondary, #1e1e2e);
+  background: var(--color-bg-secondary);
   padding: 1px 4px;
   border-radius: 3px;
 }
@@ -273,44 +273,44 @@ onMounted(() => {
 
 .terminal-cmd {
   display: flex;
-  gap: 6px;
-  color: var(--text-primary, #cdd6f4);
-  font-weight: 600;
+  gap: var(--space-1);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .terminal-prompt {
-  color: var(--color-success, #a6e3a1);
-  font-weight: 700;
+  color: var(--color-success);
+  font-weight: var(--font-weight-bold);
   user-select: none;
 }
 
 .terminal-stdout {
   margin: 0;
-  color: var(--text-secondary, #a6adc8);
+  color: var(--color-text-secondary);
   white-space: pre-wrap;
   word-break: break-all;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   line-height: 1.5;
 }
 
 .terminal-stderr {
   margin: 0;
-  color: var(--color-error, #f38ba8);
+  color: var(--color-danger);
   white-space: pre-wrap;
   word-break: break-all;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   line-height: 1.5;
 }
 
 .terminal-exit {
   font-size: 10px;
-  color: var(--color-error, #f38ba8);
+  color: var(--color-danger);
   opacity: 0.7;
 }
 
 .terminal-input-area {
   position: relative;
-  border-top: 1px solid var(--border-color, #313244);
+  border-top: 1px solid var(--color-border);
 }
 
 .terminal-suggestions {
@@ -318,8 +318,8 @@ onMounted(() => {
   bottom: 100%;
   left: 0;
   right: 0;
-  background: var(--bg-secondary, #1e1e2e);
-  border: 1px solid var(--border-color, #313244);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
   border-bottom: none;
   border-radius: 4px 4px 0 0;
   max-height: 160px;
@@ -327,27 +327,27 @@ onMounted(() => {
 }
 
 .terminal-suggestion {
-  padding: 4px 10px;
+  padding: var(--space-1) var(--space-2);
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
 }
 
 .terminal-suggestion:hover,
 .terminal-suggestion.active {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.08));
+  background: var(--color-bg-hover);
 }
 
 .terminal-input-row {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 10px;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-2);
 }
 
 .terminal-git-prefix {
-  color: var(--color-accent, #cba6f7);
+  color: var(--color-accent);
   user-select: none;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .terminal-input {
@@ -361,7 +361,7 @@ onMounted(() => {
 }
 
 .terminal-input::placeholder {
-  color: var(--text-muted, #45475a);
+  color: var(--color-text-muted);
 }
 
 .terminal-spinner {
@@ -378,17 +378,17 @@ onMounted(() => {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border-color, #313244);
-  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   background: transparent;
   color: inherit;
   cursor: pointer;
-  font-size: 12px;
-  padding: 3px 8px;
-  transition: all 0.15s;
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  transition: all var(--transition-base);
 }
 
-.btn:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.08)); }
-.btn-sm { font-size: 12px; }
+.btn:hover { background: var(--color-bg-hover); }
+.btn-sm { font-size: var(--font-size-xs); }
 .btn-ghost { border-color: transparent; }
 </style>

--- a/apps/desktop/src/components/MergeEditor.vue
+++ b/apps/desktop/src/components/MergeEditor.vue
@@ -400,12 +400,12 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 }
 
 .editor-filename {
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--text-md);
+  font-weight: var(--font-semibold);
 }
 
 .editor-stats {
-  font-size: 12px;
+  font-size: var(--text-base);
 }
 
 .btn--resolve {
@@ -413,12 +413,12 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
   align-items: center;
   gap: 6px;
   padding: 5px 12px;
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 500;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
   background: var(--color-accent);
-  color: #fff;
-  transition: background 0.15s;
+  color: var(--color-accent-text);
+  transition: background var(--transition-base);
 }
 
 .btn--resolve:hover {
@@ -438,7 +438,7 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 .code-block {
   margin: 0;
   padding: 4px 20px;
-  font-size: 13px;
+  font-size: var(--text-md);
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-all;
@@ -449,7 +449,7 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 .conflict-hunk {
   margin: 2px 0;
   border-left: 3px solid var(--color-danger);
-  background: rgba(239, 68, 68, 0.04);
+  background: var(--color-danger-soft);
 }
 
 .conflict-hunk--resolvable {
@@ -469,12 +469,12 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 }
 
 .inline-action {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--text-base);
+  font-weight: var(--font-medium);
   text-decoration: none;
   padding: 2px 0;
   cursor: pointer;
-  transition: color 0.12s;
+  transition: color var(--transition-fast);
   color: var(--color-text-muted);
 }
 
@@ -522,15 +522,16 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 /* ─── AI action ──────────────────────────────────────── */
 
 .inline-action--ai {
-  color: #a78bfa;
+  color: var(--color-accent);
   display: inline-flex;
   align-items: center;
   gap: 3px;
-  font-weight: 600;
+  font-weight: var(--font-semibold);
 }
 
 .inline-action--ai:hover {
-  color: #c4b5fd;
+  color: var(--color-accent);
+  opacity: 0.8;
 }
 
 .inline-action--loading {
@@ -554,7 +555,7 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 /* ─── Recommended action ──────────────────────────────── */
 
 .inline-action--recommended {
-  font-weight: 700;
+  font-weight: var(--font-bold);
   display: inline-flex;
   align-items: center;
   gap: 3px;
@@ -568,19 +569,19 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 .inline-sep {
   color: var(--color-border);
   padding: 0 8px;
-  font-size: 12px;
+  font-size: var(--text-base);
   user-select: none;
 }
 
 .inline-badge--recommended {
   margin-left: auto;
-  font-size: 10px;
-  font-weight: 700;
+  font-size: var(--text-xs);
+  font-weight: var(--font-bold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   padding: 1px 6px;
-  border-radius: 3px;
-  background: rgba(34, 197, 94, 0.12);
+  border-radius: var(--radius-xs);
+  background: var(--color-success-soft);
   color: var(--color-success);
 }
 
@@ -608,11 +609,11 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
   align-items: center;
   gap: 6px;
   padding: 4px 12px;
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--text-xs);
+  font-weight: var(--font-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--color-text-muted);
+  color: var(--color-text-subtle);
   border-bottom: 1px solid var(--color-border);
 }
 
@@ -629,7 +630,7 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 .panel-code {
   margin: 0;
   padding: 8px 12px;
-  font-size: 12px;
+  font-size: var(--text-base);
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-all;
@@ -662,8 +663,8 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 }
 
 .edit-label {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--text-base);
+  font-weight: var(--font-semibold);
   color: var(--color-accent);
 }
 
@@ -681,7 +682,7 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
   color: var(--color-text);
   border: none;
   border-bottom: 1px solid var(--color-border);
-  font-size: 13px;
+  font-size: var(--text-md);
   line-height: 1.6;
   resize: vertical;
   outline: none;
@@ -696,21 +697,21 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 /* ─── Diff Highlighting ────────────────────────────────── */
 
 .panel-code :deep(.diff-add) {
-  background: rgba(34, 197, 94, 0.2);
+  background: var(--color-success-soft);
   border-radius: 2px;
   padding: 0 1px;
 }
 
 .hunk-panel--ours .panel-code :deep(.diff-add) {
-  background: rgba(96, 165, 250, 0.25);
+  background: var(--color-info-soft);
 }
 
 .hunk-panel--theirs .panel-code :deep(.diff-add) {
-  background: rgba(168, 85, 247, 0.25);
+  background: var(--color-accent-soft);
 }
 
 .panel-code :deep(.diff-del) {
-  background: rgba(239, 68, 68, 0.2);
+  background: var(--color-danger-soft);
   border-radius: 2px;
   padding: 0 1px;
   text-decoration: line-through;
@@ -721,7 +722,7 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
 
 .hunk-explanation {
   padding: 6px 20px 8px;
-  font-size: 12px;
+  font-size: var(--text-base);
   font-style: italic;
   border-top: 1px solid var(--color-border);
 }
@@ -733,17 +734,17 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
   align-items: center;
   justify-content: space-between;
   padding: 6px 14px;
-  background: var(--color-danger-bg);
+  background: var(--color-danger-soft);
   color: var(--color-danger);
-  font-size: 12px;
-  border-radius: 4px;
+  font-size: var(--text-base);
+  border-radius: var(--radius-sm);
   margin: 4px 12px;
 }
 
 .ai-error-close {
   color: var(--color-danger);
-  font-weight: 600;
-  font-size: 11px;
+  font-weight: var(--font-semibold);
+  font-size: var(--text-xs);
   text-decoration: none;
 }
 
@@ -753,17 +754,17 @@ function highlightedHtml(hunkIndex: number, panel: "ours" | "base" | "theirs"): 
   gap: 8px;
   padding: 8px 14px;
   margin: 4px 12px;
-  background: rgba(167, 139, 250, 0.08);
-  border: 1px solid rgba(167, 139, 250, 0.2);
-  border-radius: 6px;
-  font-size: 12px;
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-soft);
+  border-radius: var(--radius-sm);
+  font-size: var(--text-base);
   line-height: 1.4;
-  color: #c4b5fd;
+  color: var(--color-accent);
 }
 
 .ai-explanation-icon {
   flex-shrink: 0;
   margin-top: 1px;
-  color: #a78bfa;
+  color: var(--color-accent);
 }
 </style>

--- a/apps/desktop/src/components/MergePreviewPanel.vue
+++ b/apps/desktop/src/components/MergePreviewPanel.vue
@@ -141,7 +141,7 @@ function basename(path: string): string {
 @keyframes spin { to { transform: rotate(360deg); } }
 
 .preview-panel--error {
-  color: var(--color-red, #f38ba8);
+  color: var(--color-danger);
 }
 
 /* Header */
@@ -154,13 +154,13 @@ function basename(path: string): string {
 
 .preview-badge {
   padding: 2px 8px;
-  border-radius: 4px;
-  font-weight: 600;
-  font-size: 11px;
+  border-radius: var(--radius-sm);
+  font-weight: var(--font-semibold);
+  font-size: var(--text-xs);
 }
-.preview-badge--clean  { background: #a6e3a120; color: #a6e3a1; }
-.preview-badge--auto   { background: #89b4fa20; color: #89b4fa; }
-.preview-badge--warn   { background: #fab38720; color: #fab387; }
+.preview-badge--clean  { background: var(--color-success-soft); color: var(--color-success); }
+.preview-badge--auto   { background: var(--color-info-soft); color: var(--color-info); }
+.preview-badge--warn   { background: var(--color-warning-soft); color: var(--color-warning); }
 
 .preview-branch {
   flex: 1;
@@ -191,14 +191,14 @@ function basename(path: string): string {
 }
 
 .stat {
-  font-size: 11px;
+  font-size: var(--text-xs);
   padding: 1px 6px;
-  border-radius: 3px;
+  border-radius: var(--radius-xs);
 }
-.stat--conflict { background: #f38ba820; color: #f38ba8; }
-.stat--auto     { background: #89b4fa20; color: #89b4fa; }
-.stat--manual   { background: #fab38720; color: #fab387; }
-.stat--clean    { background: #a6e3a120; color: #a6e3a1; }
+.stat--conflict { background: var(--color-danger-soft); color: var(--color-danger); }
+.stat--auto     { background: var(--color-info-soft); color: var(--color-info); }
+.stat--manual   { background: var(--color-warning-soft); color: var(--color-warning); }
+.stat--clean    { background: var(--color-success-soft); color: var(--color-success); }
 
 /* File list */
 .preview-files {
@@ -219,15 +219,15 @@ function basename(path: string): string {
 }
 
 .pf-icon {
-  font-size: 11px;
+  font-size: var(--text-xs);
   width: 14px;
   text-align: center;
   flex-shrink: 0;
 }
-.preview-file--auto-resolved .pf-icon { color: #a6e3a1; }
-.preview-file--partial .pf-icon        { color: #89b4fa; }
-.preview-file--manual .pf-icon         { color: #f38ba8; }
-.preview-file--add-delete .pf-icon     { color: #fab387; }
+.preview-file--auto-resolved .pf-icon { color: var(--color-success); }
+.preview-file--partial .pf-icon        { color: var(--color-info); }
+.preview-file--manual .pf-icon         { color: var(--color-danger); }
+.preview-file--add-delete .pf-icon     { color: var(--color-warning); }
 
 .pf-path {
   flex: 1;
@@ -235,12 +235,12 @@ function basename(path: string): string {
   text-overflow: ellipsis;
   white-space: nowrap;
   font-family: var(--font-mono, monospace);
-  font-size: 11px;
+  font-size: var(--text-xs);
 }
 
 .pf-detail {
-  font-size: 10px;
-  color: var(--color-subtext, #6c7086);
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
   white-space: nowrap;
 }
 </style>

--- a/apps/desktop/src/components/MonorepoPanel.vue
+++ b/apps/desktop/src/components/MonorepoPanel.vue
@@ -93,11 +93,11 @@ function managerIcon(manager: string): string {
 .monorepo-panel {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  padding: 8px 10px;
-  background: var(--bg-secondary, #1e1e2e);
-  border-radius: 6px;
-  border: 1px solid var(--border-color, #313244);
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-2);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
 }
 
 .monorepo-header {
@@ -107,27 +107,28 @@ function managerIcon(manager: string): string {
 }
 
 .monorepo-title {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
 }
 
 .monorepo-count {
-  color: var(--text-muted, #6c7086);
+  color: var(--color-text-muted);
   font-weight: 400;
 }
 
 .monorepo-filter {
-  background: var(--bg-tertiary, #11111b);
-  border: 1px solid var(--border-color, #313244);
-  border-radius: 4px;
-  padding: 4px 8px;
-  font-size: 12px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-xs);
   color: inherit;
   outline: none;
 }
 
 .monorepo-filter:focus {
-  border-color: var(--color-accent, #cba6f7);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .monorepo-list {
@@ -141,37 +142,37 @@ function managerIcon(manager: string): string {
 .monorepo-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 5px 8px;
-  border-radius: 4px;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
   cursor: pointer;
-  transition: background 0.15s;
-  font-size: 12px;
+  transition: background var(--transition-base);
+  font-size: var(--font-size-xs);
 }
 
 .monorepo-item:hover {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+  background: var(--color-bg-hover);
 }
 
 .monorepo-pkg-name {
-  font-weight: 600;
-  color: var(--color-accent, #cba6f7);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent);
   white-space: nowrap;
 }
 
 .monorepo-pkg-path {
   flex: 1;
-  color: var(--text-muted, #6c7086);
+  color: var(--color-text-muted);
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .monorepo-pkg-version {
-  color: var(--text-muted, #6c7086);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   flex-shrink: 0;
 }
 </style>

--- a/apps/desktop/src/components/PrCommentThread.vue
+++ b/apps/desktop/src/components/PrCommentThread.vue
@@ -226,7 +226,7 @@ function timeAgo(dateStr: string): string {
   height: 20px;
   border-radius: 50%;
   background: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
   font-size: 10px;
   font-weight: 700;
   display: flex;
@@ -264,7 +264,7 @@ function timeAgo(dateStr: string): string {
   transition: opacity 0.1s;
 }
 .pct-action-btn:hover { opacity: 1; background: var(--color-bg-tertiary); }
-.pct-action-btn--del:hover { background: rgba(243,139,168,0.15); }
+.pct-action-btn--del:hover { background: var(--color-danger-soft); }
 
 .pct-body {
   color: var(--color-text);
@@ -302,7 +302,7 @@ function timeAgo(dateStr: string): string {
 }
 
 :deep(.comment-suggestion-label) {
-  background: rgba(203,166,247,0.15);
+  background: var(--color-accent-soft);
   padding: 3px 8px;
   font-size: 10px;
   font-weight: 600;
@@ -323,16 +323,16 @@ function timeAgo(dateStr: string): string {
 }
 
 .pct-apply-btn {
-  background: rgba(166,227,161,0.15);
-  border: 1px solid rgba(166,227,161,0.4);
+  background: var(--color-success-soft);
+  border: 1px solid var(--color-success);
   border-radius: 4px;
-  color: #a6e3a1;
+  color: var(--color-success);
   padding: 3px 10px;
   font-size: 11px;
   cursor: pointer;
   transition: background 0.15s;
 }
-.pct-apply-btn:hover { background: rgba(166,227,161,0.25); }
+.pct-apply-btn:hover { background: var(--color-success); color: var(--color-success-text); }
 
 /* Edit box */
 .pct-edit-box { display: flex; flex-direction: column; gap: 6px; }
@@ -387,7 +387,7 @@ function timeAgo(dateStr: string): string {
   background: var(--color-accent);
   border: none;
   border-radius: 4px;
-  color: #fff;
+  color: var(--color-accent-text);
   padding: 3px 12px;
   font-size: 11px;
   cursor: pointer;

--- a/apps/desktop/src/components/PrDetailView.vue
+++ b/apps/desktop/src/components/PrDetailView.vue
@@ -296,8 +296,8 @@ function openInBrowser(url: string) { window.open(url, "_blank"); }
   padding: 6px 16px;
   flex-shrink: 0;
 }
-.pdv-msg--error { color: #f38ba8; background: rgba(243,139,168,0.1); }
-.pdv-msg--success { color: #a6e3a1; background: rgba(166,227,161,0.1); cursor: pointer; }
+.pdv-msg--error { color: var(--color-danger); background: var(--color-danger-soft); }
+.pdv-msg--success { color: var(--color-success); background: var(--color-success-soft); cursor: pointer; }
 .pdv-msg--full { padding: 16px; font-size: 13px; }
 
 /* Empty state */
@@ -396,7 +396,7 @@ function openInBrowser(url: string) { window.open(url, "_blank"); }
   color: var(--color-text-muted);
   font-weight: 600;
 }
-.pdv-tab-count--comment { background: rgba(203,166,247,0.15); color: var(--color-accent); }
+.pdv-tab-count--comment { background: var(--color-accent-soft); color: var(--color-accent); }
 
 .pdv-tab-spacer { flex: 1; }
 .pdv-review-btn { margin: 4px 0; font-weight: 600; }
@@ -426,8 +426,8 @@ function openInBrowser(url: string) { window.open(url, "_blank"); }
   border-radius: 6px;
   font-size: 12px;
 }
-.pdv-readiness--ok { background: rgba(22,163,74,0.08); border: 1px solid rgba(22,163,74,0.3); color: #16a34a; }
-.pdv-readiness--wait { background: rgba(202,138,4,0.1); border: 1px solid rgba(202,138,4,0.4); color: #a16207; font-weight: 600; }
+.pdv-readiness--ok { background: var(--color-success-soft); border: 1px solid var(--color-success); color: var(--color-success); }
+.pdv-readiness--wait { background: var(--color-warning-soft); border: 1px solid var(--color-warning); color: var(--color-warning); font-weight: 600; }
 
 .pdv-stats-grid {
   display: grid;
@@ -451,8 +451,8 @@ function openInBrowser(url: string) { window.open(url, "_blank"); }
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
-.pdv-add { color: #16a34a; font-weight: 600; }
-.pdv-del { color: #dc2626; font-weight: 600; }
+.pdv-add { color: var(--color-success); font-weight: 600; }
+.pdv-del { color: var(--color-danger); font-weight: 600; }
 
 .pdv-section { display: flex; flex-direction: column; gap: 6px; }
 .pdv-section-label {
@@ -541,7 +541,7 @@ function openInBrowser(url: string) { window.open(url, "_blank"); }
   width: 100%;
 }
 .pdv-diff-file:hover { background: var(--color-bg-tertiary); }
-.pdv-diff-file.active { background: rgba(203,166,247,0.1); border-color: rgba(203,166,247,0.3); }
+.pdv-diff-file.active { background: var(--color-accent-soft); border-color: var(--color-accent); }
 
 .pdv-diff-file-top { display: flex; align-items: center; gap: 4px; overflow: hidden; }
 .pdv-diff-file-name { font-size: 12px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; }
@@ -604,11 +604,11 @@ function openInBrowser(url: string) { window.open(url, "_blank"); }
 .eco-btn--primary {
   background: var(--color-accent);
   border-color: var(--color-accent);
-  color: #fff;
+  color: var(--color-accent-text);
 }
 .eco-btn--primary:hover {
   background: var(--color-accent-hover, color-mix(in srgb, var(--color-accent) 85%, #000));
   border-color: var(--color-accent-hover, var(--color-accent));
-  color: #fff;
+  color: var(--color-accent-text);
 }
 </style>

--- a/apps/desktop/src/components/PrInlineDiff.vue
+++ b/apps/desktop/src/components/PrInlineDiff.vue
@@ -333,8 +333,8 @@ function handleApplySuggestion(suggestion: string, startLine: number | null, end
   border-bottom: 1px solid transparent;
 }
 
-.pid-row--add { background: rgba(166,227,161,0.12); }
-.pid-row--del { background: rgba(243,139,168,0.12); }
+.pid-row--add { background: var(--color-success-soft); }
+.pid-row--del { background: var(--color-danger-soft); }
 .pid-row--ctx { background: transparent; }
 
 /* Line numbers */
@@ -365,7 +365,7 @@ function handleApplySuggestion(suggestion: string, startLine: number | null, end
 }
 
 .pid-lno--clickable { cursor: pointer; }
-.pid-lno--clickable:hover { background: rgba(203,166,247,0.15); }
+.pid-lno--clickable:hover { background: var(--color-accent-soft); }
 .pid-lno--clickable:hover .pid-lno-icon { opacity: 1; }
 
 /* Marker column */
@@ -376,8 +376,8 @@ function handleApplySuggestion(suggestion: string, startLine: number | null, end
   color: var(--color-text-muted);
   border-right: 1px solid var(--color-border);
 }
-.pid-row--add .pid-marker { color: #a6e3a1; }
-.pid-row--del .pid-marker { color: #f38ba8; }
+.pid-row--add .pid-marker { color: var(--color-success); }
+.pid-row--del .pid-marker { color: var(--color-danger); }
 
 /* Content column */
 .pid-content {
@@ -456,13 +456,13 @@ function handleApplySuggestion(suggestion: string, startLine: number | null, end
   cursor: pointer;
 }
 .pid-review-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.pid-review-btn:not(:disabled):hover { background: rgba(203,166,247,0.12); }
+.pid-review-btn:not(:disabled):hover { background: var(--color-accent-soft); }
 
 .pid-submit-btn {
   background: var(--color-accent);
   border: none;
   border-radius: 4px;
-  color: #fff;
+  color: var(--color-accent-text);
   padding: 3px 12px;
   font-size: 11px;
   font-weight: 600;

--- a/apps/desktop/src/components/PrIntelligencePanel.vue
+++ b/apps/desktop/src/components/PrIntelligencePanel.vue
@@ -66,10 +66,10 @@ const scope = computed(() => {
     critical: "Critique",
   };
   const riskColor: Record<string, string> = {
-    low: "#16a34a",
-    medium: "#c07a00",
+    low: "var(--color-success)",
+    medium: "var(--color-warning)",
     high: "#ea580c",
-    critical: "#dc2626",
+    critical: "var(--color-danger)",
   };
 
   return { changedFiles, additions, deletions, totalLines, pct, risk, riskLabel: riskLabel[risk], riskColor: riskColor[risk] };
@@ -396,14 +396,14 @@ watch(() => props.prDiffFiles, (files) => {
   border: 1px solid;
 }
 .pi-badge--info {
-  background: rgba(37,99,235,0.1);
-  color: #1d4ed8;
-  border-color: rgba(37,99,235,0.35);
+  background: var(--color-info-soft);
+  color: var(--color-info);
+  border-color: var(--color-info);
 }
 .pi-badge--ai {
-  background: rgba(109,40,217,0.1);
-  color: #6d28d9;
-  border-color: rgba(109,40,217,0.35);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
 }
 
 .pi-empty {
@@ -419,7 +419,7 @@ watch(() => props.prDiffFiles, (files) => {
   background: var(--color-accent);
   border: none;
   border-radius: 5px;
-  color: #fff;
+  color: var(--color-accent-text);
   font-size: 11px;
   font-weight: 600;
   padding: 3px 12px;
@@ -429,7 +429,7 @@ watch(() => props.prDiffFiles, (files) => {
 
 .pi-msg--error {
   font-size: 12px;
-  color: #f38ba8;
+  color: var(--color-danger);
   padding: 4px 0;
 }
 
@@ -454,14 +454,14 @@ watch(() => props.prDiffFiles, (files) => {
   margin-bottom: 10px;
 }
 .pi-conflict-summary--ok {
-  background: rgba(166,227,161,0.12);
-  border: 1px solid rgba(166,227,161,0.35);
-  color: #a6e3a1;
+  background: var(--color-success-soft);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
 }
 .pi-conflict-summary--bad {
-  background: rgba(243,139,168,0.12);
-  border: 1px solid rgba(243,139,168,0.35);
-  color: #f38ba8;
+  background: var(--color-danger-soft);
+  border: 1px solid var(--color-danger);
+  color: var(--color-danger);
 }
 
 .pi-conflict-detail { margin-bottom: 10px; }
@@ -478,8 +478,8 @@ watch(() => props.prDiffFiles, (files) => {
   font-size: 12px;
   background: var(--color-bg-tertiary);
 }
-.pi-file-row--conflict { border-left: 2px solid #f38ba8; }
-.pi-file-row--overlap { border-left: 2px solid #f9e2af; }
+.pi-file-row--conflict { border-left: 2px solid var(--color-danger); }
+.pi-file-row--overlap { border-left: 2px solid var(--color-warning); }
 .pi-file-icon { font-size: 13px; }
 .pi-file-name { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pi-file-label { font-size: 10px; color: var(--color-text-muted); white-space: nowrap; flex-shrink: 0; }
@@ -493,7 +493,7 @@ watch(() => props.prDiffFiles, (files) => {
   color: var(--color-text-muted);
   white-space: nowrap;
 }
-.pi-chip--clean { color: #a6e3a1; border-color: rgba(166,227,161,0.3); }
+.pi-chip--clean { color: var(--color-success); border-color: var(--color-success); }
 .pi-chip--more { color: var(--color-accent); }
 
 /* Scope */
@@ -513,8 +513,8 @@ watch(() => props.prDiffFiles, (files) => {
 }
 .pi-scope-value { font-size: 16px; font-weight: 700; color: var(--color-text); margin-bottom: 2px; }
 .pi-scope-label { font-size: 10px; color: var(--color-text-muted); text-transform: uppercase; }
-.pi-add { color: #16a34a; }
-.pi-del { color: #dc2626; }
+.pi-add { color: var(--color-success); }
+.pi-del { color: var(--color-danger); }
 
 .pi-risk-bar-track {
   height: 4px;
@@ -549,7 +549,7 @@ watch(() => props.prDiffFiles, (files) => {
 }
 .pi-hotspot-bar-fill {
   height: 100%;
-  background: #fab387;
+  background: var(--color-warning);
   border-radius: 3px;
 }
 .pi-hotspot-count { font-size: 11px; color: var(--color-text-muted); white-space: nowrap; width: 70px; text-align: right; flex-shrink: 0; }
@@ -566,9 +566,9 @@ watch(() => props.prDiffFiles, (files) => {
   background: var(--color-bg-tertiary);
   font-size: 12px;
 }
-.pi-ai-row--error { border-color: #f38ba8; }
-.pi-ai-row--warn { border-color: #f9e2af; }
-.pi-ai-row--info { border-color: #89b4fa; }
+.pi-ai-row--error { border-color: var(--color-danger); }
+.pi-ai-row--warn { border-color: var(--color-warning); }
+.pi-ai-row--info { border-color: var(--color-info); }
 .pi-ai-icon { font-size: 13px; flex-shrink: 0; margin-top: 1px; }
 .pi-ai-content { display: flex; flex-direction: column; gap: 2px; }
 .pi-ai-file { font-weight: 600; color: var(--color-text); font-size: 11px; }

--- a/apps/desktop/src/components/PrListSidebar.vue
+++ b/apps/desktop/src/components/PrListSidebar.vue
@@ -154,7 +154,7 @@ function stateChip(state: string) {
   background: var(--color-accent);
   border: none;
   border-radius: 5px;
-  color: #fff;
+  color: var(--color-accent-text);
   font-size: 11px;
   font-weight: 600;
   padding: 5px 10px;
@@ -205,7 +205,7 @@ function stateChip(state: string) {
   background: var(--color-accent);
   border: none;
   border-radius: 4px;
-  color: #fff;
+  color: var(--color-accent-text);
   font-size: 11px;
   font-weight: 600;
   padding: 3px 10px;
@@ -221,8 +221,8 @@ function stateChip(state: string) {
   font-size: 11px;
   flex-shrink: 0;
 }
-.pls-msg--error { background: rgba(243,139,168,0.1); color: #f38ba8; }
-.pls-msg--success { background: rgba(166,227,161,0.1); color: #a6e3a1; cursor: pointer; }
+.pls-msg--error { background: var(--color-danger-soft); color: var(--color-danger); }
+.pls-msg--success { background: var(--color-success-soft); color: var(--color-success); cursor: pointer; }
 
 /* Placeholder */
 .pls-placeholder {
@@ -261,8 +261,8 @@ function stateChip(state: string) {
 }
 .pls-item:hover { background: var(--color-bg-tertiary); }
 .pls-item--active {
-  background: rgba(203,166,247,0.1);
-  border-color: rgba(203,166,247,0.35);
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
 }
 
 .pls-item-top {
@@ -285,9 +285,9 @@ function stateChip(state: string) {
   border-radius: 3px;
   border: 1px solid;
 }
-.pls-chip--open { background: rgba(166,227,161,0.15); color: #16a34a; border-color: rgba(22,163,74,0.3); }
-.pls-chip--merged { background: rgba(203,166,247,0.15); color: #6d28d9; border-color: rgba(109,40,217,0.3); }
-.pls-chip--closed { background: rgba(243,139,168,0.12); color: #dc2626; border-color: rgba(220,38,38,0.3); }
+.pls-chip--open { background: var(--color-success-soft); color: var(--color-success); border-color: var(--color-success); }
+.pls-chip--merged { background: var(--color-accent-soft); color: var(--color-accent); border-color: var(--color-accent); }
+.pls-chip--closed { background: var(--color-danger-soft); color: var(--color-danger); border-color: var(--color-danger); }
 .pls-chip--draft { background: var(--color-bg-tertiary); color: var(--color-text-muted); border-color: var(--color-border); }
 
 .pls-time {
@@ -328,6 +328,6 @@ function stateChip(state: string) {
   font-weight: 600;
 }
 
-.pls-add { color: #16a34a; }
-.pls-del { color: #dc2626; }
+.pls-add { color: var(--color-success); }
+.pls-del { color: var(--color-danger); }
 </style>

--- a/apps/desktop/src/components/PrReviewModal.vue
+++ b/apps/desktop/src/components/PrReviewModal.vue
@@ -169,7 +169,7 @@ function handleKeydown(e: KeyboardEvent) {
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  box-shadow: 0 16px 48px rgba(0,0,0,0.4);
+  box-shadow: var(--shadow-xl);
 }
 
 .prm-header {
@@ -204,8 +204,8 @@ function handleKeydown(e: KeyboardEvent) {
   gap: 8px;
   margin: 12px 16px 0;
   padding: 8px 12px;
-  background: rgba(203,166,247,0.08);
-  border: 1px solid rgba(203,166,247,0.25);
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent);
   border-radius: 6px;
   font-size: 12px;
   color: var(--color-text);
@@ -234,7 +234,7 @@ function handleKeydown(e: KeyboardEvent) {
   align-items: center;
 }
 
-.prm-required { color: #f38ba8; font-weight: 500; text-transform: none; }
+.prm-required { color: var(--color-danger); font-weight: 500; text-transform: none; }
 .prm-optional { color: var(--color-text-muted); font-weight: 400; text-transform: none; }
 
 /* Radio group */
@@ -256,8 +256,8 @@ function handleKeydown(e: KeyboardEvent) {
   color: var(--color-text);
   transition: border-color 0.15s, background 0.15s;
 }
-.prm-radio-label:hover { border-color: var(--color-accent); background: rgba(203,166,247,0.06); }
-.prm-radio-label--active { border-color: var(--color-accent); background: rgba(203,166,247,0.10); }
+.prm-radio-label:hover { border-color: var(--color-accent); background: var(--color-accent-soft); }
+.prm-radio-label--active { border-color: var(--color-accent); background: var(--color-accent-soft); }
 
 .prm-radio { display: none; }
 .prm-radio-icon { font-size: 15px; }
@@ -307,12 +307,12 @@ function handleKeydown(e: KeyboardEvent) {
   font-size: 12px;
   font-weight: 600;
   cursor: pointer;
-  color: #fff;
+  color: var(--color-accent-text);
   background: var(--color-accent);
   transition: filter 0.15s;
 }
-.prm-submit-btn--approve { background: #a6e3a1; color: #1e1e2e; }
-.prm-submit-btn--request-changes { background: #f38ba8; color: #1e1e2e; }
+.prm-submit-btn--approve { background: var(--color-success); color: var(--color-success-text); }
+.prm-submit-btn--request-changes { background: var(--color-danger); color: var(--color-danger-text); }
 .prm-submit-btn--comment { background: var(--color-accent); }
 .prm-submit-btn:disabled { opacity: 0.4; cursor: not-allowed; }
 .prm-submit-btn:not(:disabled):hover { filter: brightness(1.1); }

--- a/apps/desktop/src/components/PullRequestPanel.vue
+++ b/apps/desktop/src/components/PullRequestPanel.vue
@@ -891,8 +891,8 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
   padding: 6px 16px;
   flex-shrink: 0;
 }
-.pr-msg--error { color: var(--color-error, #f38ba8); background: rgba(243,139,168,0.1); }
-.pr-msg--success { color: var(--color-success, #a6e3a1); background: rgba(166,227,161,0.1); cursor: pointer; }
+.pr-msg--error { color: var(--color-danger); background: var(--color-danger-soft); }
+.pr-msg--success { color: var(--color-success); background: var(--color-success-soft); cursor: pointer; }
 
 /* ─── Create form ─────────────────────────────────────── */
 .pr-create-form {
@@ -1039,8 +1039,8 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
 }
 
 .pr-stats { display: flex; gap: 3px; }
-.add { color: var(--color-success, #a6e3a1); }
-.del { color: var(--color-error, #f38ba8); }
+.add { color: var(--color-success); }
+.del { color: var(--color-danger); }
 
 .pr-item-chips {
   display: flex;
@@ -1138,7 +1138,7 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
   text-align: center;
 }
 .pr-tab-count--comment {
-  background: rgba(203,166,247,0.15);
+  background: var(--color-accent-soft);
   color: var(--color-accent);
 }
 
@@ -1204,7 +1204,7 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
 }
 
 .pr-body-text :deep(.pr-code) {
-  background: rgba(203,166,247,0.15);
+  background: var(--color-accent-soft);
   padding: 1px 4px;
   border-radius: 3px;
   font-family: "JetBrains Mono", "Fira Code", monospace;
@@ -1257,7 +1257,7 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
 }
 
 .pr-diff-file:hover { background: var(--color-bg-tertiary); }
-.pr-diff-file.active { background: rgba(203,166,247,0.12); }
+.pr-diff-file.active { background: var(--color-accent-soft); }
 
 .pr-diff-file-top { display: flex; align-items: center; gap: 4px; overflow: hidden; }
 .pr-diff-file-name { font-size: 12px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex: 1; }
@@ -1298,14 +1298,14 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
   margin-bottom: 10px;
 }
 .pr-readiness-banner--ready {
-  background: rgba(166,227,161,0.12);
-  border: 1px solid rgba(166,227,161,0.35);
-  color: #a6e3a1;
+  background: var(--color-success-soft);
+  border: 1px solid var(--color-success);
+  color: var(--color-success);
 }
 .pr-readiness-banner--wait {
-  background: rgba(250,219,107,0.08);
-  border: 1px solid rgba(250,219,107,0.25);
-  color: var(--color-text-muted);
+  background: var(--color-warning-soft);
+  border: 1px solid var(--color-warning);
+  color: var(--color-warning);
 }
 .pr-readiness-icon { font-size: 14px; flex-shrink: 0; }
 
@@ -1339,7 +1339,7 @@ watch(() => props.cwd, () => { loadRemote(); loadPrs(); selectedPr.value = null;
 
 .eco-btn:hover { background: var(--color-bg-tertiary); }
 .eco-btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.eco-btn--primary { background: var(--color-accent); color: #fff; border-color: transparent; font-weight: 600; }
+.eco-btn--primary { background: var(--color-accent); color: var(--color-accent-text); border-color: transparent; font-weight: 600; }
 .eco-btn--primary:hover { background: var(--color-accent-hover, var(--color-accent)); filter: brightness(1.05); }
 .eco-btn--xs { font-size: 11px; padding: 3px 8px; border-radius: 5px; }
 .eco-close { padding: 5px; border-color: transparent; color: var(--color-text-muted); }

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -169,6 +169,19 @@ function onCommitKeydown(e: KeyboardEvent) {
     <div class="view-tabs">
       <button
         class="view-tab"
+        :class="{ 'view-tab--active': viewMode === 'dashboard' }"
+        @click="emit('changeView', 'dashboard')"
+        title="Dashboard"
+      >
+        <svg width="14" height="14" viewBox="0 0 14 14" fill="none" style="vertical-align: -2px;">
+          <rect x="1" y="1" width="5" height="5" rx="1" stroke="currentColor" stroke-width="1.3"/>
+          <rect x="8" y="1" width="5" height="5" rx="1" stroke="currentColor" stroke-width="1.3"/>
+          <rect x="1" y="8" width="5" height="5" rx="1" stroke="currentColor" stroke-width="1.3"/>
+          <rect x="8" y="8" width="5" height="5" rx="1" stroke="currentColor" stroke-width="1.3"/>
+        </svg>
+      </button>
+      <button
+        class="view-tab"
         :class="{ 'view-tab--active': viewMode === 'changes' }"
         @click="emit('changeView', 'changes')"
       >
@@ -426,14 +439,14 @@ function onCommitKeydown(e: KeyboardEvent) {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 10px 12px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-5);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
   background: none;
   border-bottom: 2px solid transparent;
-  transition: color 0.15s, border-color 0.15s;
+  transition: color var(--transition-base), border-color var(--transition-base);
 }
 
 .view-tab:hover {
@@ -446,12 +459,12 @@ function onCommitKeydown(e: KeyboardEvent) {
 }
 
 .tab-badge {
-  font-size: 10px;
-  font-weight: 600;
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
   background: var(--color-accent);
-  color: #fff;
-  padding: 1px 5px;
-  border-radius: 8px;
+  color: var(--color-accent-text);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
   font-variant-numeric: tabular-nums;
 }
 
@@ -483,10 +496,10 @@ function onCommitKeydown(e: KeyboardEvent) {
 .section-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 14px;
-  font-size: 11px;
-  font-weight: 600;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-text-muted);
@@ -498,8 +511,8 @@ function onCommitKeydown(e: KeyboardEvent) {
 
 .section-icon {
   font-family: var(--font-mono);
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   width: 16px;
   text-align: center;
 }
@@ -511,8 +524,8 @@ function onCommitKeydown(e: KeyboardEvent) {
 .section-count {
   font-variant-numeric: tabular-nums;
   background: var(--color-bg-tertiary);
-  padding: 1px 6px;
-  border-radius: 8px;
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-pill);
 }
 
 .section-action {
@@ -521,13 +534,13 @@ function onCommitKeydown(e: KeyboardEvent) {
   justify-content: center;
   width: 20px;
   height: 20px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: var(--font-mono);
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-muted);
   background: none;
-  transition: background 0.1s, color 0.1s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .section-action:hover {
@@ -542,10 +555,10 @@ function onCommitKeydown(e: KeyboardEvent) {
 .file-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 14px 6px 18px;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-6) var(--space-3) 18px;
   cursor: pointer;
-  transition: background 0.1s;
+  transition: background var(--transition-fast);
   border-left: 3px solid transparent;
 }
 
@@ -596,8 +609,8 @@ function onCommitKeydown(e: KeyboardEvent) {
 }
 
 .file-status-badge {
-  font-size: 12px;
-  font-weight: 700;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
   width: 16px;
   text-align: center;
   flex-shrink: 0;
@@ -612,15 +625,15 @@ function onCommitKeydown(e: KeyboardEvent) {
 }
 
 .file-name {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .file-dir {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -632,14 +645,14 @@ function onCommitKeydown(e: KeyboardEvent) {
   justify-content: center;
   width: 20px;
   height: 20px;
-  border-radius: 4px;
+  border-radius: var(--radius-sm);
   font-family: var(--font-mono);
-  font-size: 14px;
-  font-weight: 700;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
   color: var(--color-text-muted);
   background: none;
   opacity: 0;
-  transition: opacity 0.1s, background 0.1s, color 0.1s;
+  transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
   flex-shrink: 0;
 }
 
@@ -657,41 +670,42 @@ function onCommitKeydown(e: KeyboardEvent) {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  padding: 40px 20px;
+  gap: var(--space-5);
+  padding: var(--space-10) var(--space-7);
 }
 
 .empty-text {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   color: var(--color-text-muted);
 }
 
 /* Commit panel — fixed at bottom of sidebar */
 .commit-panel {
   border-top: 1px solid var(--color-border);
-  padding: 10px 12px;
+  padding: var(--space-5) var(--space-5);
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-4);
   background: var(--color-bg-secondary);
   flex-shrink: 0;
 }
 
 .commit-summary {
   width: 100%;
-  padding: 7px 10px;
-  font-size: 11px;
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-base);
 }
 
 .commit-summary:focus {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .commit-summary::placeholder {
@@ -700,22 +714,23 @@ function onCommitKeydown(e: KeyboardEvent) {
 
 .commit-description {
   width: 100%;
-  padding: 7px 10px;
-  font-size: 11px;
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-sm);
   line-height: 1.5;
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-md);
   resize: vertical;
   min-height: 38px;
   max-height: 120px;
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-base);
 }
 
 .commit-description:focus {
   border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px var(--color-accent-soft);
 }
 
 .commit-description::placeholder {
@@ -725,22 +740,22 @@ function onCommitKeydown(e: KeyboardEvent) {
 
 .commit-actions {
   display: flex;
-  gap: 6px;
+  gap: var(--space-3);
 }
 
 .commit-stage-all {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 4px;
-  padding: 7px 10px;
-  font-size: 11px;
-  font-weight: 500;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
   background: var(--color-bg-tertiary);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
-  transition: background 0.15s, border-color 0.15s;
+  border-radius: var(--radius-md);
+  transition: background var(--transition-base), border-color var(--transition-base);
   white-space: nowrap;
 }
 
@@ -755,14 +770,14 @@ function onCommitKeydown(e: KeyboardEvent) {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
-  padding: 7px 14px;
-  font-size: 12px;
-  font-weight: 600;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-6);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
   background: var(--color-accent);
-  color: #fff;
-  border-radius: 6px;
-  transition: background 0.15s, opacity 0.15s;
+  color: var(--color-accent-text);
+  border-radius: var(--radius-pill);
+  transition: background var(--transition-base), opacity var(--transition-base);
 }
 
 .commit-btn:hover:not(:disabled) {
@@ -783,7 +798,7 @@ function onCommitKeydown(e: KeyboardEvent) {
 }
 
 .commit-hint {
-  font-size: 10px;
+  font-size: var(--font-size-xs);
   text-align: center;
 }
 </style>
@@ -796,13 +811,13 @@ function onCommitKeydown(e: KeyboardEvent) {
   min-width: 200px;
   background: var(--color-bg-secondary, #1e1e2e);
   border: 1px solid var(--color-border, #313244);
-  border-radius: 8px;
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  padding: 4px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+  padding: var(--space-2);
   display: flex;
   flex-direction: column;
-  gap: 1px;
-  animation: ctx-fade-in 0.1s ease;
+  gap: var(--space-1);
+  animation: ctx-fade-in var(--transition-fast) ease;
 }
 
 @keyframes ctx-fade-in {
@@ -813,17 +828,17 @@ function onCommitKeydown(e: KeyboardEvent) {
 .ctx-item {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 7px 10px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text, #cdd6f4);
   background: none;
-  border-radius: 5px;
+  border-radius: var(--radius-sm);
   width: 100%;
   text-align: left;
   cursor: pointer;
-  transition: background 0.1s, color 0.1s;
+  transition: background var(--transition-fast), color var(--transition-fast);
 }
 
 .ctx-item:hover {
@@ -841,6 +856,6 @@ function onCommitKeydown(e: KeyboardEvent) {
 .ctx-separator {
   height: 1px;
   background: var(--color-border, #313244);
-  margin: 3px 6px;
+  margin: var(--space-xs) var(--space-3);
 }
 </style>

--- a/apps/desktop/src/components/RepoTabBar.vue
+++ b/apps/desktop/src/components/RepoTabBar.vue
@@ -66,15 +66,16 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 </template>
 
 <style scoped>
+/* ─── Tab bar — pill-style, inspired by segmented controls ─── */
 .tab-bar {
   display: flex;
   align-items: center;
-  gap: 0;
+  gap: var(--space-3);
   background: var(--color-bg-secondary);
   border-bottom: 1px solid var(--color-border);
-  height: 36px;
+  height: var(--tabbar-height);
   flex-shrink: 0;
-  padding: 0 4px;
+  padding: 0 var(--space-5);
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: thin;
@@ -82,8 +83,8 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 
 .tab-list {
   display: flex;
-  align-items: stretch;
-  gap: 1px;
+  align-items: center;
+  gap: var(--space-2);
   flex: 1;
   min-width: 0;
 }
@@ -91,16 +92,15 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 .tab {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 0 10px;
-  height: 36px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  border-radius: var(--radius-pill);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
   cursor: pointer;
-  border-bottom: 2px solid transparent;
-  transition: color 0.12s, border-color 0.12s, background 0.12s;
-  max-width: 180px;
+  transition: color var(--transition-base), background var(--transition-base);
+  max-width: 200px;
   min-width: 0;
   flex-shrink: 1;
   user-select: none;
@@ -112,14 +112,13 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 }
 
 .tab--active {
-  color: var(--color-text);
-  border-bottom-color: var(--color-accent);
-  background: var(--color-bg);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
 }
 
 .tab-icon {
   flex-shrink: 0;
-  opacity: 0.6;
+  opacity: 0.65;
 }
 
 .tab--active .tab-icon {
@@ -136,45 +135,40 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 
 .tab-close {
   flex-shrink: 0;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 18px;
   height: 18px;
-  border-radius: 4px;
-  background: none;
-  border: none;
+  border-radius: var(--radius-pill);
   color: var(--color-text-muted);
   opacity: 0;
-  cursor: pointer;
-  transition: opacity 0.12s, background 0.12s, color 0.12s;
+  transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
   padding: 0;
 }
 
-.tab:hover .tab-close {
-  opacity: 0.6;
+.tab:hover .tab-close,
+.tab--active .tab-close {
+  opacity: 0.7;
 }
 
 .tab-close:hover {
   opacity: 1 !important;
-  background: var(--color-danger-bg);
+  background: var(--color-danger-soft);
   color: var(--color-danger);
 }
 
 .tab-new {
   flex-shrink: 0;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   width: 28px;
   height: 28px;
-  border-radius: 6px;
-  background: none;
-  border: none;
+  border-radius: var(--radius-pill);
   color: var(--color-text-muted);
-  cursor: pointer;
-  transition: background 0.12s, color 0.12s;
-  margin-left: 2px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  margin-left: auto;
 }
 
 .tab-new:hover {

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -759,12 +759,12 @@ function onKeyDown(e: KeyboardEvent) {
 .settings-panel {
   background: var(--color-bg-secondary);
   border: 1px solid var(--color-border);
-  border-radius: 12px;
+  border-radius: var(--radius-2xl);
   width: min(520px, 90vw);
   max-height: 85vh;
   display: flex;
   flex-direction: column;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--shadow-xl);
   animation: spSlideIn 0.2s ease-out;
 }
 
@@ -777,12 +777,12 @@ function onKeyDown(e: KeyboardEvent) {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px 12px;
+  padding: var(--space-6) var(--space-7) var(--space-5);
 }
 
 .sp-title {
-  font-size: 15px;
-  font-weight: 600;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
   margin: 0;
 }
 
@@ -791,38 +791,38 @@ function onKeyDown(e: KeyboardEvent) {
   border: none;
   color: var(--color-text-muted);
   cursor: pointer;
-  padding: 4px;
-  border-radius: 4px;
+  padding: var(--space-2);
+  border-radius: var(--radius-sm);
   display: flex;
   align-items: center;
 }
 
 .sp-close:hover {
   color: var(--color-text);
-  background: rgba(255, 255, 255, 0.06);
+  background: var(--color-bg-tertiary);
 }
 
 /* ─── Tab bar ──────────────────────────────────────────── */
 .sp-tabs {
   display: flex;
   gap: 0;
-  padding: 0 20px;
+  padding: 0 var(--space-7);
   border-bottom: 1px solid var(--color-border);
 }
 
 .sp-tab {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 8px 14px;
-  font-size: 12px;
-  font-weight: 500;
+  gap: var(--space-3);
+  padding: var(--space-4) var(--space-5);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
   background: none;
   border: none;
   border-bottom: 2px solid transparent;
   cursor: pointer;
-  transition: color 0.12s, border-color 0.12s;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
   white-space: nowrap;
 }
 
@@ -841,10 +841,10 @@ function onKeyDown(e: KeyboardEvent) {
 
 /* ─── Body ─────────────────────────────────────────────── */
 .sp-body {
-  padding: 16px 20px;
+  padding: var(--space-6) var(--space-7);
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: var(--space-6);
   overflow-y: auto;
   min-height: 180px;
 }
@@ -852,12 +852,12 @@ function onKeyDown(e: KeyboardEvent) {
 .sp-row {
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: var(--space-3);
 }
 
 .sp-label {
-  font-size: 12px;
-  font-weight: 600;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -865,14 +865,14 @@ function onKeyDown(e: KeyboardEvent) {
 
 .sp-select,
 .sp-input {
-  padding: 8px 10px;
-  font-size: 13px;
+  padding: var(--space-4) var(--space-3);
+  font-size: var(--font-size-md);
   background: var(--color-bg);
   color: var(--color-text);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   outline: none;
-  transition: border-color 0.15s;
+  transition: border-color var(--transition-base);
 }
 
 .sp-select:focus,
@@ -885,8 +885,8 @@ function onKeyDown(e: KeyboardEvent) {
   appearance: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 4.5l3 3 3-3' stroke='%23888' stroke-width='1.5' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
   background-repeat: no-repeat;
-  background-position: right 10px center;
-  padding-right: 30px;
+  background-position: right var(--space-3) center;
+  padding-right: var(--space-8);
 }
 
 .sp-input::placeholder {
@@ -894,14 +894,14 @@ function onKeyDown(e: KeyboardEvent) {
 }
 
 .sp-row--checkbox {
-  gap: 4px;
+  gap: var(--space-2);
 }
 
 .sp-checkbox-label {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 13px;
+  gap: var(--space-4);
+  font-size: var(--font-size-md);
   cursor: pointer;
 }
 
@@ -913,13 +913,13 @@ function onKeyDown(e: KeyboardEvent) {
 }
 
 .sp-hint {
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   color: var(--color-text-muted);
-  padding-left: 24px;
+  padding-left: var(--space-8);
 }
 
 .sp-hint--ok {
-  color: var(--color-success, #22c55e);
+  color: var(--color-success);
 }
 
 .sp-link {
@@ -934,7 +934,7 @@ function onKeyDown(e: KeyboardEvent) {
 .sp-range-row {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--space-3);
 }
 
 .sp-range {
@@ -945,7 +945,7 @@ function onKeyDown(e: KeyboardEvent) {
 }
 
 .sp-range-value {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--color-text-muted);
   min-width: 36px;
   text-align: right;
@@ -954,7 +954,7 @@ function onKeyDown(e: KeyboardEvent) {
 /* ─── API key row ──────────────────────────────────────── */
 .sp-key-row {
   display: flex;
-  gap: 6px;
+  gap: var(--space-3);
 }
 
 .sp-input--key {
@@ -970,10 +970,10 @@ function onKeyDown(e: KeyboardEvent) {
   width: 36px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: color 0.12s, border-color 0.12s;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
 }
 
 .sp-key-toggle:hover {
@@ -984,12 +984,12 @@ function onKeyDown(e: KeyboardEvent) {
 /* ─── Info box ─────────────────────────────────────────── */
 .sp-info-box {
   display: flex;
-  gap: 10px;
-  padding: 12px 14px;
-  border-radius: 8px;
+  gap: var(--space-3);
+  padding: var(--space-5) var(--space-5);
+  border-radius: var(--radius-md);
   background: var(--color-bg);
   border: 1px solid var(--color-border);
-  font-size: 12px;
+  font-size: var(--font-size-base);
   line-height: 1.5;
   color: var(--color-text-muted);
 }
@@ -1008,84 +1008,84 @@ function onKeyDown(e: KeyboardEvent) {
   display: flex;
   gap: 0;
   border: 1px solid var(--color-border);
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   overflow: hidden;
 }
 
 .sp-auth-btn {
   flex: 1;
-  padding: 5px 12px;
-  font-size: 12px;
+  padding: var(--space-1) var(--space-5);
+  font-size: var(--font-size-base);
   background: transparent;
   border: none;
   color: var(--color-text-muted);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--transition-base);
 }
 
 .sp-auth-btn:first-child { border-right: 1px solid var(--color-border); }
 
 .sp-auth-btn--active {
   background: var(--color-accent);
-  color: #fff;
-  font-weight: 600;
+  color: var(--color-accent-text);
+  font-weight: var(--font-weight-semibold);
 }
 
 .sp-connect-flow {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-4);
 }
 
 .sp-connect-start {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-2);
 }
 
 .sp-connect-btn {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  border-radius: 8px;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-6);
+  border-radius: var(--radius-md);
   border: 1px solid var(--color-accent);
-  background: rgba(203, 166, 247, 0.1);
+  background: var(--color-accent-soft);
   color: var(--color-accent);
-  font-size: 13px;
-  font-weight: 600;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--transition-base);
 }
 
 .sp-connect-btn:hover {
-  background: rgba(203, 166, 247, 0.2);
+  opacity: 0.8;
 }
 
 .sp-connect-waiting {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: var(--space-4);
 }
 
 .sp-connect-instruction {
-  font-size: 12px;
+  font-size: var(--font-size-base);
   color: var(--color-text-muted);
   line-height: 1.6;
   margin: 0;
 }
 
 .sp-connect-save-btn {
-  padding: 4px 12px;
-  border-radius: 4px;
+  padding: var(--space-2) var(--space-5);
+  border-radius: var(--radius-sm);
   border: 1px solid transparent;
   background: var(--color-accent);
-  color: #1e1e2e;
-  font-size: 12px;
-  font-weight: 600;
+  color: var(--color-accent-text);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
   cursor: pointer;
   white-space: nowrap;
-  transition: filter 0.15s;
+  transition: filter var(--transition-base);
 }
 
 .sp-connect-save-btn:hover { filter: brightness(1.1); }
@@ -1093,22 +1093,22 @@ function onKeyDown(e: KeyboardEvent) {
 
 .sp-connect-error {
   font-size: 12px;
-  color: var(--color-error, #f38ba8);
+  color: var(--color-danger);
 }
 
 .sp-connect-error-block {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-2);
 }
 
 .sp-connect-success {
-  font-size: 13px;
-  color: var(--color-success, #a6e3a1);
-  font-weight: 600;
-  padding: 8px;
-  background: rgba(166, 227, 161, 0.1);
-  border-radius: 6px;
+  font-size: var(--font-size-md);
+  color: var(--color-success);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-4);
+  background: var(--color-success-soft);
+  border-radius: var(--radius-sm);
   text-align: center;
 }
 
@@ -1116,7 +1116,7 @@ function onKeyDown(e: KeyboardEvent) {
   background: none;
   border: none;
   color: var(--color-text-muted);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
   text-decoration: underline;
   padding: 0;
@@ -1128,33 +1128,33 @@ function onKeyDown(e: KeyboardEvent) {
 .sp-connected-badge {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  border-radius: 6px;
-  background: rgba(166, 227, 161, 0.1);
-  border: 1px solid rgba(166, 227, 161, 0.3);
-  font-size: 12px;
-  color: var(--color-success, #a6e3a1);
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  border-radius: var(--radius-sm);
+  background: var(--color-success-soft);
+  border: 1px solid var(--color-success);
+  font-size: var(--font-size-base);
+  color: var(--color-success);
 }
 
 .sp-connected-dot {
   width: 8px;
   height: 8px;
-  border-radius: 50%;
-  background: var(--color-success, #a6e3a1);
+  border-radius: var(--radius-pill);
+  background: var(--color-success);
   flex-shrink: 0;
 }
 
 .sp-disconnect-btn {
   margin-left: auto;
-  padding: 2px 8px;
-  border-radius: 4px;
+  padding: var(--space-1) var(--space-4);
+  border-radius: var(--radius-sm);
   border: 1px solid rgba(243, 139, 168, 0.4);
   background: transparent;
   color: var(--color-error, #f38ba8);
-  font-size: 11px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
-  transition: all 0.15s;
+  transition: all var(--transition-base);
 }
 
 .sp-disconnect-btn:hover {

--- a/apps/desktop/src/components/StashManager.vue
+++ b/apps/desktop/src/components/StashManager.vue
@@ -186,11 +186,11 @@ watch(() => props.cwd, loadStashes);
 .stash-manager {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-  padding: 12px;
-  background: var(--bg-secondary, #1e1e2e);
-  border-radius: 8px;
-  border: 1px solid var(--border-color, #313244);
+  gap: var(--space-2);
+  padding: var(--space-3);
+  background: var(--color-bg-secondary);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
   max-height: 400px;
   overflow-y: auto;
 }
@@ -203,60 +203,60 @@ watch(() => props.cwd, loadStashes);
 
 .stash-header h3 {
   margin: 0;
-  font-size: 14px;
-  font-weight: 600;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
 }
 
 .stash-actions {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .stash-error {
-  color: var(--color-error, #f38ba8);
-  font-size: 12px;
-  padding: 4px 8px;
-  background: var(--bg-error, rgba(243, 139, 168, 0.1));
-  border-radius: 4px;
+  color: var(--color-danger);
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-danger-soft);
+  border-radius: var(--radius-sm);
 }
 
 .stash-loading,
 .stash-empty {
-  font-size: 13px;
-  color: var(--text-muted, #6c7086);
+  font-size: var(--font-size-md);
+  color: var(--color-text-muted);
   text-align: center;
-  padding: 16px 8px;
+  padding: var(--space-4) var(--space-2);
 }
 
 .stash-list {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: var(--space-1);
 }
 
 .stash-item {
-  border-radius: 6px;
-  border: 1px solid var(--border-color, #313244);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
   overflow: hidden;
 }
 
 .stash-item-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2);
   cursor: pointer;
-  transition: background 0.15s;
+  transition: background var(--transition-base);
 }
 
 .stash-item-header:hover {
-  background: var(--bg-hover, rgba(255, 255, 255, 0.05));
+  background: var(--color-bg-hover);
 }
 
 .stash-index {
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--text-muted, #6c7086);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-muted);
   min-width: 20px;
   text-align: center;
 }
@@ -270,41 +270,41 @@ watch(() => props.cwd, loadStashes);
 }
 
 .stash-message {
-  font-size: 13px;
-  font-weight: 500;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-medium);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
 .stash-meta {
-  font-size: 11px;
-  color: var(--text-muted, #6c7086);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
   display: flex;
-  gap: 8px;
+  gap: var(--space-2);
 }
 
 .stash-branch {
-  color: var(--color-accent, #cba6f7);
+  color: var(--color-accent);
 }
 
 .stash-item-actions {
   display: flex;
-  gap: 4px;
+  gap: var(--space-1);
   flex-shrink: 0;
 }
 
 .stash-diff {
-  border-top: 1px solid var(--border-color, #313244);
-  padding: 8px;
-  background: var(--bg-tertiary, #11111b);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-2);
+  background: var(--color-bg);
   max-height: 200px;
   overflow: auto;
 }
 
 .stash-diff pre {
   margin: 0;
-  font-size: 11px;
+  font-size: var(--font-size-xs);
   font-family: "JetBrains Mono", "Fira Code", monospace;
   white-space: pre-wrap;
   word-break: break-all;
@@ -315,22 +315,22 @@ watch(() => props.cwd, loadStashes);
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid var(--border-color, #313244);
-  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
   background: transparent;
   color: inherit;
   cursor: pointer;
-  font-size: 12px;
-  padding: 4px 8px;
-  transition: all 0.15s;
+  font-size: var(--font-size-xs);
+  padding: var(--space-1) var(--space-2);
+  transition: all var(--transition-base);
 }
 
-.btn:hover { background: var(--bg-hover, rgba(255, 255, 255, 0.08)); }
+.btn:hover { background: var(--color-bg-hover); }
 .btn:disabled { opacity: 0.4; cursor: not-allowed; }
-.btn-sm { font-size: 12px; padding: 3px 8px; }
-.btn-xs { font-size: 11px; padding: 2px 6px; }
-.btn-primary { background: var(--color-accent, #cba6f7); color: #1e1e2e; border-color: transparent; }
+.btn-sm { font-size: var(--font-size-xs); padding: var(--space-1) var(--space-2); }
+.btn-xs { font-size: var(--font-size-xs); padding: 2px 6px; }
+.btn-primary { background: var(--color-accent); color: var(--color-accent-text); border-color: transparent; }
 .btn-primary:hover { filter: brightness(1.1); }
-.btn-danger:hover { background: var(--color-error, #f38ba8); color: #1e1e2e; }
+.btn-danger:hover { background: var(--color-danger); color: var(--color-accent-text); }
 .btn-ghost { border-color: transparent; }
 </style>

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -37,7 +37,7 @@ import {
   gitAddToGitignore,
 } from "../utils/backend";
 
-export type ViewMode = "changes" | "history" | "graph" | "prs";
+export type ViewMode = "dashboard" | "changes" | "history" | "graph" | "prs";
 
 export interface RepoFileEntry {
   path: string;
@@ -59,7 +59,7 @@ export function useGitRepo() {
   const loading = ref(false);
   const error = ref<string | null>(null);
   const successMessage = ref<string | null>(null);
-  const viewMode = ref<ViewMode>("changes");
+  const viewMode = ref<ViewMode>("dashboard");
 
   // Commit editor state
   const COMMIT_SIGNATURE = "\u{1FA84} Commit via GitWand";

--- a/docs/design-system-preview.html
+++ b/docs/design-system-preview.html
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8" />
+<title>GitWand — Design System Preview</title>
+<style>
+/* Tokens (copie de main.css — pour preview autonome) */
+:root {
+  --font-sans: -apple-system, BlinkMacSystemFont, "Inter", "Segoe UI", Roboto, sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", monospace;
+  --font-size-xs: 10px; --font-size-sm: 11px; --font-size-base: 12px;
+  --font-size-md: 13px; --font-size-lg: 14px; --font-size-xl: 16px;
+  --font-size-2xl: 20px; --font-size-3xl: 26px;
+  --font-weight-medium: 500; --font-weight-semibold: 600; --font-weight-bold: 700;
+  --space-1: 2px; --space-2: 4px; --space-3: 6px; --space-4: 8px;
+  --space-5: 12px; --space-6: 16px; --space-7: 20px; --space-8: 24px;
+  --space-9: 32px; --space-10: 40px;
+  --radius-sm: 6px; --radius-md: 8px; --radius-lg: 10px;
+  --radius-xl: 14px; --radius-2xl: 20px; --radius-pill: 9999px;
+  --ease-out: cubic-bezier(.2,.8,.2,1);
+  --transition-fast: 100ms var(--ease-out);
+  --transition-base: 160ms var(--ease-out);
+  --header-height: 56px; --tabbar-height: 40px;
+}
+.theme-dark {
+  --color-bg: #0d0d13; --color-bg-secondary: #15151f; --color-bg-tertiary: #1f1f2d;
+  --color-surface-inverse: #f4f4f8; --color-surface-inverse-text: #15151f;
+  --color-border: #262638; --color-border-strong: #353550;
+  --color-text: #ebebf5; --color-text-muted: #8a8aa8; --color-text-subtle: #5d5d78;
+  --color-accent: #8b5cf6; --color-accent-hover: #a78bfa;
+  --color-accent-soft: rgba(139,92,246,.16); --color-accent-text: #fff;
+  --color-success: #22c55e; --color-success-soft: rgba(34,197,94,.14);
+  --color-warning: #f59e0b; --color-warning-soft: rgba(245,158,11,.16);
+  --color-danger: #ef4444; --color-danger-soft: rgba(239,68,68,.16);
+  --color-info: #60a5fa; --color-info-soft: rgba(96,165,250,.16);
+  --shadow-xs: 0 1px 2px rgba(0,0,0,.35);
+  --shadow-md: 0 8px 24px rgba(0,0,0,.45);
+}
+.theme-light {
+  --color-bg: #f4f4f8; --color-bg-secondary: #ffffff; --color-bg-tertiary: #eceef4;
+  --color-surface-inverse: #15151f; --color-surface-inverse-text: #f4f4f8;
+  --color-border: #e4e4ed; --color-border-strong: #cccfda;
+  --color-text: #15151f; --color-text-muted: #5b5b78; --color-text-subtle: #9a9ab0;
+  --color-accent: #7c3aed; --color-accent-hover: #6d28d9;
+  --color-accent-soft: rgba(124,58,237,.12); --color-accent-text: #fff;
+  --color-success: #16a34a; --color-success-soft: rgba(22,163,74,.12);
+  --color-warning: #d97706; --color-warning-soft: rgba(217,119,6,.14);
+  --color-danger: #dc2626; --color-danger-soft: rgba(220,38,38,.1);
+  --color-info: #2563eb; --color-info-soft: rgba(37,99,235,.12);
+  --shadow-xs: 0 1px 2px rgba(20,20,35,.04);
+  --shadow-md: 0 10px 30px rgba(20,20,35,.1);
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: var(--font-sans); background: #e8e8f0; padding: 32px; display: flex; flex-direction: column; gap: 48px; }
+.frame { background: var(--color-bg); border-radius: 24px; overflow: hidden; box-shadow: 0 20px 60px rgba(0,0,0,.15); border: 1px solid rgba(0,0,0,.05); }
+.label { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #6b6b88; margin-bottom: 12px; }
+
+/* Header */
+.app-header {
+  display: flex; align-items: center; justify-content: space-between;
+  height: var(--header-height); padding: 0 var(--space-6);
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border); gap: var(--space-6);
+}
+.left, .right, .center { display: flex; align-items: center; gap: var(--space-4); }
+.center { flex: 1; justify-content: center; }
+.title { font-size: var(--font-size-xl); font-weight: 600; color: var(--color-text); letter-spacing: -0.01em; }
+.logo-dot { width: 20px; height: 20px; border-radius: 6px; background: linear-gradient(135deg, #8b5cf6 0%, #5b21b6 100%); }
+
+.folder-trigger {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-5); border-radius: var(--radius-pill);
+  color: var(--color-text-muted); font-size: var(--font-size-base);
+  font-weight: 500; cursor: pointer; transition: background var(--transition-base);
+}
+.folder-trigger:hover { color: var(--color-text); background: var(--color-bg-tertiary); }
+
+.branch-trigger {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-5); border-radius: var(--radius-pill);
+  background: var(--color-bg-tertiary); color: var(--color-text);
+  font-size: var(--font-size-md); font-weight: 500; cursor: pointer;
+}
+.branch-name { font-family: var(--font-mono); }
+
+.repo-stat {
+  display: inline-flex; align-items: center; gap: var(--space-2);
+  padding: var(--space-2) var(--space-4); border-radius: var(--radius-pill);
+  background: var(--color-bg-tertiary); font-size: var(--font-size-sm);
+  font-weight: 500; color: var(--color-text-muted); font-variant-numeric: tabular-nums;
+}
+.stat-dot { width: 6px; height: 6px; border-radius: 50%; }
+.dot-success { background: var(--color-success); }
+.dot-warning { background: var(--color-warning); }
+.dot-info    { background: var(--color-info); }
+.dot-danger  { background: var(--color-danger); }
+
+.btn {
+  display: inline-flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-5); border-radius: var(--radius-pill);
+  font-size: var(--font-size-md); font-weight: 500; border: none; cursor: pointer;
+  font-family: inherit; transition: background var(--transition-base);
+}
+.btn-sync { background: var(--color-bg-tertiary); color: var(--color-text); }
+.btn-sync:hover { background: var(--color-border); }
+.btn-push-active { background: var(--color-accent); color: var(--color-accent-text); }
+.sync-badge {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-width: 20px; padding: 2px 6px; border-radius: var(--radius-pill);
+  font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1;
+  background: rgba(255,255,255,.22); color: #fff;
+}
+
+.btn-icon {
+  width: 32px; height: 32px; border-radius: var(--radius-pill);
+  background: transparent; color: var(--color-text-muted);
+  display: inline-flex; align-items: center; justify-content: center; cursor: pointer; border: none;
+  transition: background var(--transition-base), color var(--transition-base);
+}
+.btn-icon:hover { background: var(--color-bg-tertiary); color: var(--color-text); }
+
+.sep { width: 1px; height: 20px; background: var(--color-border); margin-inline: 4px; }
+
+/* Tab bar */
+.tab-bar {
+  display: flex; align-items: center; gap: var(--space-3);
+  background: var(--color-bg-secondary);
+  border-bottom: 1px solid var(--color-border);
+  height: var(--tabbar-height); padding: 0 var(--space-5);
+}
+.tab-list { display: flex; gap: var(--space-2); flex: 1; }
+.tab {
+  display: flex; align-items: center; gap: var(--space-3);
+  padding: var(--space-3) var(--space-5); border-radius: var(--radius-pill);
+  font-size: var(--font-size-base); font-weight: 500; color: var(--color-text-muted);
+  cursor: pointer; transition: all var(--transition-base);
+}
+.tab:hover { color: var(--color-text); background: var(--color-bg-tertiary); }
+.tab--active { color: var(--color-accent); background: var(--color-accent-soft); }
+.tab-close { width: 18px; height: 18px; border-radius: 50%; display: flex; align-items: center; justify-content: center; color: var(--color-text-muted); opacity: .6; font-size: 14px; cursor: pointer; }
+.tab-close:hover { background: var(--color-danger-soft); color: var(--color-danger); opacity: 1; }
+.tab-new {
+  width: 28px; height: 28px; border-radius: var(--radius-pill); margin-left: auto;
+  color: var(--color-text-muted); background: transparent; border: none;
+  display: inline-flex; align-items: center; justify-content: center; cursor: pointer;
+  font-size: 16px; transition: background var(--transition-base);
+}
+.tab-new:hover { background: var(--color-bg-tertiary); color: var(--color-text); }
+
+/* Demo surface */
+.demo-surface { padding: 32px; display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+.card {
+  background: var(--color-bg-secondary); border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl); padding: 20px; box-shadow: var(--shadow-xs);
+  color: var(--color-text);
+}
+.card h4 { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-text-muted); margin-bottom: 8px; }
+.card .big { font-size: var(--font-size-3xl); font-weight: 700; letter-spacing: -0.02em; }
+.card.card-hero {
+  background: var(--color-surface-inverse); color: var(--color-surface-inverse-text);
+  border-color: transparent; border-radius: var(--radius-2xl);
+  box-shadow: var(--shadow-md); grid-row: span 2;
+}
+.card.card-hero h4 { color: #8a8aa8; }
+.badge {
+  display: inline-block; padding: 3px 10px; border-radius: var(--radius-pill);
+  font-size: 10px; font-weight: 600;
+  background: var(--color-accent-soft); color: var(--color-accent);
+}
+.badge-solid { background: var(--color-accent); color: var(--color-accent-text); }
+</style>
+</head>
+<body>
+
+<section>
+  <div class="label">Light theme — AppHeader + RepoTabBar</div>
+  <div class="frame theme-light">
+    <header class="app-header">
+      <div class="left">
+        <div class="logo-dot"></div>
+        <div class="title">GitWand</div>
+        <button class="folder-trigger">
+          📁 gitwand-desktop <span style="opacity:.5">▾</span>
+        </button>
+      </div>
+      <div class="center">
+        <button class="branch-trigger">
+          ⑃ <span class="branch-name">feature/design-system</span> <span style="opacity:.5">▾</span>
+        </button>
+        <div style="display:flex; gap:6px;">
+          <span class="repo-stat"><span class="stat-dot dot-success"></span>3 staged</span>
+          <span class="repo-stat"><span class="stat-dot dot-warning"></span>7 modified</span>
+          <span class="repo-stat"><span class="stat-dot dot-info"></span>2 untracked</span>
+        </div>
+      </div>
+      <div class="right">
+        <button class="btn btn-sync">↓ Sync</button>
+        <button class="btn btn-push-active">↑ Push <span class="sync-badge">4</span></button>
+        <button class="btn btn-sync">⑃ Merge</button>
+        <div class="sep"></div>
+        <button class="btn-icon">☾</button>
+        <button class="btn-icon">≡</button>
+      </div>
+    </header>
+    <div class="tab-bar">
+      <div class="tab-list">
+        <div class="tab tab--active">📁 gitwand-desktop <span class="tab-close">×</span></div>
+        <div class="tab">📁 gitwand-cli <span class="tab-close">×</span></div>
+        <div class="tab">📁 docs-site <span class="tab-close">×</span></div>
+      </div>
+      <button class="tab-new">+</button>
+    </div>
+    <div class="demo-surface">
+      <div class="card card-hero">
+        <h4>Commit activity</h4>
+        <div class="big">142</div>
+        <div style="opacity:.6; font-size:12px; margin-top:4px;">commits this week</div>
+        <div style="margin-top:20px; display:flex; gap:6px; flex-wrap:wrap;">
+          <span class="badge badge-solid">main</span>
+          <span class="badge" style="background:rgba(255,255,255,.1); color:#f4f4f8;">feature/*</span>
+        </div>
+      </div>
+      <div class="card">
+        <h4>Open PRs</h4>
+        <div class="big">7</div>
+        <span class="badge">3 approved</span>
+      </div>
+      <div class="card">
+        <h4>Conflicts resolved</h4>
+        <div class="big">23</div>
+        <span class="badge">+12% this week</span>
+      </div>
+      <div class="card">
+        <h4>Branches</h4>
+        <div class="big">14</div>
+        <span class="badge">2 stale</span>
+      </div>
+      <div class="card">
+        <h4>Merge queue</h4>
+        <div class="big">3</div>
+        <span class="badge">ready</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="label">Dark theme — AppHeader + RepoTabBar</div>
+  <div class="frame theme-dark">
+    <header class="app-header">
+      <div class="left">
+        <div class="logo-dot"></div>
+        <div class="title" style="color: var(--color-text);">GitWand</div>
+        <button class="folder-trigger">
+          📁 gitwand-desktop <span style="opacity:.5">▾</span>
+        </button>
+      </div>
+      <div class="center">
+        <button class="branch-trigger">
+          ⑃ <span class="branch-name">feature/design-system</span> <span style="opacity:.5">▾</span>
+        </button>
+        <div style="display:flex; gap:6px;">
+          <span class="repo-stat"><span class="stat-dot dot-success"></span>3 staged</span>
+          <span class="repo-stat"><span class="stat-dot dot-warning"></span>7 modified</span>
+          <span class="repo-stat"><span class="stat-dot dot-danger"></span>1 conflict</span>
+        </div>
+      </div>
+      <div class="right">
+        <button class="btn btn-sync">↓ Sync</button>
+        <button class="btn btn-push-active">↑ Push <span class="sync-badge">4</span></button>
+        <button class="btn btn-sync">⑃ Merge</button>
+        <div class="sep"></div>
+        <button class="btn-icon">☀</button>
+        <button class="btn-icon">≡</button>
+      </div>
+    </header>
+    <div class="tab-bar">
+      <div class="tab-list">
+        <div class="tab tab--active">📁 gitwand-desktop <span class="tab-close">×</span></div>
+        <div class="tab">📁 gitwand-cli <span class="tab-close">×</span></div>
+        <div class="tab">📁 docs-site <span class="tab-close">×</span></div>
+      </div>
+      <button class="tab-new">+</button>
+    </div>
+    <div class="demo-surface">
+      <div class="card card-hero">
+        <h4>Commit activity</h4>
+        <div class="big">142</div>
+        <div style="opacity:.6; font-size:12px; margin-top:4px;">commits this week</div>
+      </div>
+      <div class="card"><h4>Open PRs</h4><div class="big">7</div><span class="badge">3 approved</span></div>
+      <div class="card"><h4>Conflicts resolved</h4><div class="big">23</div><span class="badge">+12% this week</span></div>
+      <div class="card"><h4>Branches</h4><div class="big">14</div><span class="badge">2 stale</span></div>
+      <div class="card"><h4>Merge queue</h4><div class="big">3</div><span class="badge">ready</span></div>
+    </div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -1,0 +1,209 @@
+# GitWand Design System
+
+Version 1.0 — 2026-04-13
+Inspiration : dashboard MindPath (hiérarchie typographique forte, cards contrastées, formes pilules) appliquée à l'identité violette existante de GitWand.
+
+## 1. Principes
+
+1. **Identité conservée.** Accent violet `#8b5cf6` reste la signature produit. On emprunte à MindPath la *grammaire visuelle*, pas la palette.
+2. **Parité light/dark.** Les deux thèmes sont de première classe. Chaque token a une variante light et dark cohérente.
+3. **Contraste de hiérarchie.** Les surfaces clés (hero, panneau actif) peuvent inverser la relation claire/sombre pour créer du relief — comme la card "Stress Level" de MindPath.
+4. **Pilules plutôt que rectangles.** Boutons, badges, inputs de filtre → radius élevés (≥ lg). Cards → radius xl à 2xl.
+5. **Échelle 4/8 px.** Toutes les mesures (espacement, radius) sont des multiples de 4, pivot à 8.
+6. **Tokens en CSS custom properties.** Aucune couleur/taille/ombre hardcodée dans les composants. Toute nouvelle valeur passe par un token.
+
+## 2. Couleurs
+
+### 2.1 Tokens sémantiques
+
+| Token | Rôle |
+|---|---|
+| `--color-bg` | Fond d'application principal |
+| `--color-bg-secondary` | Fond panneaux / cards standard |
+| `--color-bg-tertiary` | Fond éléments interactifs au repos, hover subtil |
+| `--color-surface-inverse` | Card "hero" contrastée (dark dans thème light, light dans thème dark) |
+| `--color-surface-inverse-text` | Texte sur surface inverse |
+| `--color-border` | Séparateurs, bordures cards |
+| `--color-border-strong` | Séparateurs plus marqués (modals) |
+| `--color-text` | Texte principal |
+| `--color-text-muted` | Texte secondaire / labels |
+| `--color-text-subtle` | Texte tertiaire (timestamps, hints) |
+| `--color-accent` | Action primaire, états sélectionnés |
+| `--color-accent-hover` | Hover accent |
+| `--color-accent-soft` | Tint accent pour badges, pills actifs |
+| `--color-accent-text` | Texte sur fond accent (toujours blanc) |
+| `--color-success` / `--color-success-soft` | Vert — stagé, résolu |
+| `--color-warning` / `--color-warning-soft` | Ambre — modifié |
+| `--color-danger` / `--color-danger-soft` | Rouge — conflit, delete |
+| `--color-info` / `--color-info-soft` | Bleu — info, untracked |
+| `--color-ours` / `--color-ours-bg` | Côté "ours" (merge) |
+| `--color-theirs` / `--color-theirs-bg` | Côté "theirs" (merge) |
+| `--color-focus-ring` | Anneau focus clavier |
+
+### 2.2 Palette light
+
+Off-white d'ambiance, cards blanches pures, bordure ultra-discrète. Accent conservé en `#7c3aed` (mêmes valeurs qu'actuelles).
+
+- `--color-bg: #f4f4f8`
+- `--color-bg-secondary: #ffffff`
+- `--color-bg-tertiary: #eceef4`
+- `--color-surface-inverse: #15151f` (card hero sombre, comme MindPath Stress Level)
+- `--color-surface-inverse-text: #f4f4f8`
+- `--color-border: #e4e4ed`
+- `--color-border-strong: #cccfda`
+- `--color-text: #15151f`
+- `--color-text-muted: #5b5b78`
+- `--color-text-subtle: #9a9ab0`
+
+### 2.3 Palette dark
+
+Révisée : fonds plus neutres (moins bleutés), accent légèrement adouci.
+
+- `--color-bg: #0d0d13`
+- `--color-bg-secondary: #15151f`
+- `--color-bg-tertiary: #1f1f2d`
+- `--color-surface-inverse: #f4f4f8` (inverse en dark : card claire sur fond sombre)
+- `--color-surface-inverse-text: #15151f`
+- `--color-border: #262638`
+- `--color-border-strong: #353550`
+- `--color-text: #ebebf5`
+- `--color-text-muted: #8a8aa8`
+- `--color-text-subtle: #5d5d78`
+
+## 3. Typographie
+
+Échelle T-shirt, basée sur 1.125 (ratio modeste, dense pour app desktop).
+
+| Token | Taille | Line-height | Usage |
+|---|---|---|---|
+| `--font-size-xs` | 10px | 1.4 | micro labels, tags |
+| `--font-size-sm` | 11px | 1.45 | meta, timestamps |
+| `--font-size-base` | 12px | 1.5 | corps UI par défaut |
+| `--font-size-md` | 13px | 1.5 | boutons, nav, branch name |
+| `--font-size-lg` | 14px | 1.5 | titres de section |
+| `--font-size-xl` | 16px | 1.4 | titres de panneaux |
+| `--font-size-2xl` | 20px | 1.3 | headings modals |
+| `--font-size-3xl` | 26px | 1.2 | hero (EmptyState, stats large) |
+
+Poids : `--font-weight-regular: 400`, `--font-weight-medium: 500`, `--font-weight-semibold: 600`, `--font-weight-bold: 700`.
+Letter-spacing titres : `-0.01em`. Labels majuscules : `+0.05em`.
+
+## 4. Espacement
+
+Base 4 px. Tous padding/margin/gap doivent s'ancrer ici.
+
+| Token | Valeur |
+|---|---|
+| `--space-1` | 2px |
+| `--space-2` | 4px |
+| `--space-3` | 6px |
+| `--space-4` | 8px |
+| `--space-5` | 12px |
+| `--space-6` | 16px |
+| `--space-7` | 20px |
+| `--space-8` | 24px |
+| `--space-9` | 32px |
+| `--space-10` | 40px |
+| `--space-11` | 48px |
+| `--space-12` | 64px |
+
+Règle : usage privilégié de 4, 8, 12, 16, 24. Les 2/6/20/32 pour ajustements fins.
+
+## 5. Radius
+
+Pilules partout où c'est pertinent.
+
+| Token | Valeur | Usage |
+|---|---|---|
+| `--radius-xs` | 3px | word-diff highlights, très petits tags |
+| `--radius-sm` | 6px | inputs, petits boutons icon-only |
+| `--radius-md` | 8px | boutons standard, file items |
+| `--radius-lg` | 10px | popovers, dropdowns |
+| `--radius-xl` | 14px | cards secondaires |
+| `--radius-2xl` | 20px | cards hero, panneaux majeurs |
+| `--radius-pill` | 9999px | badges, segments, pills |
+
+## 6. Élévations (shadows)
+
+Ombres adoucies, rgb pré-composé par thème pour lisibilité.
+
+| Token | Usage |
+|---|---|
+| `--shadow-xs` | subtil — cards internes |
+| `--shadow-sm` | hover légers |
+| `--shadow-md` | popovers, dropdowns |
+| `--shadow-lg` | modals |
+| `--shadow-xl` | dialogs de confirmation |
+
+Light : `0 1px 2px rgba(20,20,35,.04)` → `0 24px 48px rgba(20,20,35,.18)`
+Dark : `0 1px 2px rgba(0,0,0,.35)` → `0 24px 48px rgba(0,0,0,.6)`
+
+## 7. Transitions
+
+| Token | Valeur | Usage |
+|---|---|---|
+| `--transition-fast` | 100ms cubic-bezier(.2,.8,.2,1) | hovers micro |
+| `--transition-base` | 160ms cubic-bezier(.2,.8,.2,1) | défaut UI |
+| `--transition-slow` | 240ms cubic-bezier(.2,.8,.2,1) | popovers, modals |
+
+## 8. Composants primitifs (classes utilitaires)
+
+Déclarés dans `main.css`, ré-utilisables depuis tout composant.
+
+### 8.1 Buttons
+
+- `.btn` — base (inline-flex, gap, radius md, transition base, font medium)
+- `.btn--primary` — fond accent, texte blanc
+- `.btn--secondary` — fond bg-tertiary, texte standard
+- `.btn--ghost` — transparent, hover bg-tertiary
+- `.btn--danger` — fond danger, texte blanc
+- `.btn--pill` — radius pill, padding horizontal généreux (inspiration MindPath)
+- `.btn--icon` — carré 28×28, radius md
+- `.btn--sm` — padding 4/10, font-size md
+- `.btn--lg` — padding 10/20, font-size lg
+
+### 8.2 Inputs
+
+- `.input` — base (padding 4 8, radius sm, border 1, focus-ring accent)
+- `.input--pill` — radius pill, padding horizontal 12
+
+### 8.3 Surfaces
+
+- `.card` — bg secondary, border 1, radius xl, shadow xs
+- `.card--hero` — inverse (dark on light, light on dark), radius 2xl
+- `.popover` — bg secondary, border, radius lg, shadow md, animation slide
+
+### 8.4 Badges / Pills
+
+- `.badge` — radius pill, padding 2/8, font xs/semibold, tabular-nums
+- `.badge--success`, `.badge--warning`, `.badge--danger`, `.badge--info`, `.badge--accent` — versions teintées (fond soft + texte fort)
+- `.stat-dot` — 6×6 rond, coloré par couleur sémantique
+
+### 8.5 Segments / tabs
+
+- `.segmented` — group container, bg tertiary, radius pill, padding 2
+- `.segmented__item` — radius pill, transition fast ; actif = bg secondary + shadow xs
+
+## 9. Plan d'application
+
+### Phase 1 — Tokens (cette livraison)
+Mise à jour `main.css` avec l'ensemble des tokens ci-dessus et primitives `.btn/.input/.card/.badge`. Compatibilité descendante : les anciens noms (`--color-bg`, etc.) restent valides.
+
+### Phase 2 — Pilote (cette livraison)
+Refonte `AppHeader.vue` et `RepoTabBar.vue` sur les nouveaux tokens et primitives. Objectif : zéro valeur magique, hauteur header `56px`, tabs en pilules.
+
+### Phase 3 — Surfaces principales
+`RepoSidebar.vue`, `EmptyState.vue`, `FolderPicker.vue`, `SettingsPanel.vue`. Introduction de la `.card--hero` sur l'EmptyState.
+
+### Phase 4 — Surfaces PR / diff
+`PrInlineDiff.vue`, `PrIntelligencePanel.vue`, `MergePreviewPanel.vue` : suppression des `#a6e3a1 / #89b4fa / #f38ba8` → tokens de severity, remappage des couleurs syntaxiques sur les tokens.
+
+### Phase 5 — Composants spécialisés
+`MergeEditor.vue`, `DiffViewer.vue`, `CommitGraph.vue` — modulaires, modification minimale (seulement les tokens).
+
+## 10. Ne pas faire
+
+- Pas de mesures en `em` hors typo ; `px` uniquement pour espace/radius.
+- Pas de shadow hardcodée dans un composant.
+- Pas de `color: #fff` ; utiliser `--color-accent-text` ou `--color-surface-inverse-text`.
+- Pas de nouvelle variante de bouton sans passer par le système (si besoin → on ajoute un modifier documenté ici).


### PR DESCRIPTION
Introduce a unified design system (tokens, primitives, themes) and migrate all 30 components from hardcoded Catppuccin colors to semantic CSS custom properties. Add a new Dashboard view as the default tab when opening a repo, featuring stat cards, sync status, recent commits, and a README.md viewer with formatted/raw toggle.