### PR TITLE
Feat: claude code cli provider

### DIFF
--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -1997,6 +1997,30 @@ const server = createServer(async (req, res) => {
       }
     }
 
+    // POST /api/git-exec  { cwd, args }
+    // Generic git command execution — mirrors the Rust `git_exec` Tauri command.
+    // Used by useCommitMessage to get the staged diff.
+    if (url.pathname === "/api/git-exec" && req.method === "POST") {
+      try {
+        const { cwd: execCwd, args } = await readBody(req);
+        if (!args || !Array.isArray(args) || args.length === 0) {
+          return jsonResponse(res, { error: "No arguments provided" }, 400);
+        }
+        const r = spawnSync(GIT, args, {
+          cwd: resolve(execCwd),
+          encoding: "utf-8",
+          maxBuffer: 20 * 1024 * 1024,
+        });
+        return jsonResponse(res, {
+          stdout: r.stdout ?? "",
+          stderr: r.stderr ?? "",
+          exitCode: r.status ?? -1,
+        });
+      } catch (err) {
+        return jsonResponse(res, { error: err.message }, 500);
+      }
+    }
+
     // POST /api/read-gitwandrc  { cwd }
     // Searches: .gitwandrc → .gitwandrc.json → package.json#gitwand
     if (url.pathname === "/api/read-gitwandrc" && req.method === "POST") {

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -1836,6 +1836,147 @@ const server = createServer(async (req, res) => {
       }
     }
 
+    // ─── Claude Code CLI (dev mirror) ─────────────────────
+    //
+    // Wraps the user's locally-installed `claude` binary so GitWand can
+    // piggyback on their Claude Max/Pro subscription without implementing
+    // OAuth. Mirrors the Rust commands `detect_claude_cli`, `claude_cli_prompt`
+    // and `claude_cli_login`.
+
+    // GET /api/claude-cli-detect
+    if (url.pathname === "/api/claude-cli-detect" && req.method === "GET") {
+      try {
+        const CLAUDE = resolveBin("claude");
+        // `resolveBin` falls back to the bare name on PATH; if nothing
+        // matches, we consider it not found.
+        const exists = (() => {
+          try {
+            return existsSync(CLAUDE);
+          } catch { return false; }
+        })();
+
+        // Also try explicit PATH lookup via `which`.
+        let resolved = exists ? CLAUDE : "";
+        if (!resolved) {
+          try {
+            const r = spawnSync(process.platform === "win32" ? "where" : "which", ["claude"], { encoding: "utf-8" });
+            if (r.status === 0 && r.stdout.trim()) {
+              resolved = r.stdout.split(/\r?\n/)[0].trim();
+            }
+          } catch { /* ignore */ }
+        }
+
+        if (!resolved) {
+          return jsonResponse(res, {
+            found: false,
+            path: "",
+            version: "",
+            logged_in: false,
+            status: "not_found",
+            detail: "Binaire `claude` introuvable. Installez-le avec `npm install -g @anthropic-ai/claude-code`.",
+          });
+        }
+
+        let version = "";
+        try {
+          const r = spawnSync(resolved, ["--version"], { encoding: "utf-8" });
+          if (r.status === 0) version = r.stdout.trim();
+        } catch { /* ignore */ }
+
+        // Ping to check auth.
+        let loggedIn = false;
+        let status = "error";
+        let detail = "";
+        try {
+          const r = spawnSync(resolved, ["-p", "ping", "--output-format", "text"], { encoding: "utf-8" });
+          if (r.status === 0) {
+            loggedIn = true;
+            status = "ok";
+          } else {
+            const combined = (r.stderr || r.stdout || "").trim();
+            const lower = combined.toLowerCase();
+            const authy = lower.includes("login") || lower.includes("authenticat") || lower.includes("unauthor") || lower.includes("api key");
+            status = authy ? "not_logged_in" : "error";
+            detail = combined;
+          }
+        } catch (err) {
+          detail = `Impossible d'exécuter claude: ${err.message}`;
+        }
+
+        return jsonResponse(res, {
+          found: true,
+          path: resolved,
+          version,
+          logged_in: loggedIn,
+          status,
+          detail,
+        });
+      } catch (err) {
+        return jsonResponse(res, { error: err.message }, 500);
+      }
+    }
+
+    // POST /api/claude-cli-prompt  { prompt, systemPrompt?, cwd?, outputFormat? }
+    if (url.pathname === "/api/claude-cli-prompt" && req.method === "POST") {
+      try {
+        const body = await readBody(req);
+        const CLAUDE = resolveBin("claude");
+        const fullPrompt = body.systemPrompt && body.systemPrompt.trim()
+          ? `# System\n${body.systemPrompt.trim()}\n\n# User\n${(body.prompt || "").trim()}`
+          : (body.prompt || "");
+        const fmt = body.outputFormat || "text";
+        const r = spawnSync(CLAUDE, ["-p", fullPrompt, "--output-format", fmt], {
+          cwd: body.cwd || undefined,
+          encoding: "utf-8",
+          maxBuffer: 20 * 1024 * 1024,
+        });
+        if (r.status !== 0) {
+          const detail = (r.stderr || r.stdout || "").trim() || "Claude CLI a échoué sans message";
+          return jsonResponse(res, { error: detail }, 500);
+        }
+        return res.writeHead(200, { ...CORS, "Content-Type": "text/plain" }).end(r.stdout);
+      } catch (err) {
+        return jsonResponse(res, { error: err.message }, 500);
+      }
+    }
+
+    // POST /api/claude-cli-login  (opens a terminal with `claude login`)
+    if (url.pathname === "/api/claude-cli-login" && req.method === "POST") {
+      try {
+        const CLAUDE = resolveBin("claude");
+        if (process.platform === "darwin") {
+          const script = `tell application "Terminal" to do script "${CLAUDE.replace(/"/g, '\\"')} login"`;
+          spawn("osascript", ["-e", script], { detached: true, stdio: "ignore" }).unref();
+        } else if (process.platform === "win32") {
+          spawn("cmd", ["/c", "start", "cmd", "/k", `"${CLAUDE}" login`], { detached: true, stdio: "ignore" }).unref();
+        } else {
+          const inner = `${CLAUDE} login; echo; read -p 'Press enter to close...'`;
+          const tried = [
+            ["gnome-terminal", ["--", "sh", "-c", inner]],
+            ["konsole", ["-e", "sh", "-c", inner]],
+            ["xfce4-terminal", ["-e", inner]],
+            ["kitty", ["sh", "-c", inner]],
+            ["alacritty", ["-e", "sh", "-c", inner]],
+            ["x-terminal-emulator", ["-e", "sh", "-c", inner]],
+          ];
+          let ok = false;
+          for (const [prog, args] of tried) {
+            try {
+              spawn(prog, args, { detached: true, stdio: "ignore" }).unref();
+              ok = true;
+              break;
+            } catch { /* try next */ }
+          }
+          if (!ok) {
+            return jsonResponse(res, { error: "Aucun terminal compatible trouvé. Ouvrez un terminal et tapez: claude login" }, 500);
+          }
+        }
+        return jsonResponse(res, { ok: true });
+      } catch (err) {
+        return jsonResponse(res, { error: err.message }, 500);
+      }
+    }
+
     // POST /api/read-gitwandrc  { cwd }
     // Searches: .gitwandrc → .gitwandrc.json → package.json#gitwand
     if (url.pathname === "/api/read-gitwandrc" && req.method === "POST") {

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -31,6 +31,19 @@ function resolveBin(name) {
 
 const GH = resolveBin("gh");
 const GIT = resolveBin("git");
+
+/**
+ * Environment passed when spawning the `claude` CLI. We strip API-key env
+ * vars so the CLI falls back to the OAuth session (`claude login`) — same
+ * rationale as the Rust backend's `strip_claude_auth_env`.
+ */
+const claudeSpawnEnv = (() => {
+  const clean = { ...process.env };
+  delete clean.ANTHROPIC_API_KEY;
+  delete clean.CLAUDE_API_KEY;
+  delete clean.ANTHROPIC_AUTH_TOKEN;
+  return clean;
+})();
 console.log(`[dev-server] gh binary:  ${GH}`);
 console.log(`[dev-server] git binary: ${GIT}`);
 
@@ -1838,6 +1851,12 @@ const server = createServer(async (req, res) => {
 
     // ─── Claude Code CLI (dev mirror) ─────────────────────
     //
+    // When spawning the `claude` binary, we strip API-key env vars (see
+    // `claudeSpawnEnv` at module scope) so the CLI uses the user's OAuth
+    // subscription instead of a stale key that may be lying around in
+    // their shell. Matches the Rust backend.
+
+    //
     // Wraps the user's locally-installed `claude` binary so GitWand can
     // piggyback on their Claude Max/Pro subscription without implementing
     // OAuth. Mirrors the Rust commands `detect_claude_cli`, `claude_cli_prompt`
@@ -1888,7 +1907,7 @@ const server = createServer(async (req, res) => {
         let status = "error";
         let detail = "";
         try {
-          const r = spawnSync(resolved, ["-p", "ping", "--output-format", "text"], { encoding: "utf-8" });
+          const r = spawnSync(resolved, ["-p", "ping", "--output-format", "text"], { encoding: "utf-8", env: claudeSpawnEnv });
           if (r.status === 0) {
             loggedIn = true;
             status = "ok";
@@ -1929,6 +1948,7 @@ const server = createServer(async (req, res) => {
           cwd: body.cwd || undefined,
           encoding: "utf-8",
           maxBuffer: 20 * 1024 * 1024,
+          env: claudeSpawnEnv,
         });
         if (r.status !== 0) {
           const detail = (r.stderr || r.stdout || "").trim() || "Claude CLI a échoué sans message";

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2688,6 +2688,260 @@ fn merge_file_preview(
     }
 }
 
+// ─── Claude Code CLI (piggyback on user's local install) ─────
+//
+// Wraps the official `claude` CLI (Claude Code) so GitWand can use the
+// user's existing Claude Max/Pro subscription without implementing OAuth
+// ourselves. Inspired by Solo's approach, but headless (no PTY): we only
+// need one-shot prompts for commit messages, merge resolution and PR review.
+
+#[derive(Serialize)]
+struct ClaudeCliInfo {
+    found: bool,
+    /// Absolute path of the resolved binary (empty when `found == false`).
+    path: String,
+    /// Raw `claude --version` output (e.g. "2.0.14 (Claude Code)").
+    version: String,
+    /// True if `claude -p "ping"` answered without an auth error.
+    logged_in: bool,
+    /// Human-readable status: "ok", "not_found", "not_logged_in", "error".
+    status: String,
+    /// Optional detail line surfaced to the UI on errors.
+    detail: String,
+}
+
+/// Resolve the path to the `claude` binary, checking the usual install
+/// locations on macOS / Linux / Windows in addition to PATH.
+fn resolve_claude_binary() -> Option<String> {
+    // 1) Try PATH first via `which` / `where`.
+    let which_cmd = if cfg!(windows) { "where" } else { "which" };
+    if let Ok(out) = std::process::Command::new(which_cmd).arg("claude").output() {
+        if out.status.success() {
+            let raw = String::from_utf8_lossy(&out.stdout);
+            let first = raw.lines().next().unwrap_or("").trim();
+            if !first.is_empty() && std::path::Path::new(first).exists() {
+                return Some(first.to_string());
+            }
+        }
+    }
+
+    // 2) Fall back to common install locations.
+    let home = dirs::home_dir();
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(h) = home.as_ref() {
+        candidates.push(h.join(".claude/local/claude"));
+        candidates.push(h.join(".local/bin/claude"));
+        candidates.push(h.join(".npm-global/bin/claude"));
+        // Windows npm global
+        candidates.push(h.join("AppData/Roaming/npm/claude.cmd"));
+        candidates.push(h.join("AppData/Roaming/npm/claude"));
+    }
+    candidates.push(PathBuf::from("/opt/homebrew/bin/claude"));
+    candidates.push(PathBuf::from("/usr/local/bin/claude"));
+    candidates.push(PathBuf::from("/usr/bin/claude"));
+
+    for c in candidates {
+        if c.exists() {
+            return Some(c.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+#[tauri::command]
+fn detect_claude_cli() -> Result<ClaudeCliInfo, String> {
+    let binary = match resolve_claude_binary() {
+        Some(b) => b,
+        None => {
+            return Ok(ClaudeCliInfo {
+                found: false,
+                path: String::new(),
+                version: String::new(),
+                logged_in: false,
+                status: "not_found".to_string(),
+                detail: "Binaire `claude` introuvable. Installez-le avec `npm install -g @anthropic-ai/claude-code`."
+                    .to_string(),
+            });
+        }
+    };
+
+    // Query version
+    let version = std::process::Command::new(&binary)
+        .arg("--version")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    // Ping with a tiny prompt to check auth. Timeout is enforced by the
+    // caller via the Tauri command; here we just run synchronously with a
+    // short output cap. The CLI exits non-zero when auth is missing.
+    let ping = std::process::Command::new(&binary)
+        .args(["-p", "ping", "--output-format", "text"])
+        .output();
+
+    match ping {
+        Ok(out) if out.status.success() => Ok(ClaudeCliInfo {
+            found: true,
+            path: binary,
+            version,
+            logged_in: true,
+            status: "ok".to_string(),
+            detail: String::new(),
+        }),
+        Ok(out) => {
+            let stderr = String::from_utf8_lossy(&out.stderr).trim().to_string();
+            let stdout = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            let combined = if stderr.is_empty() { stdout } else { stderr };
+            let lower = combined.to_lowercase();
+            let looks_like_auth = lower.contains("login")
+                || lower.contains("authenticat")
+                || lower.contains("unauthor")
+                || lower.contains("api key");
+            Ok(ClaudeCliInfo {
+                found: true,
+                path: binary,
+                version,
+                logged_in: false,
+                status: if looks_like_auth { "not_logged_in" } else { "error" }.to_string(),
+                detail: combined,
+            })
+        }
+        Err(e) => Ok(ClaudeCliInfo {
+            found: true,
+            path: binary,
+            version,
+            logged_in: false,
+            status: "error".to_string(),
+            detail: format!("Impossible d'exécuter `claude`: {}", e),
+        }),
+    }
+}
+
+/// Run `claude -p <prompt>` and return stdout.
+///
+/// The CLI already handles auth via the user's subscription — we just pipe
+/// text in and get text back.
+#[tauri::command]
+fn claude_cli_prompt(
+    prompt: String,
+    system_prompt: Option<String>,
+    cwd: Option<String>,
+    output_format: Option<String>,
+) -> Result<String, String> {
+    let binary = resolve_claude_binary()
+        .ok_or_else(|| "Binaire `claude` introuvable".to_string())?;
+
+    // Compose the full prompt: if a system prompt is provided, prepend it
+    // as a Markdown-delimited section. `claude -p` doesn't expose a separate
+    // system/user channel, so this is the simplest portable shape.
+    let full_prompt = match system_prompt {
+        Some(sys) if !sys.trim().is_empty() => {
+            format!(
+                "# System\n{}\n\n# User\n{}",
+                sys.trim(),
+                prompt.trim()
+            )
+        }
+        _ => prompt,
+    };
+
+    let fmt = output_format.unwrap_or_else(|| "text".to_string());
+
+    let mut cmd = std::process::Command::new(&binary);
+    cmd.args(["-p", &full_prompt, "--output-format", &fmt]);
+    if let Some(dir) = cwd {
+        if !dir.trim().is_empty() {
+            cmd.current_dir(dir);
+        }
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run claude CLI: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            "Claude CLI a échoué sans message".to_string()
+        } else {
+            detail
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+/// Launch `claude login` in the user's native terminal emulator. We don't
+/// embed a PTY because this is a one-shot setup flow: the user validates
+/// in their browser and comes back to GitWand.
+#[tauri::command]
+fn claude_cli_login() -> Result<(), String> {
+    let binary = resolve_claude_binary()
+        .ok_or_else(|| "Binaire `claude` introuvable. Installez-le d'abord.".to_string())?;
+
+    #[cfg(target_os = "macos")]
+    {
+        // Open Terminal.app with the login command. `osascript` keeps the
+        // window focused so the user sees the OAuth prompt in the browser
+        // that Claude Code opens automatically.
+        let script = format!(
+            "tell application \"Terminal\" to do script \"{} login\"",
+            binary.replace('"', "\\\"")
+        );
+        std::process::Command::new("osascript")
+            .args(["-e", &script])
+            .spawn()
+            .map_err(|e| format!("Failed to open Terminal: {}", e))?;
+        return Ok(());
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        // cmd /k keeps the window open after login completes so the user
+        // can read any status message.
+        std::process::Command::new("cmd")
+            .args(["/c", "start", "cmd", "/k", &format!("\"{}\" login", binary)])
+            .spawn()
+            .map_err(|e| format!("Failed to open cmd: {}", e))?;
+        return Ok(());
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        // Try the common Linux terminal emulators in order of popularity.
+        // Each entry's last slot is where the shell command gets appended.
+        let candidates: [&[&str]; 6] = [
+            &["gnome-terminal", "--", "sh", "-c"],
+            &["konsole", "-e", "sh", "-c"],
+            &["xfce4-terminal", "-e"],
+            &["kitty", "sh", "-c"],
+            &["alacritty", "-e", "sh", "-c"],
+            &["x-terminal-emulator", "-e", "sh", "-c"],
+        ];
+        let inner = format!("{} login; echo; read -p 'Press enter to close...'", binary);
+        for args in candidates.iter() {
+            let (prog, rest) = args.split_first().unwrap();
+            let mut cmd = std::process::Command::new(prog);
+            for a in *rest {
+                cmd.arg(a);
+            }
+            cmd.arg(&inner);
+            if cmd.spawn().is_ok() {
+                return Ok(());
+            }
+        }
+        return Err(
+            "Aucun terminal compatible trouvé. Ouvrez un terminal et tapez: claude login"
+                .to_string(),
+        );
+    }
+
+    #[allow(unreachable_code)]
+    Err("Plateforme non supportée".to_string())
+}
+
 // ─── Open in external editor ──────────────────────────────
 
 #[tauri::command]
@@ -2787,6 +3041,9 @@ pub fn run() {
             git_exec,
             git_autocomplete,
             git_get_user,
+            detect_claude_cli,
+            claude_cli_prompt,
+            claude_cli_login,
         ])
         .run(tauri::generate_context!())
         .expect("error while running GitWand");

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2710,6 +2710,24 @@ struct ClaudeCliInfo {
     detail: String,
 }
 
+/// Environment variables that make the Claude Code CLI fall back to
+/// API-key auth instead of using the OAuth session from `claude login`.
+/// When the user explicitly picks the "Claude Code CLI" provider in GitWand,
+/// they've asked to use their Max/Pro subscription — so we strip these to
+/// avoid a stale/invalid key in the shell hijacking the call.
+const CLAUDE_AUTH_OVERRIDE_ENV: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+];
+
+/// Apply the API-key env strip to a `std::process::Command` before spawning.
+fn strip_claude_auth_env(cmd: &mut std::process::Command) {
+    for var in CLAUDE_AUTH_OVERRIDE_ENV {
+        cmd.env_remove(var);
+    }
+}
+
 /// Resolve the path to the `claude` binary, checking the usual install
 /// locations on macOS / Linux / Windows in addition to PATH.
 fn resolve_claude_binary() -> Option<String> {
@@ -2775,9 +2793,14 @@ fn detect_claude_cli() -> Result<ClaudeCliInfo, String> {
     // Ping with a tiny prompt to check auth. Timeout is enforced by the
     // caller via the Tauri command; here we just run synchronously with a
     // short output cap. The CLI exits non-zero when auth is missing.
-    let ping = std::process::Command::new(&binary)
-        .args(["-p", "ping", "--output-format", "text"])
-        .output();
+    //
+    // We strip API-key env vars here too so the detection reflects the
+    // actual OAuth-session state that prompts will use — otherwise a stale
+    // `ANTHROPIC_API_KEY` in the shell would mask the real auth status.
+    let mut ping_cmd = std::process::Command::new(&binary);
+    ping_cmd.args(["-p", "ping", "--output-format", "text"]);
+    strip_claude_auth_env(&mut ping_cmd);
+    let ping = ping_cmd.output();
 
     match ping {
         Ok(out) if out.status.success() => Ok(ClaudeCliInfo {
@@ -2849,6 +2872,7 @@ fn claude_cli_prompt(
 
     let mut cmd = std::process::Command::new(&binary);
     cmd.args(["-p", &full_prompt, "--output-format", &fmt]);
+    strip_claude_auth_env(&mut cmd);
     if let Some(dir) = cwd {
         if !dir.trim().is_empty() {
             cmd.current_dir(dir);

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -675,6 +675,7 @@ onUnmounted(() => {
     <div class="app-body">
       <aside class="sidebar" v-if="hasRepo">
         <RepoSidebar
+          :cwd="repoFolderPath ?? ''"
           :files="repoFiles"
           :selected-file="repoSelectedFile"
           :view-mode="viewMode"

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -5,8 +5,12 @@ import type { GitLogEntry, GitBranch } from "../utils/backend";
 import CommitLog from "./CommitLog.vue";
 import PrListSidebar from "./PrListSidebar.vue";
 import { useI18n } from "../composables/useI18n";
+import { useCommitMessage } from "../composables/useCommitMessage";
+import { useAIProvider } from "../composables/useAIProvider";
 
 const props = defineProps<{
+  /** Repo directory, used by AI commit message generation. */
+  cwd: string;
   files: RepoFileEntry[];
   selectedFile: string | null;
   viewMode: ViewMode;
@@ -60,7 +64,7 @@ const emit = defineEmits<{
   addToGitignore: [path: string];
 }>();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 
 // ─── Context menu ─────────────────────────────────────────────
 interface CtxMenu {
@@ -104,6 +108,25 @@ onUnmounted(() => {
   window.removeEventListener("click", closeContextMenu);
   window.removeEventListener("contextmenu", closeContextMenu);
 });
+
+// ─── AI commit message generation ─────────────────────────
+const ai = useAIProvider();
+const { isGenerating, lastError: aiError, generate: generateCommitMsg } = useCommitMessage();
+
+async function onGenerateCommitMessage() {
+  if (!props.cwd || isGenerating.value) return;
+  const lang = locale.value.startsWith("en") ? "en" : "fr";
+  try {
+    const msg = await generateCommitMsg(props.cwd, { locale: lang as "fr" | "en" });
+    // Split on first newline: summary = first line, description = rest.
+    const [summary, ...rest] = msg.split("\n");
+    emit("update:commitSummary", summary.trim());
+    const body = rest.join("\n").trim();
+    if (body) emit("update:commitDescription", body);
+  } catch {
+    // lastError is already set by the composable — the UI shows it.
+  }
+}
 
 const sections = computed(() => {
   const map: Record<string, RepoFileEntry[]> = {
@@ -382,14 +405,35 @@ function formatActivityDate(dateStr: string): string {
 
     <!-- Commit panel — fixed at bottom, always visible in changes view -->
     <div class="commit-panel" v-if="viewMode === 'changes'">
-      <input
-        class="commit-summary mono"
-        type="text"
-        :value="commitSummary"
-        @input="onSummaryInput"
-        @keydown="onCommitKeydown"
-        :placeholder="t('sidebar.summaryPlaceholder')"
-      />
+      <div class="commit-summary-row">
+        <input
+          class="commit-summary mono"
+          type="text"
+          :value="commitSummary"
+          @input="onSummaryInput"
+          @keydown="onCommitKeydown"
+          :placeholder="t('sidebar.summaryPlaceholder')"
+        />
+        <!-- AI generate commit message button -->
+        <button
+          v-if="ai.isAvailable.value"
+          class="commit-ai-btn"
+          :class="{ 'commit-ai-btn--loading': isGenerating }"
+          :disabled="isGenerating || repoStats.staged === 0"
+          :title="isGenerating ? t('sidebar.aiGeneratingTooltip') : t('sidebar.aiGenerateTooltip')"
+          @click="onGenerateCommitMessage"
+        >
+          <svg v-if="isGenerating" class="commit-spinner" width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+            <circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.3"/>
+            <path d="M7 1.5A5.5 5.5 0 0112.5 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+          </svg>
+          <svg v-else width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path d="M8 2l1.5 3.5L13 7l-3.5 1.5L8 12l-1.5-3.5L3 7l3.5-1.5L8 2z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="none"/>
+          </svg>
+        </button>
+      </div>
+      <!-- AI error feedback -->
+      <div v-if="aiError" class="commit-ai-error">{{ aiError }}</div>
       <textarea
         class="commit-description mono"
         :value="commitDescription"
@@ -976,8 +1020,15 @@ function formatActivityDate(dateStr: string): string {
   flex-shrink: 0;
 }
 
+.commit-summary-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: stretch;
+}
+
 .commit-summary {
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   padding: var(--space-3) var(--space-5);
   font-size: var(--font-size-sm);
   line-height: 1.5;
@@ -987,6 +1038,41 @@ function formatActivityDate(dateStr: string): string {
   border-radius: var(--radius-md);
   outline: none;
   transition: border-color var(--transition-base);
+}
+
+.commit-ai-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  background: var(--color-bg-tertiary);
+  color: var(--color-accent);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--transition-base), border-color var(--transition-base), color var(--transition-base);
+}
+
+.commit-ai-btn:hover:not(:disabled) {
+  background: var(--color-bg);
+  border-color: var(--color-accent);
+}
+
+.commit-ai-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.commit-ai-btn--loading {
+  color: var(--color-warning);
+}
+
+.commit-ai-error {
+  font-size: var(--font-size-xs);
+  color: var(--color-danger);
+  padding: 0 var(--space-2);
+  line-height: 1.4;
 }
 
 .commit-summary:focus {

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -7,13 +7,19 @@ import {
   supportedLocales,
   type SupportedLocale,
 } from "../locales";
+import { detectClaudeCli, claudeCliLogin, type ClaudeCliInfo } from "../utils/backend";
 
 const { t, locale, isAuto, setLocale } = useI18n();
 const { theme, setTheme } = useTheme();
 
 export type PullMode = "merge" | "rebase";
 export type SwitchBehavior = "stash" | "ask" | "refuse";
-export type AIProvider = "none" | "claude" | "openai-compat" | "ollama";
+export type AIProvider =
+  | "none"
+  | "claude"
+  | "claude-code-cli"
+  | "openai-compat"
+  | "ollama";
 
 const emit = defineEmits<{
   close: [];
@@ -189,7 +195,10 @@ function onAIEnabledChange(e: Event) {
 function onAIProviderChange(val: AIProvider) {
   updateSetting("aiProvider", val);
   // Set sensible defaults per provider
-  if (val === "claude") {
+  if (val === "claude-code-cli") {
+    // Refresh detection when the user picks this provider.
+    runClaudeCliDetect();
+  } else if (val === "claude") {
     if (!settings.value.aiApiEndpoint || settings.value.aiApiEndpoint === "https://api.openai.com/v1") {
       updateSetting("aiApiEndpoint", "https://api.anthropic.com");
     }
@@ -283,8 +292,60 @@ function disconnectClaude() {
 
 const claudeConnectKeyInput = ref("");
 
+// ─── Claude Code CLI detection ──────────────────────────
+const claudeCliInfo = ref<ClaudeCliInfo | null>(null);
+const claudeCliDetecting = ref(false);
+const claudeCliLoginLoading = ref(false);
+
+async function runClaudeCliDetect() {
+  claudeCliDetecting.value = true;
+  try {
+    claudeCliInfo.value = await detectClaudeCli();
+  } catch (e) {
+    claudeCliInfo.value = {
+      found: false,
+      path: "",
+      version: "",
+      logged_in: false,
+      status: "error",
+      detail: (e as Error).message,
+    };
+  } finally {
+    claudeCliDetecting.value = false;
+  }
+}
+
+async function runClaudeCliLogin() {
+  claudeCliLoginLoading.value = true;
+  try {
+    await claudeCliLogin();
+    // After launching the terminal, re-poll a few times so the UI flips to
+    // "logged in" without the user having to click Detect again.
+    for (let i = 0; i < 12; i++) {
+      await new Promise((r) => setTimeout(r, 5000));
+      await runClaudeCliDetect();
+      if (claudeCliInfo.value?.logged_in) break;
+    }
+  } catch (e) {
+    claudeCliInfo.value = {
+      found: claudeCliInfo.value?.found ?? false,
+      path: claudeCliInfo.value?.path ?? "",
+      version: claudeCliInfo.value?.version ?? "",
+      logged_in: false,
+      status: "error",
+      detail: (e as Error).message,
+    };
+  } finally {
+    claudeCliLoginLoading.value = false;
+  }
+}
+
 onMounted(() => {
   detectOllama();
+  // Lazy-detect Claude CLI only when the user has that provider active,
+  // or run a background detect so the option can be highlighted in the
+  // dropdown. We do a one-shot detect at mount — it's fast (just `which`).
+  runClaudeCliDetect();
 });
 
 function onKeyDown(e: KeyboardEvent) {
@@ -509,7 +570,10 @@ function onKeyDown(e: KeyboardEvent) {
                 :value="settings.aiProvider"
                 @change="onAIProviderChange(($event.target as HTMLSelectElement).value as AIProvider)"
               >
-                <option value="claude">Claude (Anthropic)</option>
+                <option value="claude">Claude (Anthropic API)</option>
+                <option value="claude-code-cli">
+                  Claude Code CLI (abonnement Max/Pro){{ claudeCliInfo && !claudeCliInfo.found ? ' — non détecté' : '' }}
+                </option>
                 <option value="openai-compat">API compatible OpenAI</option>
                 <option value="ollama" :disabled="!ollamaAvailable">
                   Ollama (local){{ ollamaAvailable ? '' : ' — non détecté' }}
@@ -638,6 +702,65 @@ function onKeyDown(e: KeyboardEvent) {
                   <option value="claude-haiku-4-5-20251001">Claude Haiku 4.5 (rapide)</option>
                   <option value="claude-opus-4-20250514">Claude Opus 4 (premium)</option>
                 </select>
+              </div>
+            </template>
+
+            <!-- Claude Code CLI provider (piggyback on user's subscription) -->
+            <template v-if="settings.aiProvider === 'claude-code-cli'">
+              <div class="sp-row">
+                <label class="sp-label">État du CLI</label>
+                <div class="sp-cli-status">
+                  <template v-if="claudeCliDetecting">
+                    <span class="sp-hint">Détection en cours…</span>
+                  </template>
+                  <template v-else-if="!claudeCliInfo || !claudeCliInfo.found">
+                    <div class="sp-connect-error-block">
+                      <div class="sp-connect-error">
+                        Binaire <code>claude</code> introuvable.
+                      </div>
+                      <span class="sp-hint">
+                        Installez-le avec
+                        <code>npm install -g @anthropic-ai/claude-code</code>
+                        puis cliquez sur Re-détecter.
+                      </span>
+                      <button class="sp-text-btn" @click="runClaudeCliDetect">Re-détecter</button>
+                    </div>
+                  </template>
+                  <template v-else-if="claudeCliInfo.logged_in">
+                    <div class="sp-connected-badge">
+                      <span class="sp-connected-dot"></span>
+                      <span>Connecté — {{ claudeCliInfo.version || 'claude' }}</span>
+                      <button class="sp-disconnect-btn" @click="runClaudeCliDetect">Re-détecter</button>
+                    </div>
+                    <span class="sp-hint">Les appels utiliseront votre abonnement Claude Max/Pro.</span>
+                  </template>
+                  <template v-else>
+                    <div class="sp-connect-error-block">
+                      <div class="sp-connect-error">
+                        CLI trouvé mais non authentifié.
+                      </div>
+                      <span class="sp-hint">{{ claudeCliInfo.detail || "Lance `claude login` pour te connecter." }}</span>
+                      <button
+                        class="sp-connect-btn"
+                        :disabled="claudeCliLoginLoading"
+                        @click="runClaudeCliLogin"
+                      >
+                        {{ claudeCliLoginLoading ? 'En attente de connexion…' : 'Se connecter (ouvre un terminal)' }}
+                      </button>
+                    </div>
+                  </template>
+                </div>
+              </div>
+
+              <div v-if="claudeCliInfo?.logged_in" class="sp-info-box">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3">
+                  <circle cx="8" cy="8" r="7"/><path d="M8 7v4" stroke-linecap="round"/><circle cx="8" cy="5" r="0.7" fill="currentColor" stroke="none"/>
+                </svg>
+                <p>
+                  GitWand exécute <code>claude -p</code> localement.
+                  Aucune clé API n'est requise : la session utilise l'authentification
+                  stockée par Claude Code sur votre machine.
+                </p>
               </div>
             </template>
 
@@ -1124,6 +1247,20 @@ function onKeyDown(e: KeyboardEvent) {
 }
 
 .sp-text-btn:hover { color: var(--color-text); }
+
+.sp-cli-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.sp-cli-status code {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.9em;
+  padding: 0 var(--space-2);
+  background: var(--color-bg);
+  border-radius: var(--radius-xs);
+}
 
 .sp-connected-badge {
   display: flex;

--- a/apps/desktop/src/composables/useAIProvider.ts
+++ b/apps/desktop/src/composables/useAIProvider.ts
@@ -204,7 +204,8 @@ async function callClaudeCodeCli(
   systemPrompt: string,
   userPrompt: string,
 ): Promise<string> {
-  return claudeCliPrompt(userPrompt, systemPrompt, undefined, "text");
+  const result = await claudeCliPrompt(userPrompt, systemPrompt, undefined, "text");
+  return result ?? "";
 }
 
 /**

--- a/apps/desktop/src/composables/useAIProvider.ts
+++ b/apps/desktop/src/composables/useAIProvider.ts
@@ -1,9 +1,21 @@
 import { ref, computed } from "vue";
+import { claudeCliPrompt } from "../utils/backend";
 
 /**
  * AI provider types matching SettingsPanel configuration.
+ *
+ * - `claude`         : direct Anthropic API with user-provided API key
+ * - `claude-code-cli`: piggyback on the user's locally-installed Claude Code
+ *                     CLI (uses their Max/Pro subscription, no API key needed)
+ * - `openai-compat`  : any OpenAI-compatible endpoint
+ * - `ollama`         : local Ollama instance
  */
-export type AIProvider = "none" | "claude" | "openai-compat" | "ollama";
+export type AIProvider =
+  | "none"
+  | "claude"
+  | "claude-code-cli"
+  | "openai-compat"
+  | "ollama";
 
 export interface AISettings {
   aiEnabled: boolean;
@@ -185,6 +197,17 @@ async function callOpenAICompat(
 }
 
 /**
+ * Call the local Claude Code CLI (`claude -p`). Uses the user's Max/Pro
+ * subscription — no API key required as long as they've run `claude login`.
+ */
+async function callClaudeCodeCli(
+  systemPrompt: string,
+  userPrompt: string,
+): Promise<string> {
+  return claudeCliPrompt(userPrompt, systemPrompt, undefined, "text");
+}
+
+/**
  * Call Ollama's local API.
  */
 async function callOllama(
@@ -255,6 +278,10 @@ export function useAIProvider() {
     if (s.aiProvider === "claude" && !s.aiApiKey) return false;
     if (s.aiProvider === "openai-compat" && (!s.aiApiKey || !s.aiApiEndpoint)) return false;
     if (s.aiProvider === "ollama") return true; // Ollama doesn't need a key
+    // claude-code-cli: availability is verified at runtime via detectClaudeCli()
+    // so we optimistically consider it available here. The actual call will
+    // surface a clear error if the CLI is missing or not logged in.
+    if (s.aiProvider === "claude-code-cli") return true;
     if (s.aiProvider === "none") return false;
     return true;
   });
@@ -278,6 +305,9 @@ export function useAIProvider() {
         case "claude":
           rawResponse = await callClaude(s, systemPrompt, userPrompt);
           break;
+        case "claude-code-cli":
+          rawResponse = await callClaudeCodeCli(systemPrompt, userPrompt);
+          break;
         case "openai-compat":
           rawResponse = await callOpenAICompat(s, systemPrompt, userPrompt);
           break;
@@ -299,11 +329,36 @@ export function useAIProvider() {
     }
   }
 
+  /**
+   * Free-form prompt dispatch — same provider selection as `suggest()`,
+   * but without the conflict-resolution-specific scaffolding. Used by
+   * commit-message generation, PR summaries, and other single-shot tasks.
+   */
+  async function rawPrompt(
+    systemPrompt: string,
+    userPrompt: string,
+  ): Promise<string> {
+    const s = loadAISettings();
+    switch (s.aiProvider) {
+      case "claude":
+        return callClaude(s, systemPrompt, userPrompt);
+      case "claude-code-cli":
+        return callClaudeCodeCli(systemPrompt, userPrompt);
+      case "openai-compat":
+        return callOpenAICompat(s, systemPrompt, userPrompt);
+      case "ollama":
+        return callOllama(s, systemPrompt, userPrompt);
+      default:
+        throw new Error("Aucun provider IA configuré");
+    }
+  }
+
   return {
     isAvailable,
     isLoading,
     lastError,
     lastSuggestion,
     suggest,
+    rawPrompt,
   };
 }

--- a/apps/desktop/src/composables/useCommitMessage.ts
+++ b/apps/desktop/src/composables/useCommitMessage.ts
@@ -48,7 +48,8 @@ Write the commit message.`;
 }
 
 /** Strip code fences / leading labels the model sometimes adds anyway. */
-function cleanMessage(raw: string): string {
+function cleanMessage(raw: string | undefined | null): string {
+  if (!raw) return "";
   let msg = raw.trim();
   const fence = msg.match(/^```(?:[a-z]*)?\s*\n([\s\S]*?)\n```\s*$/i);
   if (fence) msg = fence[1].trim();
@@ -88,18 +89,31 @@ export function useCommitMessage() {
 
       // Pull the staged diff + a short status summary via the existing
       // git_exec primitive — no new backend command needed.
-      const [diffRes, statusRes] = await Promise.all([
-        gitExec(cwd, ["diff", "--cached", "--no-color"]),
-        gitExec(cwd, ["diff", "--cached", "--name-status"]),
-      ]);
+      if (!cwd) {
+        throw new Error("Aucun repo ouvert (cwd vide).");
+      }
 
-      if (diffRes.exitCode !== 0) {
+      let diffRes, statusRes;
+      try {
+        [diffRes, statusRes] = await Promise.all([
+          gitExec(cwd, ["diff", "--cached", "--no-color"]),
+          gitExec(cwd, ["diff", "--cached", "--name-status"]),
+        ]);
+      } catch (execErr: unknown) {
         throw new Error(
-          diffRes.stderr.trim() || "git diff --cached a échoué",
+          `git exec failed: ${execErr instanceof Error ? execErr.message : String(execErr)}`,
         );
       }
 
-      let diff = diffRes.stdout;
+      if (diffRes.exitCode !== 0) {
+        const stderr = (diffRes.stderr ?? "").trim();
+        throw new Error(
+          stderr
+            || `git diff --cached a échoué (exit ${diffRes.exitCode}, cwd: ${cwd})`,
+        );
+      }
+
+      let diff = diffRes.stdout ?? "";
       if (diff.length === 0) {
         throw new Error("Aucun changement stagé — stage des fichiers avant de générer un message.");
       }
@@ -117,10 +131,13 @@ export function useCommitMessage() {
       // call from useAIProvider. For now we go direct via the CLI / HTTP
       // layers by piggybacking on the existing provider config.
       const systemPrompt = buildSystemPrompt(locale);
-      const userPrompt = buildUserPrompt(diff, statusRes.stdout);
+      const userPrompt = buildUserPrompt(diff, statusRes.stdout ?? "");
 
       // Use the provider's own free-form prompt entry point.
       const raw = await ai.rawPrompt(systemPrompt, userPrompt);
+      if (!raw) {
+        throw new Error("Le provider IA n'a retourné aucune réponse.");
+      }
       const message = cleanMessage(raw);
       lastMessage.value = message;
       return message;

--- a/apps/desktop/src/composables/useCommitMessage.ts
+++ b/apps/desktop/src/composables/useCommitMessage.ts
@@ -1,0 +1,142 @@
+import { ref } from "vue";
+import { gitExec } from "../utils/backend";
+import { useAIProvider } from "./useAIProvider";
+
+/**
+ * Generates commit messages from the currently staged diff.
+ *
+ * Relies on `useAIProvider` under the hood, so it works with every provider
+ * configured in Settings (Anthropic API, Claude Code CLI, OpenAI-compatible,
+ * Ollama). The Claude Code CLI path is the most interesting here: it lets
+ * users generate commit messages using their Claude Max/Pro subscription
+ * without having to configure an API key.
+ */
+
+export interface CommitMessageOptions {
+  /** "fr" or "en" — locale used for the message body when style is "conventional". */
+  locale?: "fr" | "en";
+  /** Max number of diff characters sent to the model (default 16k). */
+  maxDiffChars?: number;
+}
+
+function buildSystemPrompt(locale: "fr" | "en"): string {
+  const lang = locale === "fr" ? "French" : "English";
+  return `You are a senior software engineer writing a Git commit message.
+
+Rules:
+1. Follow the Conventional Commits spec: "<type>(<optional scope>): <subject>".
+   Valid types: feat, fix, refactor, perf, docs, test, chore, build, ci, style.
+2. Subject line MUST be 72 characters or less, imperative mood, no trailing period.
+3. After the subject, leave a blank line, then optionally add a short body (1-3 lines)
+   explaining *why* the change was made. Skip the body for trivial changes.
+4. Write in ${lang}.
+5. Never include "Co-Authored-By", "Signed-off-by", or any other trailer.
+6. Never wrap your answer in code fences or add explanations — output ONLY the
+   raw commit message, ready to be passed to \`git commit -m\`.`;
+}
+
+function buildUserPrompt(diff: string, status: string): string {
+  return `Here is the staged change to describe.
+
+--- git status (staged files) ---
+${status.trim() || "(empty)"}
+
+--- git diff --cached ---
+${diff.trim() || "(empty)"}
+
+Write the commit message.`;
+}
+
+/** Strip code fences / leading labels the model sometimes adds anyway. */
+function cleanMessage(raw: string): string {
+  let msg = raw.trim();
+  const fence = msg.match(/^```(?:[a-z]*)?\s*\n([\s\S]*?)\n```\s*$/i);
+  if (fence) msg = fence[1].trim();
+  // Some models prefix with "Commit message:" — strip it.
+  msg = msg.replace(/^commit message:\s*/i, "").trim();
+  return msg;
+}
+
+const isGenerating = ref(false);
+const lastError = ref<string | null>(null);
+const lastMessage = ref<string | null>(null);
+
+export function useCommitMessage() {
+  const ai = useAIProvider();
+
+  /**
+   * Generate a commit message from the current staged diff.
+   *
+   * @throws if no provider is configured or the model call fails.
+   */
+  async function generate(
+    cwd: string,
+    options: CommitMessageOptions = {},
+  ): Promise<string> {
+    const { locale = "fr", maxDiffChars = 16_000 } = options;
+
+    isGenerating.value = true;
+    lastError.value = null;
+    lastMessage.value = null;
+
+    try {
+      if (!ai.isAvailable.value) {
+        throw new Error(
+          "Aucun provider IA configuré. Ouvre les paramètres pour en activer un.",
+        );
+      }
+
+      // Pull the staged diff + a short status summary via the existing
+      // git_exec primitive — no new backend command needed.
+      const [diffRes, statusRes] = await Promise.all([
+        gitExec(cwd, ["diff", "--cached", "--no-color"]),
+        gitExec(cwd, ["diff", "--cached", "--name-status"]),
+      ]);
+
+      if (diffRes.exitCode !== 0) {
+        throw new Error(
+          diffRes.stderr.trim() || "git diff --cached a échoué",
+        );
+      }
+
+      let diff = diffRes.stdout;
+      if (diff.length === 0) {
+        throw new Error("Aucun changement stagé — stage des fichiers avant de générer un message.");
+      }
+      if (diff.length > maxDiffChars) {
+        diff = diff.slice(0, maxDiffChars) + "\n... (diff truncated)";
+      }
+
+      // We call the provider directly through the same mechanism used for
+      // conflict resolution. The `suggest()` API expects a ConflictContext,
+      // which is the wrong shape here, so we re-implement the minimal
+      // provider dispatch by rebuilding the prompts and going through the
+      // provider's underlying call. To keep this simple, we hijack the
+      // suggest path by encoding the commit-message request as a fake
+      // conflict — but that's ugly. Cleaner: expose a free-form `prompt`
+      // call from useAIProvider. For now we go direct via the CLI / HTTP
+      // layers by piggybacking on the existing provider config.
+      const systemPrompt = buildSystemPrompt(locale);
+      const userPrompt = buildUserPrompt(diff, statusRes.stdout);
+
+      // Use the provider's own free-form prompt entry point.
+      const raw = await ai.rawPrompt(systemPrompt, userPrompt);
+      const message = cleanMessage(raw);
+      lastMessage.value = message;
+      return message;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      lastError.value = msg;
+      throw err;
+    } finally {
+      isGenerating.value = false;
+    }
+  }
+
+  return {
+    isGenerating,
+    lastError,
+    lastMessage,
+    generate,
+  };
+}

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -104,6 +104,8 @@ const en: Locale = {
     commitButton: "Commit ({0})",
     commitButtonLoading: "Committing\u2026",
     commitHint: "Ctrl+Enter to commit",
+    aiGenerateTooltip: "Generate message with AI",
+    aiGeneratingTooltip: "Generating\u2026",
     // Empty
     cleanTree: "Working tree clean",
     // Dashboard-specific sidebar blocks

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -105,6 +105,8 @@ const fr = {
     commitButton: "Commiter ({0})",
     commitButtonLoading: "En cours\u2026",
     commitHint: "Ctrl+Enter pour valider",
+    aiGenerateTooltip: "Générer un message avec l'IA",
+    aiGeneratingTooltip: "Génération en cours\u2026",
     // Empty
     cleanTree: "Espace de travail propre",
     // Dashboard-specific sidebar blocks

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -1163,15 +1163,13 @@ export interface TerminalResult {
  */
 export async function gitExec(cwd: string, args: string[]): Promise<TerminalResult> {
   if (isTauri()) {
-    const raw = await tauriInvoke<{
-      stdout: string;
-      stderr: string;
-      exit_code: number;
-    }>("git_exec", { cwd, args });
+    // Tauri 2 may serialize the Rust struct field `exit_code` as either
+    // snake_case or camelCase depending on the serde config — accept both.
+    const raw = await tauriInvoke<Record<string, unknown>>("git_exec", { cwd, args });
     return {
-      stdout: raw.stdout,
-      stderr: raw.stderr,
-      exitCode: raw.exit_code,
+      stdout: (raw.stdout as string) ?? "",
+      stderr: (raw.stderr as string) ?? "",
+      exitCode: (raw.exitCode ?? raw.exit_code ?? -1) as number,
     };
   }
   const res = await fetch(`${DEV_SERVER}/api/git-exec`, {
@@ -1179,7 +1177,12 @@ export async function gitExec(cwd: string, args: string[]): Promise<TerminalResu
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ cwd, args }),
   });
-  return res.json();
+  const data = await res.json();
+  return {
+    stdout: data.stdout ?? "",
+    stderr: data.stderr ?? "",
+    exitCode: data.exitCode ?? data.exit_code ?? -1,
+  };
 }
 
 /**

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -1790,6 +1790,118 @@ export async function ghPrFileHistory(
   return raw as Record<string, PrFileHistory>;
 }
 
+// ─── Claude Code CLI wrapper ─────────────────────────────
+//
+// Thin wrappers around the Rust/dev-server commands that shell out to the
+// user's locally-installed `claude` binary (official Claude Code CLI).
+// This is how we piggyback on the user's Max/Pro subscription without
+// implementing OAuth ourselves — same trick as Solo / SoloTerm.
+
+export interface ClaudeCliInfo {
+  /** True when the `claude` binary was found on disk. */
+  found: boolean;
+  /** Absolute path to the binary, or "" if not found. */
+  path: string;
+  /** Raw `claude --version` output. */
+  version: string;
+  /** True if a ping prompt answered without an auth error. */
+  logged_in: boolean;
+  /** Machine-readable status: "ok" | "not_found" | "not_logged_in" | "error". */
+  status: "ok" | "not_found" | "not_logged_in" | "error" | string;
+  /** Optional error detail line. */
+  detail: string;
+}
+
+/**
+ * Detect whether the Claude Code CLI is installed and authenticated.
+ * Safe to call on app boot — returns `found: false` instead of throwing
+ * when the binary is missing.
+ */
+export async function detectClaudeCli(): Promise<ClaudeCliInfo> {
+  if (isTauri()) {
+    return tauriInvoke<ClaudeCliInfo>("detect_claude_cli");
+  }
+  try {
+    const res = await fetch(`${DEV_SERVER}/api/claude-cli-detect`);
+    if (res.ok) return (await res.json()) as ClaudeCliInfo;
+  } catch {
+    // Dev server unavailable
+  }
+  return {
+    found: false,
+    path: "",
+    version: "",
+    logged_in: false,
+    status: "not_found",
+    detail: "",
+  };
+}
+
+/**
+ * Run a prompt through the local Claude Code CLI.
+ *
+ * @param prompt User prompt (main content).
+ * @param systemPrompt Optional system-level instructions (prepended as a
+ *                     `# System` section since `claude -p` has no separate
+ *                     system channel).
+ * @param cwd Optional working directory for the CLI process.
+ * @param outputFormat "text" (default) or "json".
+ * @returns Raw stdout from the CLI.
+ */
+export async function claudeCliPrompt(
+  prompt: string,
+  systemPrompt?: string,
+  cwd?: string,
+  outputFormat: "text" | "json" = "text",
+): Promise<string> {
+  if (isTauri()) {
+    return tauriInvoke<string>("claude_cli_prompt", {
+      prompt,
+      systemPrompt,
+      cwd,
+      outputFormat,
+    });
+  }
+  const res = await fetch(`${DEV_SERVER}/api/claude-cli-prompt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, systemPrompt, cwd, outputFormat }),
+  });
+  if (!res.ok) {
+    let msg = `claude CLI error ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body?.error) msg = body.error;
+    } catch { /* ignore */ }
+    throw new Error(msg);
+  }
+  return await res.text();
+}
+
+/**
+ * Open the native terminal with `claude login` so the user can complete
+ * the OAuth-style setup. Not a PTY integration — just a one-shot bootstrap.
+ */
+export async function claudeCliLogin(): Promise<void> {
+  if (isTauri()) {
+    await tauriInvoke("claude_cli_login");
+    return;
+  }
+  const res = await fetch(`${DEV_SERVER}/api/claude-cli-login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  if (!res.ok) {
+    let msg = `claude login failed (${res.status})`;
+    try {
+      const body = await res.json();
+      if (body?.error) msg = body.error;
+    } catch { /* ignore */ }
+    throw new Error(msg);
+  }
+}
+
 // ─── Merge Preview (Phase 8.1) ─────────────────────────────
 
 /** Résultat brut d'un fichier analysé par preview_merge (Rust) */


### PR DESCRIPTION
## Summary
- New AI provider `claude-code-cli` that wraps the locally-installed `claude` binary, letting users piggyback on their Claude Max/Pro subscription without an API key (same strategy as Solo, but headless — no PTY).
- Backend: `detect_claude_cli`, `claude_cli_prompt`, `claude_cli_login` in Rust + dev-server mirror + TS wrappers.
- Frontend: provider option + detection UI in Settings, new `useCommitMessage` composable ready to wire into the commit panel.

## Test plan
- [ ] Settings → IA → "Claude Code CLI" without CLI installed: detection error + install hint shown.
- [ ] With CLI installed but not logged in: "Se connecter" button opens system terminal with `claude login`; detection flips to "Connecté" within ~1 min.
- [ ] Trigger an AI conflict resolution with this provider selected: returns a suggestion.
- [ ] Browser dev mode (pnpm dev + node dev-server.mjs): same flow works via HTTP endpoints.
- [ ] Windows & Linux login launchers (manual).