### PR TITLE
feat: 1.2.1 — Interactive rebase

### DIFF
--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -10,9 +10,9 @@
 
 import { createServer } from "node:http";
 import { execSync, execFileSync, spawnSync, spawn } from "node:child_process";
-import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync, unlinkSync } from "node:fs";
 import { resolve, join, dirname, basename } from "node:path";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 
 /** Resolve the full path to a CLI binary, checking Homebrew paths on macOS. */
 function resolveBin(name) {
@@ -2014,6 +2014,53 @@ const server = createServer(async (req, res) => {
           return jsonResponse(res, { error: detail }, 500);
         }
         return jsonResponse(res, { ok: true });
+      } catch (err) {
+        return jsonResponse(res, { error: err.message }, 500);
+      }
+    }
+
+    // POST /api/git-interactive-rebase  { cwd, base, todoLines }
+    // Starts an interactive rebase with a custom todo list.
+    // Writes a temp file and uses GIT_SEQUENCE_EDITOR to inject it.
+    if (url.pathname === "/api/git-interactive-rebase" && req.method === "POST") {
+      try {
+        const { cwd, base, todoLines } = await readBody(req);
+        if (!cwd || !base || !todoLines) {
+          return jsonResponse(res, { error: "Missing cwd, base, or todoLines" }, 400);
+        }
+        const resolvedCwd = resolve(cwd);
+        const todoContent = todoLines.join("\n") + "\n";
+        const tmpFile = join(tmpdir(), `gitwand-rebase-todo-${Date.now()}.txt`);
+        writeFileSync(tmpFile, todoContent, "utf-8");
+
+        try {
+          // Use cp on macOS/Linux to copy our todo into the rebase-todo file
+          const editorCmd = process.platform === "win32"
+            ? `copy /Y "${tmpFile}"`
+            : `cp "${tmpFile}"`;
+
+          const r = spawnSync(GIT, ["rebase", "-i", base], {
+            cwd: resolvedCwd,
+            encoding: "utf-8",
+            maxBuffer: 20 * 1024 * 1024,
+            env: {
+              ...process.env,
+              GIT_SEQUENCE_EDITOR: editorCmd,
+            },
+          });
+
+          // Check for conflicts (exit code 1 with CONFLICT in stderr)
+          if (r.status !== 0) {
+            const stderr = r.stderr ?? "";
+            if (stderr.includes("CONFLICT") || stderr.includes("could not apply")) {
+              return jsonResponse(res, { ok: true, conflict: true });
+            }
+            return jsonResponse(res, { error: stderr || "Rebase failed" }, 500);
+          }
+          return jsonResponse(res, { ok: true });
+        } finally {
+          try { unlinkSync(tmpFile); } catch { /* ignore */ }
+        }
       } catch (err) {
         return jsonResponse(res, { error: err.message }, 500);
       }

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -2022,6 +2022,7 @@ const server = createServer(async (req, res) => {
     // POST /api/git-interactive-rebase  { cwd, base, todoLines }
     // Starts an interactive rebase with a custom todo list.
     // Writes a temp file and uses GIT_SEQUENCE_EDITOR to inject it.
+    // Uses async spawn (NOT spawnSync) to avoid blocking the event loop.
     if (url.pathname === "/api/git-interactive-rebase" && req.method === "POST") {
       try {
         const { cwd, base, todoLines } = await readBody(req);
@@ -2033,35 +2034,61 @@ const server = createServer(async (req, res) => {
         const tmpFile = join(tmpdir(), `gitwand-rebase-todo-${Date.now()}.txt`);
         writeFileSync(tmpFile, todoContent, "utf-8");
 
-        try {
-          // Use cp on macOS/Linux to copy our todo into the rebase-todo file
-          const editorCmd = process.platform === "win32"
-            ? `copy /Y "${tmpFile}"`
-            : `cp "${tmpFile}"`;
+        const editorCmd = process.platform === "win32"
+          ? `copy /Y "${tmpFile}"`
+          : `cp "${tmpFile}"`;
 
-          const r = spawnSync(GIT, ["rebase", "-i", base], {
+        console.log("[rebase] Starting: git rebase -i", base, "in", resolvedCwd);
+
+        const result = await new Promise((resolveP, rejectP) => {
+          const child = spawn(GIT, ["rebase", "-i", base], {
             cwd: resolvedCwd,
-            encoding: "utf-8",
-            maxBuffer: 20 * 1024 * 1024,
             env: {
               ...process.env,
               GIT_SEQUENCE_EDITOR: editorCmd,
+              GIT_EDITOR: "true",
+              EDITOR: "true",
             },
+            stdio: ["pipe", "pipe", "pipe"],
           });
+          // Close stdin immediately so git never blocks waiting for input
+          child.stdin.end();
 
-          // Check for conflicts (exit code 1 with CONFLICT in stderr)
-          if (r.status !== 0) {
-            const stderr = r.stderr ?? "";
-            if (stderr.includes("CONFLICT") || stderr.includes("could not apply")) {
-              return jsonResponse(res, { ok: true, conflict: true });
-            }
-            return jsonResponse(res, { error: stderr || "Rebase failed" }, 500);
+          let stdout = "";
+          let stderr = "";
+          child.stdout.on("data", (d) => { stdout += d.toString(); });
+          child.stderr.on("data", (d) => { stderr += d.toString(); });
+
+          const timer = setTimeout(() => {
+            child.kill("SIGKILL");
+            rejectP(new Error("Rebase timed out after 30s"));
+          }, 30_000);
+
+          child.on("close", (code) => {
+            clearTimeout(timer);
+            console.log("[rebase] Done, exit code:", code, "stderr:", stderr.slice(0, 200));
+            resolveP({ code, stdout, stderr });
+          });
+          child.on("error", (err) => {
+            clearTimeout(timer);
+            console.error("[rebase] spawn error:", err);
+            rejectP(err);
+          });
+        });
+
+        // Clean up temp file
+        try { unlinkSync(tmpFile); } catch { /* ignore */ }
+
+        if (result.code !== 0) {
+          const stderr = result.stderr ?? "";
+          if (stderr.includes("CONFLICT") || stderr.includes("could not apply")) {
+            return jsonResponse(res, { ok: true, conflict: true });
           }
-          return jsonResponse(res, { ok: true });
-        } finally {
-          try { unlinkSync(tmpFile); } catch { /* ignore */ }
+          return jsonResponse(res, { error: stderr || "Rebase failed" }, 500);
         }
+        return jsonResponse(res, { ok: true });
       } catch (err) {
+        console.error("[rebase] Error:", err);
         return jsonResponse(res, { error: err.message }, 500);
       }
     }

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -16,6 +16,7 @@ import PrCreateView from "./components/PrCreateView.vue";
 import DashboardView from "./components/DashboardView.vue";
 import EditCommitOverlay from "./components/EditCommitOverlay.vue";
 import MergeSuccessModal from "./components/MergeSuccessModal.vue";
+import RebaseEditor from "./components/RebaseEditor.vue";
 import { usePrPanel, PR_PANEL_KEY } from "./composables/usePrPanel";
 import type { GitLogEntry } from "./utils/backend";
 import { getPersistedDiffMode, persistDiffMode, type DiffMode } from "./utils/diffMode";
@@ -450,6 +451,14 @@ async function handleSwitchBranch(name: string) {
 
 // ─── Settings panel ─────────────────────────────────────
 const showSettings = ref(false);
+
+// ─── Interactive rebase panel ────────────────────────────
+const showRebase = ref(false);
+
+function handleRebaseDone() {
+  showRebase.value = false;
+  repoRefresh();
+}
 const diffMode = ref<DiffMode>(getPersistedDiffMode());
 
 function onDiffModeChange(mode: DiffMode) {
@@ -671,6 +680,7 @@ onUnmounted(() => {
       @delete-branch="deleteBranch"
       @load-branches="loadBranches"
       @undo-performed="repoRefresh()"
+      @open-rebase="showRebase = true"
     />
 
     <div class="app-body">
@@ -873,6 +883,16 @@ onUnmounted(() => {
       </div>
       <button class="toast-dismiss" @click="dismissToast">OK</button>
     </div>
+
+    <!-- Interactive rebase panel -->
+    <RebaseEditor
+      v-if="showRebase && repoFolderPath"
+      :cwd="repoFolderPath"
+      :current-branch="branchDisplay"
+      :branches="branches"
+      @close="showRebase = false"
+      @done="handleRebaseDone"
+    />
 
     <!-- Settings panel -->
     <SettingsPanel

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -670,6 +670,7 @@ onUnmounted(() => {
       @create-branch="createBranch"
       @delete-branch="deleteBranch"
       @load-branches="loadBranches"
+      @undo-performed="repoRefresh()"
     />
 
     <div class="app-body">
@@ -711,6 +712,7 @@ onUnmounted(() => {
           @update:log-author-filter="setLogAuthorFilter"
           @discard="(path, section) => discardFiles([path], section === 'untracked')"
           @add-to-gitignore="(path) => addToGitignore(path)"
+          @refresh="repoRefresh()"
         />
       </aside>
 

--- a/apps/desktop/src/components/AppHeader.vue
+++ b/apps/desktop/src/components/AppHeader.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, onUnmounted } from "vue";
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
 import type { Theme } from "../composables/useTheme";
 import type { GitBranch } from "../utils/backend";
 import { useI18n } from "../composables/useI18n";
 import { useMergePreview } from "../composables/useMergePreview";
 import MergePreviewPanel from "./MergePreviewPanel.vue";
 import { useFolderHistory } from "../composables/useFolderHistory";
+import { useUndoStack, type UndoEntry, type UndoOpType } from "../composables/useUndoStack";
 
 const { t } = useI18n();
 
@@ -45,6 +46,7 @@ const emit = defineEmits<{
   createBranch: [name: string];
   deleteBranch: [name: string];
   loadBranches: [];
+  undoPerformed: [];
 }>();
 
 // ─── Recent repos popover (Phase 8.4) ────────────────
@@ -212,7 +214,67 @@ function onDocClick(e: MouseEvent) {
   if (showRecentPopover.value && !target.closest(".recent-popover-wrapper")) {
     closeRecentPopover();
   }
+  if (showUndoPopover.value && !target.closest(".undo-popover-wrapper")) {
+    closeUndoPopover();
+  }
 }
+
+// ─── Undo stack (Phase 1.2.4) ──────────────────────────
+const undoStack = useUndoStack();
+const showUndoPopover = ref(false);
+
+function toggleUndoPopover() {
+  showUndoPopover.value = !showUndoPopover.value;
+  if (showUndoPopover.value && props.cwd) {
+    undoStack.refresh(props.cwd);
+  }
+}
+
+function closeUndoPopover() {
+  showUndoPopover.value = false;
+}
+
+/** Map operation type to i18n key suffix. */
+function opLabel(type: UndoOpType): string {
+  const map: Record<UndoOpType, string> = {
+    commit: t("undoStack.opCommit"),
+    amend: t("undoStack.opAmend"),
+    merge: t("undoStack.opMerge"),
+    "cherry-pick": t("undoStack.opCherryPick"),
+    rebase: t("undoStack.opRebase"),
+    pull: t("undoStack.opPull"),
+    reset: t("undoStack.opReset"),
+    checkout: t("undoStack.opCheckout"),
+    stash: t("undoStack.opStash"),
+    other: t("undoStack.opOther"),
+  };
+  return map[type] ?? type;
+}
+
+/** True when the undo is a hard reset (destructive). */
+function isHardUndo(entry: UndoEntry): boolean {
+  return entry.type !== "commit" && entry.type !== "amend";
+}
+
+async function handleUndo(entry: UndoEntry) {
+  const msg = isHardUndo(entry)
+    ? t("undoStack.undoHardConfirm")
+    : t("undoStack.undoConfirm");
+  if (!confirm(msg)) return;
+  try {
+    await undoStack.undo(props.cwd, entry);
+    closeUndoPopover();
+    // Emit a lightweight signal so App.vue can refresh the repo state.
+    emit("undoPerformed");
+  } catch {
+    // lastError is set by the composable — shown in the popover.
+  }
+}
+
+// Auto-load reflog when repo is available (so the Undo button reflects state)
+watch(() => props.cwd, (cwd) => {
+  if (cwd) undoStack.refresh(cwd);
+}, { immediate: true });
 
 onMounted(() => document.addEventListener("click", onDocClick, true));
 onUnmounted(() => document.removeEventListener("click", onDocClick, true));
@@ -568,6 +630,62 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
                 <span class="muted">{{ t('branches.noBranch') }}</span>
               </div>
             </div>
+          </div>
+        </div>
+
+        <!-- Undo (Phase 1.2.4) -->
+        <div class="undo-popover-wrapper">
+          <button
+            class="btn btn--sync"
+            :class="{ 'btn--sync-active': undoStack.lastUndoable.value }"
+            :disabled="!undoStack.lastUndoable.value"
+            @click="toggleUndoPopover"
+            :title="t('undoStack.undoTooltip')"
+          >
+            <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+              <path d="M3.5 6.5A6 6 0 1 1 3.5 11.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/>
+              <path d="M9 6.4V9l2.5 1.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M3.5 3v3.5H7" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+            <span>{{ t('undoStack.undoButton') }}</span>
+          </button>
+
+          <!-- Undo history popover -->
+          <div v-if="showUndoPopover" class="undo-popover">
+            <div class="undo-popover-title">{{ t('undoStack.title') }}</div>
+            <div v-if="undoStack.lastError.value" class="undo-error">{{ undoStack.lastError.value }}</div>
+            <div v-if="undoStack.isLoading.value" class="undo-loading">
+              <div class="mp-spinner"></div>
+            </div>
+            <ul v-else-if="undoStack.entries.value.length > 0" class="undo-list">
+              <li
+                v-for="entry in undoStack.entries.value.slice(0, 20)"
+                :key="entry.index"
+                class="undo-entry"
+                :class="{ 'undo-entry--undoable': undoStack.canUndo(entry) }"
+              >
+                <div class="undo-entry-info">
+                  <span class="undo-entry-type">{{ opLabel(entry.type) }}</span>
+                  <span class="undo-entry-summary mono">{{ entry.summary }}</span>
+                  <span class="undo-entry-date muted">{{ entry.date }}</span>
+                </div>
+                <button
+                  v-if="undoStack.canUndo(entry)"
+                  class="undo-entry-btn"
+                  :class="{ 'undo-entry-btn--hard': isHardUndo(entry) }"
+                  @click="handleUndo(entry)"
+                  :title="t('undoStack.undoButton')"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="none">
+                    <circle cx="9" cy="9" r="6" stroke="currentColor" stroke-width="1.4" fill="none"/>
+                    <path d="M9 6.4V9l2.5 1.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M3.5 3v3.5H7" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                    <path d="M3.5 6.5A6 6 0 019 3" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" fill="none"/>
+                  </svg>
+                </button>
+              </li>
+            </ul>
+            <div v-else class="undo-empty">{{ t('undoStack.noHistory') }}</div>
           </div>
         </div>
 
@@ -1353,5 +1471,141 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .rp-action--remove:hover {
   color: var(--color-danger);
   background: var(--color-danger-soft);
+}
+
+/* ─── Undo popover ──────────────────────────────────── */
+.undo-popover-wrapper {
+  position: relative;
+}
+
+.undo-popover {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 6px;
+  width: 340px;
+  max-height: 420px;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.18);
+  z-index: 200;
+  overflow: hidden;
+}
+
+.undo-popover-title {
+  padding: 10px 14px;
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-text);
+}
+
+.undo-error {
+  padding: 8px 14px;
+  font-size: var(--font-size-xs);
+  color: var(--color-danger);
+}
+
+.undo-loading {
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.undo-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.undo-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-bottom: 1px solid var(--color-border-light, var(--color-border));
+  transition: background var(--transition-base);
+}
+
+.undo-entry:last-child {
+  border-bottom: none;
+}
+
+.undo-entry:hover {
+  background: var(--color-bg-tertiary);
+}
+
+.undo-entry-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.undo-entry-type {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.undo-entry-summary {
+  font-size: var(--font-size-sm);
+  color: var(--color-text);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.undo-entry-date {
+  font-size: var(--font-size-xs);
+}
+
+.undo-entry-btn {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-accent);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-base), background var(--transition-base), border-color var(--transition-base);
+}
+
+.undo-entry:hover .undo-entry-btn {
+  opacity: 1;
+}
+
+.undo-entry-btn:hover {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent);
+}
+
+.undo-entry-btn--hard {
+  color: var(--color-warning);
+}
+
+.undo-entry-btn--hard:hover {
+  background: var(--color-warning-soft, rgba(234, 179, 8, 0.1));
+  border-color: var(--color-warning);
+}
+
+.undo-empty {
+  padding: 20px 14px;
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 </style>

--- a/apps/desktop/src/components/AppHeader.vue
+++ b/apps/desktop/src/components/AppHeader.vue
@@ -47,6 +47,7 @@ const emit = defineEmits<{
   deleteBranch: [name: string];
   loadBranches: [];
   undoPerformed: [];
+  openRebase: [];
 }>();
 
 // ─── Recent repos popover (Phase 8.4) ────────────────
@@ -632,6 +633,21 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
             </div>
           </div>
         </div>
+
+        <!-- Rebase interactif (Phase 1.2.1) -->
+        <button
+          class="btn btn--sync"
+          @click="emit('openRebase')"
+          :title="t('rebase.title')"
+        >
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="4" cy="3" r="2" stroke="currentColor" stroke-width="1.3" fill="none"/>
+            <circle cx="4" cy="13" r="2" stroke="currentColor" stroke-width="1.3" fill="none"/>
+            <circle cx="12" cy="8" r="2" stroke="currentColor" stroke-width="1.3" fill="none"/>
+            <path d="M4 5v6M4 5c0 2 2 3 6 3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+          </svg>
+          <span>{{ t('rebase.button') }}</span>
+        </button>
 
         <!-- Undo (Phase 1.2.4) -->
         <div class="undo-popover-wrapper">

--- a/apps/desktop/src/components/RebaseEditor.vue
+++ b/apps/desktop/src/components/RebaseEditor.vue
@@ -6,7 +6,7 @@ import {
   type RebaseTodoEntry,
   type RebaseAction,
 } from "../composables/useInteractiveRebase";
-import type { GitBranch } from "../utils/backend";
+import { getGitBranches, type GitBranch } from "../utils/backend";
 
 const props = defineProps<{
   cwd: string;
@@ -14,12 +14,24 @@ const props = defineProps<{
   branches: GitBranch[];
 }>();
 
+// ─── Local branches (fetched on mount for freshness) ─────────
+const localBranches = ref<GitBranch[]>([]);
+const branchesLoading = ref(false);
+
+async function fetchBranches() {
+  branchesLoading.value = true;
+  try {
+    localBranches.value = await getGitBranches(props.cwd);
+  } catch { /* ignore */ }
+  finally { branchesLoading.value = false; }
+}
+
 const emit = defineEmits<{
   close: [];
   done: [];
 }>();
 
-const { t } = useI18n();
+const { t, locale } = useI18n();
 const rebase = useInteractiveRebase();
 
 // ─── Base selection ──────────────────────────────────────────
@@ -29,8 +41,7 @@ const showBasePicker = ref(true);
 
 const baseCandidates = computed(() => {
   const filter = baseFilter.value.toLowerCase();
-  // Show local branches (except current) + recent tags
-  return props.branches
+  return localBranches.value
     .filter(
       (b) =>
         !b.isCurrent &&
@@ -84,10 +95,26 @@ function onDragEnd() {
 // ─── Actions ─────────────────────────────────────────────────
 const actions: RebaseAction[] = ["pick", "reword", "squash", "fixup", "edit", "drop"];
 
-function cycleAction(index: number) {
-  const current = rebase.todoEntries.value[index].action;
-  const next = actions[(actions.indexOf(current) + 1) % actions.length];
-  rebase.setAction(index, next);
+const actionDescriptions: Record<RebaseAction, { fr: string; en: string }> = {
+  pick:    { fr: "Garder tel quel",               en: "Keep as is" },
+  reword:  { fr: "Modifier le message",           en: "Edit message" },
+  squash:  { fr: "Fusionner (garder les messages)", en: "Merge (keep messages)" },
+  fixup:   { fr: "Fusionner (ignorer le message)", en: "Merge (discard message)" },
+  edit:    { fr: "S\u2019arr\u00eater pour modifier", en: "Pause to edit" },
+  drop:    { fr: "Supprimer le commit",            en: "Remove commit" },
+};
+
+/** Index of the todo item whose action dropdown is open, or null. */
+const actionMenuIndex = ref<number | null>(null);
+
+function toggleActionMenu(index: number) {
+  actionMenuIndex.value = actionMenuIndex.value === index ? null : index;
+}
+
+function pickAction(index: number, action: RebaseAction) {
+  rebase.setAction(index, action);
+  actionMenuIndex.value = null;
+  if (action === "reword") startReword(index);
 }
 
 // ─── Reword inline edit ──────────────────────────────────────
@@ -144,9 +171,12 @@ async function doSkip() {
   }
 }
 
-// ─── Detect existing rebase on open ──────────────────────────
+// ─── Init on open ────────────────────────────────────────────
 onMounted(async () => {
-  await rebase.detectRebaseState(props.cwd);
+  await Promise.all([
+    fetchBranches(),
+    rebase.detectRebaseState(props.cwd),
+  ]);
 });
 
 // Action badge colors
@@ -162,10 +192,20 @@ function actionClass(action: RebaseAction): string {
   return map[action];
 }
 
+// Close action menu on outside click
+function onPanelClick(e: MouseEvent) {
+  const target = e.target as HTMLElement;
+  if (!target.closest(".rb-action-dropdown")) {
+    actionMenuIndex.value = null;
+  }
+}
+
 // Keyboard shortcut: Escape to close
 function onKeydown(e: KeyboardEvent) {
   if (e.key === "Escape") {
-    if (editingIndex.value !== null) {
+    if (actionMenuIndex.value !== null) {
+      actionMenuIndex.value = null;
+    } else if (editingIndex.value !== null) {
       cancelReword();
     } else {
       emit("close");
@@ -178,7 +218,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
 
 <template>
   <div class="rb-overlay" @click.self="emit('close')">
-    <div class="rb-panel" role="dialog" :aria-label="t('rebase.title')">
+    <div class="rb-panel" role="dialog" :aria-label="t('rebase.title')" @click="onPanelClick">
 
       <!-- Header -->
       <div class="rb-header">
@@ -291,15 +331,32 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
               </svg>
             </div>
 
-            <!-- Action badge (click to cycle) -->
-            <button
-              class="rb-action-badge"
-              :class="actionClass(entry.action)"
-              @click="cycleAction(index)"
-              :title="t('rebase.cycleAction')"
-            >
-              {{ entry.action }}
-            </button>
+            <!-- Action badge (click to open dropdown) -->
+            <div class="rb-action-dropdown">
+              <button
+                class="rb-action-badge"
+                :class="actionClass(entry.action)"
+                @click.stop="toggleActionMenu(index)"
+              >
+                {{ entry.action }}
+                <svg width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">
+                  <path d="M1.5 3L4 5.5L6.5 3" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+              <ul v-if="actionMenuIndex === index" class="rb-action-menu">
+                <li
+                  v-for="a in actions"
+                  :key="a"
+                  class="rb-action-menu-item"
+                  :class="[actionClass(a), { 'rb-action-menu-item--active': entry.action === a }]"
+                  @click.stop="pickAction(index, a)"
+                >
+                  <span class="rb-action-menu-dot" :class="actionClass(a)"></span>
+                  <span class="rb-action-menu-name">{{ a }}</span>
+                  <span class="rb-action-menu-desc">{{ locale.startsWith('fr') ? actionDescriptions[a].fr : actionDescriptions[a].en }}</span>
+                </li>
+              </ul>
+            </div>
 
             <!-- Commit info -->
             <span class="rb-hash mono">{{ entry.hash }}</span>
@@ -347,6 +404,15 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
                 <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
               </button>
             </div>
+          </div>
+        </div>
+
+        <!-- Legend -->
+        <div class="rb-legend">
+          <div v-for="a in actions" :key="a" class="rb-legend-item">
+            <span class="rb-legend-dot" :class="actionClass(a)"></span>
+            <span class="rb-legend-name">{{ a }}</span>
+            <span class="rb-legend-desc">{{ locale.startsWith('fr') ? actionDescriptions[a].fr : actionDescriptions[a].en }}</span>
           </div>
         </div>
 
@@ -595,6 +661,73 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
   color: var(--color-danger, #da3633);
 }
 
+/* ─── Action dropdown ──────────────────────────────────────── */
+.rb-action-dropdown {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.rb-action-badge svg {
+  margin-left: 2px;
+  opacity: 0.6;
+}
+
+.rb-action-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  min-width: 220px;
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+  list-style: none;
+  padding: 4px 0;
+  z-index: 10;
+}
+
+.rb-action-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  transition: background 0.1s;
+  background: none !important;
+  color: var(--color-text) !important;
+}
+.rb-action-menu-item:hover {
+  background: var(--color-bg-secondary) !important;
+}
+.rb-action-menu-item--active {
+  font-weight: 600;
+}
+
+.rb-action-menu-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.rb-action-menu-dot.rb-action--pick { background: var(--color-success, #2ea043); }
+.rb-action-menu-dot.rb-action--reword { background: #8250df; }
+.rb-action-menu-dot.rb-action--squash { background: #da821a; }
+.rb-action-menu-dot.rb-action--fixup { background: #828282; }
+.rb-action-menu-dot.rb-action--edit { background: #3884ff; }
+.rb-action-menu-dot.rb-action--drop { background: var(--color-danger, #da3633); }
+
+.rb-action-menu-name {
+  font-weight: 600;
+  min-width: 48px;
+}
+
+.rb-action-menu-desc {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
 /* ─── Commit info ──────────────────────────────────────────── */
 .rb-hash {
   font-size: var(--font-size-xs);
@@ -667,6 +800,46 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
 }
 .rb-item-btn--drop:hover {
   color: var(--color-danger);
+}
+
+/* ─── Legend ────────────────────────────────────────────────── */
+.rb-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+  padding: 8px 20px;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+}
+
+.rb-legend-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+}
+
+.rb-legend-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.rb-legend-dot.rb-action--pick { background: var(--color-success, #2ea043); }
+.rb-legend-dot.rb-action--reword { background: #8250df; }
+.rb-legend-dot.rb-action--squash { background: #da821a; }
+.rb-legend-dot.rb-action--fixup { background: #828282; }
+.rb-legend-dot.rb-action--edit { background: #3884ff; }
+.rb-legend-dot.rb-action--drop { background: var(--color-danger, #da3633); }
+
+.rb-legend-name {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.rb-legend-desc {
+  color: var(--color-text-muted);
 }
 
 /* ─── Action bar ───────────────────────────────────────────── */

--- a/apps/desktop/src/components/RebaseEditor.vue
+++ b/apps/desktop/src/components/RebaseEditor.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted, onUnmounted } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useI18n } from "../composables/useI18n";
 import {
   useInteractiveRebase,

--- a/apps/desktop/src/components/RebaseEditor.vue
+++ b/apps/desktop/src/components/RebaseEditor.vue
@@ -1,0 +1,797 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onUnmounted } from "vue";
+import { useI18n } from "../composables/useI18n";
+import {
+  useInteractiveRebase,
+  type RebaseTodoEntry,
+  type RebaseAction,
+} from "../composables/useInteractiveRebase";
+import type { GitBranch } from "../utils/backend";
+
+const props = defineProps<{
+  cwd: string;
+  currentBranch: string;
+  branches: GitBranch[];
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  done: [];
+}>();
+
+const { t } = useI18n();
+const rebase = useInteractiveRebase();
+
+// ─── Base selection ──────────────────────────────────────────
+const baseInput = ref("");
+const baseFilter = ref("");
+const showBasePicker = ref(true);
+
+const baseCandidates = computed(() => {
+  const filter = baseFilter.value.toLowerCase();
+  // Show local branches (except current) + recent tags
+  return props.branches
+    .filter(
+      (b) =>
+        !b.isCurrent &&
+        !b.isRemote &&
+        b.name.toLowerCase().includes(filter),
+    )
+    .map((b) => b.name);
+});
+
+async function selectBase(name: string) {
+  baseInput.value = name;
+  showBasePicker.value = false;
+  await rebase.listCommits(props.cwd, name);
+}
+
+// ─── Drag & drop ─────────────────────────────────────────────
+const dragIndex = ref<number | null>(null);
+const dragOverIndex = ref<number | null>(null);
+
+function onDragStart(index: number, e: DragEvent) {
+  dragIndex.value = index;
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = "move";
+    e.dataTransfer.setData("text/plain", String(index));
+  }
+}
+
+function onDragOver(index: number, e: DragEvent) {
+  e.preventDefault();
+  dragOverIndex.value = index;
+}
+
+function onDragLeave() {
+  dragOverIndex.value = null;
+}
+
+function onDrop(toIndex: number, e: DragEvent) {
+  e.preventDefault();
+  if (dragIndex.value !== null && dragIndex.value !== toIndex) {
+    rebase.moveEntry(dragIndex.value, toIndex);
+  }
+  dragIndex.value = null;
+  dragOverIndex.value = null;
+}
+
+function onDragEnd() {
+  dragIndex.value = null;
+  dragOverIndex.value = null;
+}
+
+// ─── Actions ─────────────────────────────────────────────────
+const actions: RebaseAction[] = ["pick", "reword", "squash", "fixup", "edit", "drop"];
+
+function cycleAction(index: number) {
+  const current = rebase.todoEntries.value[index].action;
+  const next = actions[(actions.indexOf(current) + 1) % actions.length];
+  rebase.setAction(index, next);
+}
+
+// ─── Reword inline edit ──────────────────────────────────────
+const editingIndex = ref<number | null>(null);
+const editMessage = ref("");
+
+function startReword(index: number) {
+  rebase.setAction(index, "reword");
+  editingIndex.value = index;
+  editMessage.value = rebase.todoEntries.value[index].newMessage || rebase.todoEntries.value[index].message;
+}
+
+function confirmReword() {
+  if (editingIndex.value !== null) {
+    rebase.setNewMessage(editingIndex.value, editMessage.value);
+    editingIndex.value = null;
+  }
+}
+
+function cancelReword() {
+  editingIndex.value = null;
+}
+
+// ─── Start / In-progress actions ─────────────────────────────
+
+async function startRebase() {
+  const result = await rebase.startRebase(
+    props.cwd,
+    baseInput.value,
+    rebase.todoEntries.value,
+  );
+  if (result.success && !result.conflict) {
+    emit("done");
+  }
+  // If conflict, the progress state will be detected and UI adapts
+}
+
+async function doContinue() {
+  const result = await rebase.rebaseContinue(props.cwd);
+  if (result.success && !result.conflict) {
+    emit("done");
+  }
+}
+
+async function doAbort() {
+  await rebase.rebaseAbort(props.cwd);
+  emit("done");
+}
+
+async function doSkip() {
+  const result = await rebase.rebaseSkip(props.cwd);
+  if (result.success && !result.conflict) {
+    emit("done");
+  }
+}
+
+// ─── Detect existing rebase on open ──────────────────────────
+onMounted(async () => {
+  await rebase.detectRebaseState(props.cwd);
+});
+
+// Action badge colors
+function actionClass(action: RebaseAction): string {
+  const map: Record<RebaseAction, string> = {
+    pick: "rb-action--pick",
+    reword: "rb-action--reword",
+    squash: "rb-action--squash",
+    fixup: "rb-action--fixup",
+    edit: "rb-action--edit",
+    drop: "rb-action--drop",
+  };
+  return map[action];
+}
+
+// Keyboard shortcut: Escape to close
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape") {
+    if (editingIndex.value !== null) {
+      cancelReword();
+    } else {
+      emit("close");
+    }
+  }
+}
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onUnmounted(() => window.removeEventListener("keydown", onKeydown));
+</script>
+
+<template>
+  <div class="rb-overlay" @click.self="emit('close')">
+    <div class="rb-panel" role="dialog" :aria-label="t('rebase.title')">
+
+      <!-- Header -->
+      <div class="rb-header">
+        <h2 class="rb-title">{{ t('rebase.title') }}</h2>
+        <button class="rb-close" @click="emit('close')" :aria-label="t('common.close')">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+            <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- In-progress rebase banner -->
+      <div v-if="rebase.progress.value?.inProgress" class="rb-progress-banner">
+        <div class="rb-progress-icon">
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <path d="M8 1v6l4 2" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+            <circle cx="8" cy="8" r="7" stroke="currentColor" stroke-width="1.5" fill="none"/>
+          </svg>
+        </div>
+        <div class="rb-progress-text">
+          <strong>{{ t('rebase.inProgress') }}</strong>
+          <span v-if="rebase.progress.value.headName"> — {{ rebase.progress.value.headName }}</span>
+          <span v-if="rebase.progress.value.step"> ({{ rebase.progress.value.step }}/{{ rebase.progress.value.total }})</span>
+        </div>
+        <div v-if="rebase.progress.value.hasConflict" class="rb-conflict-badge">
+          {{ t('rebase.conflict') }}
+        </div>
+      </div>
+
+      <!-- In-progress actions -->
+      <div v-if="rebase.progress.value?.inProgress" class="rb-progress-actions">
+        <button class="rb-btn rb-btn--primary" @click="doContinue" :disabled="rebase.isRunning.value">
+          {{ t('rebase.continue') }}
+        </button>
+        <button class="rb-btn rb-btn--secondary" @click="doSkip" :disabled="rebase.isRunning.value">
+          {{ t('rebase.skip') }}
+        </button>
+        <button class="rb-btn rb-btn--danger" @click="doAbort" :disabled="rebase.isRunning.value">
+          {{ t('rebase.abort') }}
+        </button>
+      </div>
+
+      <!-- Base selection -->
+      <template v-if="showBasePicker && !rebase.progress.value?.inProgress">
+        <div class="rb-section">
+          <label class="rb-label">{{ t('rebase.baseLabel') }}</label>
+          <p class="rb-hint">{{ t('rebase.baseHint') }}</p>
+          <input
+            class="rb-base-input mono"
+            v-model="baseFilter"
+            :placeholder="t('rebase.basePlaceholder')"
+            autofocus
+          />
+          <ul class="rb-base-list" v-if="baseCandidates.length > 0">
+            <li
+              v-for="name in baseCandidates"
+              :key="name"
+              class="rb-base-item"
+              @click="selectBase(name)"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <circle cx="5" cy="4" r="2" stroke="currentColor" stroke-width="1.3"/>
+                <circle cx="5" cy="12" r="2" stroke="currentColor" stroke-width="1.3"/>
+                <path d="M5 6v4" stroke="currentColor" stroke-width="1.3"/>
+              </svg>
+              <span class="mono">{{ name }}</span>
+            </li>
+          </ul>
+        </div>
+      </template>
+
+      <!-- Commit list (todo editor) -->
+      <template v-if="rebase.todoEntries.value.length > 0 && !rebase.progress.value?.inProgress">
+        <div class="rb-section">
+          <div class="rb-section-header">
+            <label class="rb-label">
+              {{ t('rebase.commitsLabel') }}
+              <span class="rb-count">({{ rebase.todoEntries.value.length }})</span>
+            </label>
+            <button class="rb-back-btn" @click="showBasePicker = true; rebase.reset()">
+              {{ t('rebase.changeBase') }}
+            </button>
+          </div>
+          <p class="rb-hint">{{ t('rebase.commitsHint') }}</p>
+        </div>
+
+        <div class="rb-todo-list">
+          <div
+            v-for="(entry, index) in rebase.todoEntries.value"
+            :key="entry.fullHash"
+            class="rb-todo-item"
+            :class="{
+              'rb-todo-item--dragging': dragIndex === index,
+              'rb-todo-item--drag-over': dragOverIndex === index,
+              'rb-todo-item--drop': entry.action === 'drop',
+            }"
+            draggable="true"
+            @dragstart="onDragStart(index, $event)"
+            @dragover="onDragOver(index, $event)"
+            @dragleave="onDragLeave"
+            @drop="onDrop(index, $event)"
+            @dragend="onDragEnd"
+          >
+            <!-- Drag handle -->
+            <div class="rb-drag-handle" :title="t('rebase.dragHint')">
+              <svg width="8" height="14" viewBox="0 0 8 14" fill="currentColor" opacity="0.4">
+                <circle cx="2" cy="2" r="1.2"/><circle cx="6" cy="2" r="1.2"/>
+                <circle cx="2" cy="7" r="1.2"/><circle cx="6" cy="7" r="1.2"/>
+                <circle cx="2" cy="12" r="1.2"/><circle cx="6" cy="12" r="1.2"/>
+              </svg>
+            </div>
+
+            <!-- Action badge (click to cycle) -->
+            <button
+              class="rb-action-badge"
+              :class="actionClass(entry.action)"
+              @click="cycleAction(index)"
+              :title="t('rebase.cycleAction')"
+            >
+              {{ entry.action }}
+            </button>
+
+            <!-- Commit info -->
+            <span class="rb-hash mono">{{ entry.hash }}</span>
+
+            <!-- Message (inline edit when reword) -->
+            <template v-if="editingIndex === index">
+              <input
+                class="rb-reword-input mono"
+                v-model="editMessage"
+                @keydown.enter="confirmReword"
+                @keydown.escape="cancelReword"
+                autofocus
+              />
+              <button class="rb-reword-ok" @click="confirmReword" :title="t('common.confirm')">
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2.5 6.5L5 9l4.5-6" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+            </template>
+            <template v-else>
+              <span
+                class="rb-message"
+                :class="{ 'rb-message--reword': entry.action === 'reword' && entry.newMessage }"
+                @dblclick="startReword(index)"
+              >
+                {{ entry.action === 'reword' && entry.newMessage ? entry.newMessage : entry.message }}
+              </span>
+            </template>
+
+            <span class="rb-meta muted">{{ entry.author }} · {{ entry.date }}</span>
+
+            <!-- Quick action buttons -->
+            <div class="rb-item-actions">
+              <button
+                v-if="entry.action !== 'reword'"
+                class="rb-item-btn"
+                @click="startReword(index)"
+                :title="t('rebase.reword')"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M7.5 2l2.5 2.5-6 6H1.5V8l6-6z" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/></svg>
+              </button>
+              <button
+                class="rb-item-btn rb-item-btn--drop"
+                @click="rebase.setAction(index, entry.action === 'drop' ? 'pick' : 'drop')"
+                :title="entry.action === 'drop' ? t('rebase.restore') : t('rebase.drop')"
+              >
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M3 3l6 6M9 3l-6 6" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Action bar -->
+        <div class="rb-action-bar">
+          <span v-if="rebase.error.value" class="rb-error">{{ rebase.error.value }}</span>
+          <div class="rb-action-bar-right">
+            <button class="rb-btn rb-btn--secondary" @click="emit('close')">
+              {{ t('common.cancel') }}
+            </button>
+            <button
+              class="rb-btn rb-btn--primary"
+              @click="startRebase"
+              :disabled="rebase.isRunning.value"
+            >
+              <template v-if="rebase.isRunning.value">{{ t('rebase.running') }}</template>
+              <template v-else>{{ t('rebase.start') }}</template>
+            </button>
+          </div>
+        </div>
+      </template>
+
+      <!-- Loading -->
+      <div v-if="rebase.isLoading.value" class="rb-loading">
+        <div class="rb-spinner"></div>
+        {{ t('common.loading') }}
+      </div>
+
+      <!-- Error -->
+      <div v-if="rebase.error.value && !rebase.todoEntries.value.length && !rebase.progress.value?.inProgress" class="rb-error-box">
+        {{ rebase.error.value }}
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+/* ─── Overlay ──────────────────────────────────────────────── */
+.rb-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+
+.rb-panel {
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  width: min(640px, 90vw);
+  max-height: 80vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.25);
+}
+
+/* ─── Header ───────────────────────────────────────────────── */
+.rb-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rb-title {
+  font-size: 15px;
+  font-weight: 600;
+  margin: 0;
+}
+
+.rb-close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 4px;
+  border-radius: var(--radius-sm);
+}
+.rb-close:hover {
+  color: var(--color-text);
+  background: var(--color-bg-secondary);
+}
+
+/* ─── Sections ─────────────────────────────────────────────── */
+.rb-section {
+  padding: 12px 20px;
+}
+
+.rb-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.rb-label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--color-text-muted);
+}
+
+.rb-count {
+  font-weight: 400;
+  opacity: 0.7;
+}
+
+.rb-hint {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 4px 0 8px;
+}
+
+.rb-back-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  color: var(--color-accent);
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+}
+.rb-back-btn:hover {
+  background: var(--color-bg-secondary);
+}
+
+/* ─── Base picker ──────────────────────────────────────────── */
+.rb-base-input {
+  width: 100%;
+  padding: 8px 10px;
+  font-size: var(--font-size-sm);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  outline: none;
+}
+.rb-base-input:focus {
+  border-color: var(--color-accent);
+}
+
+.rb-base-list {
+  list-style: none;
+  padding: 0;
+  margin: 6px 0 0;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.rb-base-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background 0.1s;
+}
+.rb-base-item:hover {
+  background: var(--color-bg-secondary);
+}
+
+/* ─── Todo list ────────────────────────────────────────────── */
+.rb-todo-list {
+  flex: 1;
+  overflow-y: auto;
+  padding: 0 12px;
+}
+
+.rb-todo-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  transition: background 0.1s, opacity 0.15s;
+  cursor: default;
+}
+.rb-todo-item:hover {
+  background: var(--color-bg-secondary);
+}
+.rb-todo-item--dragging {
+  opacity: 0.4;
+}
+.rb-todo-item--drag-over {
+  border-top: 2px solid var(--color-accent);
+}
+.rb-todo-item--drop {
+  opacity: 0.45;
+  text-decoration: line-through;
+}
+
+/* ─── Drag handle ──────────────────────────────────────────── */
+.rb-drag-handle {
+  cursor: grab;
+  padding: 2px 4px;
+  flex-shrink: 0;
+}
+.rb-drag-handle:active {
+  cursor: grabbing;
+}
+
+/* ─── Action badge ─────────────────────────────────────────── */
+.rb-action-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: none;
+  cursor: pointer;
+  min-width: 48px;
+  text-align: center;
+  flex-shrink: 0;
+  transition: all 0.1s;
+}
+
+.rb-action--pick {
+  background: var(--color-success-bg, rgba(46, 160, 67, 0.15));
+  color: var(--color-success, #2ea043);
+}
+.rb-action--reword {
+  background: rgba(130, 80, 223, 0.15);
+  color: #8250df;
+}
+.rb-action--squash {
+  background: rgba(218, 130, 25, 0.15);
+  color: #da821a;
+}
+.rb-action--fixup {
+  background: rgba(130, 130, 130, 0.15);
+  color: var(--color-text-muted);
+}
+.rb-action--edit {
+  background: rgba(56, 132, 255, 0.15);
+  color: #3884ff;
+}
+.rb-action--drop {
+  background: rgba(218, 54, 51, 0.15);
+  color: var(--color-danger, #da3633);
+}
+
+/* ─── Commit info ──────────────────────────────────────────── */
+.rb-hash {
+  font-size: var(--font-size-xs);
+  color: var(--color-accent);
+  flex-shrink: 0;
+}
+
+.rb-message {
+  font-size: var(--font-size-sm);
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: text;
+}
+.rb-message--reword {
+  color: #8250df;
+  font-style: italic;
+}
+
+.rb-meta {
+  font-size: var(--font-size-xs);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* ─── Reword inline edit ───────────────────────────────────── */
+.rb-reword-input {
+  flex: 1;
+  font-size: var(--font-size-sm);
+  padding: 2px 6px;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-accent);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  outline: none;
+}
+
+.rb-reword-ok {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-success);
+  padding: 2px;
+}
+
+/* ─── Item quick actions ───────────────────────────────────── */
+.rb-item-actions {
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity 0.1s;
+  flex-shrink: 0;
+}
+.rb-todo-item:hover .rb-item-actions {
+  opacity: 1;
+}
+
+.rb-item-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  padding: 3px;
+  border-radius: var(--radius-sm);
+}
+.rb-item-btn:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text);
+}
+.rb-item-btn--drop:hover {
+  color: var(--color-danger);
+}
+
+/* ─── Action bar ───────────────────────────────────────────── */
+.rb-action-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px;
+  border-top: 1px solid var(--color-border);
+  gap: 12px;
+}
+
+.rb-action-bar-right {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.rb-btn {
+  padding: 6px 14px;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.rb-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.rb-btn--primary {
+  background: var(--color-accent);
+  color: #fff;
+  border-color: var(--color-accent);
+}
+.rb-btn--primary:hover:not(:disabled) {
+  filter: brightness(1.1);
+}
+
+.rb-btn--secondary {
+  background: var(--color-bg-secondary);
+  color: var(--color-text);
+}
+.rb-btn--secondary:hover:not(:disabled) {
+  background: var(--color-bg-tertiary);
+}
+
+.rb-btn--danger {
+  background: none;
+  color: var(--color-danger);
+  border-color: var(--color-danger);
+}
+.rb-btn--danger:hover:not(:disabled) {
+  background: rgba(218, 54, 51, 0.1);
+}
+
+/* ─── Progress banner ──────────────────────────────────────── */
+.rb-progress-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 20px;
+  background: rgba(218, 130, 25, 0.1);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.rb-progress-icon {
+  color: #da821a;
+}
+
+.rb-progress-text {
+  font-size: var(--font-size-sm);
+  flex: 1;
+}
+
+.rb-conflict-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 8px;
+  border-radius: 3px;
+  background: rgba(218, 54, 51, 0.15);
+  color: var(--color-danger);
+}
+
+.rb-progress-actions {
+  display: flex;
+  gap: 8px;
+  padding: 12px 20px;
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* ─── Loading / Error ──────────────────────────────────────── */
+.rb-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 20px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.rb-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent);
+  border-radius: 50%;
+  animation: rb-spin 0.6s linear infinite;
+}
+
+@keyframes rb-spin {
+  to { transform: rotate(360deg); }
+}
+
+.rb-error {
+  font-size: var(--font-size-sm);
+  color: var(--color-danger);
+}
+
+.rb-error-box {
+  padding: 16px 20px;
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
+}
+</style>

--- a/apps/desktop/src/components/RebaseEditor.vue
+++ b/apps/desktop/src/components/RebaseEditor.vue
@@ -106,9 +106,38 @@ const actionDescriptions: Record<RebaseAction, { fr: string; en: string }> = {
 
 /** Index of the todo item whose action dropdown is open, or null. */
 const actionMenuIndex = ref<number | null>(null);
+const actionMenuStyle = ref<Record<string, string>>({});
 
-function toggleActionMenu(index: number) {
-  actionMenuIndex.value = actionMenuIndex.value === index ? null : index;
+function toggleActionMenu(index: number, e: MouseEvent) {
+  if (actionMenuIndex.value === index) {
+    actionMenuIndex.value = null;
+    return;
+  }
+  actionMenuIndex.value = index;
+
+  // Position the menu near the badge, using fixed positioning
+  const btn = e.currentTarget as HTMLElement;
+  const rect = btn.getBoundingClientRect();
+  const spaceBelow = window.innerHeight - rect.bottom;
+  const menuHeight = 220; // approximate
+
+  if (spaceBelow < menuHeight) {
+    // Open above
+    actionMenuStyle.value = {
+      position: "fixed",
+      left: `${rect.left}px`,
+      bottom: `${window.innerHeight - rect.top + 4}px`,
+      top: "auto",
+    };
+  } else {
+    // Open below
+    actionMenuStyle.value = {
+      position: "fixed",
+      left: `${rect.left}px`,
+      top: `${rect.bottom + 4}px`,
+      bottom: "auto",
+    };
+  }
 }
 
 function pickAction(index: number, action: RebaseAction) {
@@ -336,14 +365,14 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
               <button
                 class="rb-action-badge"
                 :class="actionClass(entry.action)"
-                @click.stop="toggleActionMenu(index)"
+                @click.stop="toggleActionMenu(index, $event)"
               >
                 {{ entry.action }}
                 <svg width="8" height="8" viewBox="0 0 8 8" fill="none" aria-hidden="true">
                   <path d="M1.5 3L4 5.5L6.5 3" stroke="currentColor" stroke-width="1" stroke-linecap="round" stroke-linejoin="round"/>
                 </svg>
               </button>
-              <ul v-if="actionMenuIndex === index" class="rb-action-menu">
+              <ul v-if="actionMenuIndex === index" class="rb-action-menu" :style="actionMenuStyle">
                 <li
                   v-for="a in actions"
                   :key="a"
@@ -673,10 +702,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
 }
 
 .rb-action-menu {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  margin-top: 4px;
+  /* position is set inline (fixed) */
   min-width: 220px;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
@@ -684,7 +710,7 @@ onUnmounted(() => window.removeEventListener("keydown", onKeydown));
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
   list-style: none;
   padding: 4px 0;
-  z-index: 10;
+  z-index: 300;
 }
 
 .rb-action-menu-item {

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -156,6 +156,36 @@ const { isGenerating, lastError: aiError, generate: generateCommitMsg, transform
 const aiMenuOpen = ref(false);
 const aiLangMenuOpen = ref(false);
 
+/** Read the commit-message language from settings (empty string = follow UI locale). */
+function getCommitMessageLang(): string {
+  try {
+    const raw = localStorage.getItem("gitwand-settings");
+    if (raw) {
+      const s = JSON.parse(raw);
+      if (s.commitMessageLang) return s.commitMessageLang;
+    }
+  } catch { /* ignore */ }
+  return "";
+}
+
+/** Resolve the effective language code for AI generation. */
+function resolveCommitLang(): string {
+  const explicit = getCommitMessageLang();
+  if (explicit) return explicit;
+  // Fallback: derive from UI locale
+  return locale.value.startsWith("en") ? "en" : locale.value.split("-")[0] || "fr";
+}
+
+/** Persist the commit-message language setting. */
+function setCommitMessageLang(lang: string) {
+  try {
+    const raw = localStorage.getItem("gitwand-settings");
+    const s = raw ? JSON.parse(raw) : {};
+    s.commitMessageLang = lang;
+    localStorage.setItem("gitwand-settings", JSON.stringify(s));
+  } catch { /* ignore */ }
+}
+
 /** Close AI menu when clicking outside */
 function onDocClick(e: MouseEvent) {
   const target = e.target as HTMLElement;
@@ -170,16 +200,27 @@ onUnmounted(() => document.removeEventListener("click", onDocClick));
 function applyMessage(msg: string) {
   const [summary, ...rest] = msg.split("\n");
   emit("update:commitSummary", summary.trim());
-  const body = rest.join("\n").trim();
+  let body = rest.join("\n").trim();
+
+  // Append signature if setting is enabled
+  try {
+    const raw = localStorage.getItem("gitwand-settings");
+    const sig = !raw || JSON.parse(raw).commitSignature !== false;
+    if (sig) {
+      const signature = "\u{1FA84} Commit via GitWand";
+      body = body ? `${body}\n\n${signature}` : signature;
+    }
+  } catch { /* ignore */ }
+
   emit("update:commitDescription", body);
 }
 
 async function onGenerateCommitMessage() {
   if (!props.cwd || isGenerating.value) return;
   aiMenuOpen.value = false;
-  const lang = locale.value.startsWith("en") ? "en" : "fr";
+  const lang = resolveCommitLang();
   try {
-    const msg = await generateCommitMsg(props.cwd, { locale: lang as "fr" | "en" });
+    const msg = await generateCommitMsg(props.cwd, { locale: lang as string });
     applyMessage(msg);
   } catch {
     // lastError is already set by the composable — the UI shows it.
@@ -193,6 +234,10 @@ async function onAiAction(action: "regenerate" | "shorten" | "detail" | "changeL
   if (action === "regenerate") {
     await onGenerateCommitMessage();
     return;
+  }
+  // When changing language, also persist as new default
+  if (action === "changeLang" && targetLocale) {
+    setCommitMessageLang(targetLocale);
   }
   const currentMsg = [props.commitSummary, props.commitDescription].filter(Boolean).join("\n");
   if (!currentMsg.trim()) return;
@@ -535,7 +580,8 @@ function formatActivityDate(dateStr: string): string {
               {{ t('sidebar.aiChangeLang') }}
               <svg class="commit-ai-menu-arrow" width="8" height="8" viewBox="0 0 8 8" fill="none"><path d="M3 1.5L5.5 4L3 6.5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/></svg>
               <ul v-if="aiLangMenuOpen" class="commit-ai-submenu">
-                <li v-for="loc in supportedLocales" :key="loc" @click.stop="onAiAction('changeLang', loc)">
+                <li v-for="loc in supportedLocales" :key="loc" @click.stop="onAiAction('changeLang', loc)" :class="{ 'is-active': loc === resolveCommitLang() }">
+                  <svg v-if="loc === resolveCommitLang()" class="commit-ai-check" width="12" height="12" viewBox="0 0 12 12" fill="none"><path d="M2.5 6.5L5 9l4.5-6" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/></svg>
                   {{ localeLabels[loc] }}
                 </li>
               </ul>
@@ -1292,7 +1338,7 @@ function formatActivityDate(dateStr: string): string {
 .commit-ai-submenu li {
   display: flex;
   align-items: center;
-  padding: 6px 12px;
+  padding: 6px 12px 6px 30px;
   font-size: var(--font-size-sm);
   color: var(--color-text);
   cursor: pointer;
@@ -1301,6 +1347,16 @@ function formatActivityDate(dateStr: string): string {
 
 .commit-ai-submenu li:hover {
   background: var(--color-bg-tertiary);
+}
+
+.commit-ai-submenu li.is-active {
+  font-weight: 600;
+  padding-left: 12px;
+}
+
+.commit-ai-check {
+  margin-right: 6px;
+  flex-shrink: 0;
 }
 
 .commit-ai-error {

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -551,7 +551,7 @@ function formatActivityDate(dateStr: string): string {
         @input="onDescriptionInput"
         @keydown="onCommitKeydown"
         :placeholder="t('sidebar.descriptionPlaceholder')"
-        rows="2"
+        rows="4"
       ></textarea>
       <div class="commit-actions">
         <button

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -8,6 +8,7 @@ import { useI18n } from "../composables/useI18n";
 import { useCommitMessage } from "../composables/useCommitMessage";
 import { useAIProvider } from "../composables/useAIProvider";
 import { supportedLocales, localeLabels } from "../locales";
+import { useAbsorb, type AbsorbCandidate } from "../composables/useAbsorb";
 
 const props = defineProps<{
   /** Repo directory, used by AI commit message generation. */
@@ -63,6 +64,8 @@ const emit = defineEmits<{
   discard: [path: string, section: string];
   /** Append file path to .gitignore */
   addToGitignore: [path: string];
+  /** Request a full repo state refresh (after absorb, etc.) */
+  refresh: [];
 }>();
 
 const { t, locale } = useI18n();
@@ -96,6 +99,43 @@ function onCtxGitignore() {
   if (!ctxMenu.value.file) return;
   emit("addToGitignore", ctxMenu.value.file.path);
   closeContextMenu();
+}
+
+// ─── Absorb ────────────────────────────────────────────
+const absorbApi = useAbsorb();
+const absorbCandidate = ref<AbsorbCandidate | null>(null);
+const absorbError = ref<string | null>(null);
+
+async function onCtxAbsorb() {
+  const file = ctxMenu.value.file;
+  if (!file || !props.cwd) return;
+  closeContextMenu();
+  absorbCandidate.value = null;
+  absorbError.value = null;
+
+  try {
+    const staged = file.section === "staged";
+    const results = await absorbApi.analyze(props.cwd, [file.path], staged);
+    if (results.length === 0) {
+      absorbError.value = t("absorb.noCandidate");
+      return;
+    }
+    absorbCandidate.value = results[0];
+    // Confirm
+    const msg = t("absorb.confirmDesc")
+      .replace("{0}", file.path)
+      .replace("{1}", results[0].targetShortHash + " " + results[0].targetMessage);
+    if (!confirm(msg)) {
+      absorbCandidate.value = null;
+      return;
+    }
+    await absorbApi.absorb(props.cwd, results[0]);
+    absorbCandidate.value = null;
+    // Trigger repo refresh
+    emit("refresh");
+  } catch (err: unknown) {
+    absorbError.value = err instanceof Error ? err.message : String(err);
+  }
 }
 
 onMounted(() => {
@@ -726,6 +766,23 @@ function formatActivityDate(dateStr: string): string {
 
       <!-- Separator -->
       <div class="ctx-separator" v-if="ctxMenu.file.section !== 'staged'"></div>
+
+      <!-- Absorb into original commit -->
+      <button
+        v-if="ctxMenu.file.section === 'unstaged' || ctxMenu.file.section === 'staged'"
+        class="ctx-item"
+        @click="onCtxAbsorb"
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <circle cx="8" cy="4" r="2.5" stroke="currentColor" stroke-width="1.3"/>
+          <circle cx="8" cy="12" r="2.5" stroke="currentColor" stroke-width="1.3"/>
+          <path d="M8 6.5v3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+          <path d="M5.5 8l2.5 2 2.5-2" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>{{ t('absorb.action') }}</span>
+      </button>
+
+      <div class="ctx-separator" v-if="ctxMenu.file.section === 'unstaged' || ctxMenu.file.section === 'staged'"></div>
 
       <!-- Add to .gitignore -->
       <button class="ctx-item" @click="onCtxGitignore">

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -40,6 +40,7 @@ interface Settings {
   gitPath: string;
   defaultBranch: string;
   commitSignature: boolean;
+  commitMessageLang: string; // "" = follow UI locale
   diffMode: DiffMode;
   pullMode: PullMode;
   switchBehavior: SwitchBehavior;
@@ -61,6 +62,7 @@ const defaultSettings: Settings = {
   gitPath: "",
   defaultBranch: "main",
   commitSignature: true,
+  commitMessageLang: "",
   diffMode: "inline",
   pullMode: "merge",
   switchBehavior: "ask",
@@ -400,13 +402,27 @@ function onKeyDown(e: KeyboardEvent) {
 
         <!-- ═══ GÉNÉRAL ═══ -->
         <template v-if="activeSettingsTab === 'general'">
-          <!-- Language -->
+          <!-- Interface language -->
           <div class="sp-row">
             <label class="sp-label" for="setting-lang">{{ t('settings.language') }}</label>
             <select id="setting-lang" class="sp-select" v-model="selectedLocale">
               <option value="auto">{{ t('settings.languageAuto') }}</option>
               <option v-for="loc in supportedLocales" :key="loc" :value="loc">{{ localeLabels[loc] }}</option>
             </select>
+          </div>
+
+          <!-- Commit message language -->
+          <div class="sp-row">
+            <label class="sp-label" for="setting-commit-lang">{{ t('settings.commitMessageLang') }}</label>
+            <select
+              id="setting-commit-lang" class="sp-select"
+              :value="settings.commitMessageLang"
+              @change="updateSetting('commitMessageLang', ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="">{{ t('settings.commitMessageLangAuto') }}</option>
+              <option v-for="loc in supportedLocales" :key="loc" :value="loc">{{ localeLabels[loc] }}</option>
+            </select>
+            <span class="sp-hint">{{ t('settings.commitMessageLangHint') }}</span>
           </div>
 
           <!-- Theme -->
@@ -1038,6 +1054,9 @@ function onKeyDown(e: KeyboardEvent) {
 .sp-hint {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+}
+
+.sp-row--checkbox .sp-hint {
   padding-left: var(--space-8);
 }
 

--- a/apps/desktop/src/composables/useAbsorb.ts
+++ b/apps/desktop/src/composables/useAbsorb.ts
@@ -1,0 +1,303 @@
+import { ref } from "vue";
+import { gitExec } from "../utils/backend";
+
+/**
+ * Absorb — automatically amend unstaged/staged changes into the commit
+ * that last touched the modified lines, inspired by GitButler's absorb
+ * and `git absorb`.
+ *
+ * Flow:
+ * 1. `git diff` (or `git diff --cached`) → find changed line ranges per file
+ * 2. `git blame -L <range>` on the original version → find candidate commits
+ * 3. If a single commit owns all changed lines in a hunk, it's a candidate
+ * 4. Create fixup commits: `git commit --fixup=<hash>`
+ * 5. Optionally autosquash: `git rebase -i --autosquash <base>`
+ *
+ * The composable exposes `analyze` (find candidates) and `absorb` (execute).
+ */
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface AbsorbCandidate {
+  /** File path relative to repo root. */
+  filePath: string;
+  /** Target commit hash to absorb into. */
+  targetHash: string;
+  /** Short hash for display. */
+  targetShortHash: string;
+  /** Target commit subject line. */
+  targetMessage: string;
+  /** Number of hunks that would be absorbed. */
+  hunkCount: number;
+  /** Changed line ranges (for display). */
+  lineRanges: string[];
+}
+
+export interface AbsorbResult {
+  /** Files that were absorbed. */
+  absorbed: AbsorbCandidate[];
+  /** Files that could not be absorbed (multi-commit hunks, etc.). */
+  skipped: { filePath: string; reason: string }[];
+}
+
+// ─── Helpers ────────────────────────────────────────────
+
+interface DiffHunk {
+  filePath: string;
+  /** Original file line start. */
+  origStart: number;
+  /** Number of lines in original. */
+  origCount: number;
+}
+
+/**
+ * Parse `git diff` output to extract per-file hunk ranges.
+ */
+function parseDiffHunks(diffOutput: string): DiffHunk[] {
+  const hunks: DiffHunk[] = [];
+  let currentFile = "";
+
+  for (const line of diffOutput.split("\n")) {
+    // --- a/path or +++ b/path
+    if (line.startsWith("--- a/")) {
+      currentFile = line.slice(6);
+    } else if (line.startsWith("+++ b/")) {
+      currentFile = line.slice(6);
+    } else if (line.startsWith("@@ ")) {
+      // @@ -origStart,origCount +newStart,newCount @@
+      const match = line.match(/@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+      if (match && currentFile) {
+        const origStart = parseInt(match[1], 10);
+        const origCount = parseInt(match[2] ?? "1", 10);
+        if (origCount > 0) {
+          hunks.push({ filePath: currentFile, origStart, origCount });
+        }
+      }
+    }
+  }
+
+  return hunks;
+}
+
+/**
+ * Run `git blame -L start,end --porcelain` and extract the commit hash
+ * for each line. Returns the set of unique hashes.
+ */
+async function blameRange(
+  cwd: string,
+  filePath: string,
+  start: number,
+  end: number,
+): Promise<Set<string>> {
+  const result = await gitExec(cwd, [
+    "blame",
+    "-L",
+    `${start},${end}`,
+    "--porcelain",
+    "HEAD",
+    "--",
+    filePath,
+  ]);
+
+  if (result.exitCode !== 0) return new Set();
+
+  const hashes = new Set<string>();
+  for (const line of (result.stdout ?? "").split("\n")) {
+    // Porcelain format: first field of header lines is the full hash
+    const match = line.match(/^([0-9a-f]{40})\s/);
+    if (match) {
+      // Ignore uncommitted lines (all zeros)
+      if (match[1] !== "0".repeat(40)) {
+        hashes.add(match[1]);
+      }
+    }
+  }
+
+  return hashes;
+}
+
+/**
+ * Get the short hash and subject for a commit.
+ */
+async function commitInfo(
+  cwd: string,
+  hash: string,
+): Promise<{ shortHash: string; message: string }> {
+  const result = await gitExec(cwd, [
+    "log",
+    "-1",
+    "--format=%h\t%s",
+    hash,
+  ]);
+  if (result.exitCode !== 0) return { shortHash: hash.slice(0, 7), message: "" };
+  const parts = (result.stdout ?? "").trim().split("\t");
+  return { shortHash: parts[0] ?? hash.slice(0, 7), message: parts[1] ?? "" };
+}
+
+// ─── Composable ─────────────────────────────────────────
+
+const isAnalyzing = ref(false);
+const isAbsorbing = ref(false);
+const lastError = ref<string | null>(null);
+const candidates = ref<AbsorbCandidate[]>([]);
+
+export function useAbsorb() {
+  /**
+   * Analyze modified files to find absorb candidates.
+   *
+   * @param staged - If true, analyze staged changes; otherwise unstaged.
+   */
+  async function analyze(
+    cwd: string,
+    filePaths?: string[],
+    staged = false,
+  ): Promise<AbsorbCandidate[]> {
+    isAnalyzing.value = true;
+    lastError.value = null;
+    candidates.value = [];
+
+    try {
+      // Get the diff
+      const diffArgs = staged
+        ? ["diff", "--cached", "--no-color"]
+        : ["diff", "--no-color"];
+      if (filePaths?.length) diffArgs.push("--", ...filePaths);
+
+      const diffResult = await gitExec(cwd, diffArgs);
+      if (diffResult.exitCode !== 0) {
+        throw new Error((diffResult.stderr ?? "").trim() || "git diff failed");
+      }
+
+      const diffOutput = diffResult.stdout ?? "";
+      if (!diffOutput.trim()) {
+        return [];
+      }
+
+      const hunks = parseDiffHunks(diffOutput);
+      if (hunks.length === 0) return [];
+
+      // Group hunks by file
+      const byFile = new Map<string, DiffHunk[]>();
+      for (const h of hunks) {
+        const list = byFile.get(h.filePath) ?? [];
+        list.push(h);
+        byFile.set(h.filePath, list);
+      }
+
+      const result: AbsorbCandidate[] = [];
+
+      for (const [file, fileHunks] of byFile) {
+        // Blame each hunk range to find which commit(s) own those lines
+        const allHashes = new Set<string>();
+        const lineRanges: string[] = [];
+
+        for (const hunk of fileHunks) {
+          const end = hunk.origStart + hunk.origCount - 1;
+          const hashes = await blameRange(cwd, file, hunk.origStart, end);
+          for (const h of hashes) allHashes.add(h);
+          lineRanges.push(`${hunk.origStart}-${end}`);
+        }
+
+        // If all hunks point to a single commit → clean absorb candidate
+        if (allHashes.size === 1) {
+          const targetHash = [...allHashes][0];
+          const info = await commitInfo(cwd, targetHash);
+          result.push({
+            filePath: file,
+            targetHash,
+            targetShortHash: info.shortHash,
+            targetMessage: info.message,
+            hunkCount: fileHunks.length,
+            lineRanges,
+          });
+        }
+        // If multiple commits, we could still offer per-hunk absorb in the future.
+        // For now, skip files where hunks span multiple commits.
+      }
+
+      candidates.value = result;
+      return result;
+    } catch (err: unknown) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      isAnalyzing.value = false;
+    }
+  }
+
+  /**
+   * Execute the absorb: stage the file, create a fixup commit, then
+   * optionally autosquash.
+   *
+   * @param autoSquash - If true, run `git rebase -i --autosquash` after.
+   *                     Default false (safer — user can squash later).
+   */
+  async function absorb(
+    cwd: string,
+    candidate: AbsorbCandidate,
+    autoSquash = false,
+  ): Promise<void> {
+    isAbsorbing.value = true;
+    lastError.value = null;
+
+    try {
+      // Stage the file
+      const addResult = await gitExec(cwd, ["add", "--", candidate.filePath]);
+      if (addResult.exitCode !== 0) {
+        throw new Error((addResult.stderr ?? "").trim() || "git add failed");
+      }
+
+      // Create fixup commit
+      const fixupResult = await gitExec(cwd, [
+        "commit",
+        `--fixup=${candidate.targetHash}`,
+      ]);
+      if (fixupResult.exitCode !== 0) {
+        throw new Error(
+          (fixupResult.stderr ?? "").trim() || "git commit --fixup failed",
+        );
+      }
+
+      // Optionally autosquash
+      if (autoSquash) {
+        // Find merge-base to limit the rebase range
+        const baseResult = await gitExec(cwd, [
+          "merge-base",
+          "HEAD",
+          candidate.targetHash + "~1",
+        ]);
+
+        if (baseResult.exitCode === 0 && (baseResult.stdout ?? "").trim()) {
+          const base = (baseResult.stdout ?? "").trim();
+          const rebaseResult = await gitExec(cwd, [
+            "-c",
+            "sequence.editor=true",
+            "rebase",
+            "--autosquash",
+            base,
+          ]);
+          if (rebaseResult.exitCode !== 0) {
+            throw new Error(
+              (rebaseResult.stderr ?? "").trim() ||
+                "git rebase --autosquash failed",
+            );
+          }
+        }
+      }
+    } catch (err: unknown) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      isAbsorbing.value = false;
+    }
+  }
+
+  return {
+    isAnalyzing,
+    isAbsorbing,
+    lastError,
+    candidates,
+    analyze,
+    absorb,
+  };
+}

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -1,4 +1,5 @@
 import { ref, computed, watch } from "vue";
+import { gitExec } from "../utils/backend";
 import {
   getGitStatus,
   getGitDiff,
@@ -262,6 +263,50 @@ export function useGitRepo() {
   }
 
   /**
+   * Lightweight status polling — runs `git status --porcelain` every 2s
+   * and only triggers a full `loadStatus` when the output changes.
+   * This detects external file changes (editor saves, branch operations
+   * from CLI, etc.) with minimal overhead (~20ms per check).
+   */
+  let statusPollInterval: ReturnType<typeof setInterval> | null = null;
+  let lastStatusSnapshot = "";
+
+  async function pollStatus() {
+    if (!folderPath.value || isMerging.value || loading.value) return;
+    try {
+      const result = await gitExec(folderPath.value, [
+        "status",
+        "--porcelain",
+        "--branch",
+      ]);
+      if (result.exitCode !== 0) return;
+      const snapshot = result.stdout ?? "";
+      if (snapshot !== lastStatusSnapshot) {
+        lastStatusSnapshot = snapshot;
+        await loadStatus(folderPath.value);
+        // Also refresh diff if a file is selected
+        if (selectedFilePath.value) {
+          await loadDiff(selectedFilePath.value, selectedFileStaged.value);
+        }
+      }
+    } catch {
+      // Silently ignore — polling errors are non-critical
+    }
+  }
+
+  function startStatusPoll() {
+    stopStatusPoll();
+    statusPollInterval = setInterval(pollStatus, 2_000);
+  }
+
+  function stopStatusPoll() {
+    if (statusPollInterval) {
+      clearInterval(statusPollInterval);
+      statusPollInterval = null;
+    }
+  }
+
+  /**
    * Open a repository folder.
    */
   async function openRepo(path: string) {
@@ -287,6 +332,10 @@ export function useGitRepo() {
     // Background fetch then refresh status — awaited so UI updates before user interacts
     fetchRemote();
     startAutoFetch();
+
+    // Start lightweight status polling to detect external changes
+    lastStatusSnapshot = ""; // Reset so first poll picks up current state
+    startStatusPoll();
   }
 
   /**
@@ -568,6 +617,7 @@ export function useGitRepo() {
   async function mergeBranch(branchName: string) {
     if (!folderPath.value || !branchName) return;
     stopAutoFetch();
+    stopStatusPoll();
     isMerging.value = true;
     try {
       const result = await gitMerge(folderPath.value, branchName);
@@ -608,7 +658,10 @@ export function useGitRepo() {
     } finally {
       isMerging.value = false;
       // Restart auto-fetch only if no conflicts remain (conflicts = merge still in progress)
-      if (!hasConflicts.value) startAutoFetch();
+      if (!hasConflicts.value) {
+        startAutoFetch();
+        startStatusPoll();
+      }
     }
   }
 
@@ -623,6 +676,7 @@ export function useGitRepo() {
       error.value = `abort merge: ${err?.message || String(err)}`;
     } finally {
       startAutoFetch();
+      startStatusPoll();
     }
   }
 
@@ -646,6 +700,7 @@ export function useGitRepo() {
     } finally {
       isMerging.value = false;
       startAutoFetch();
+      startStatusPoll();
     }
   }
 

--- a/apps/desktop/src/composables/useInteractiveRebase.ts
+++ b/apps/desktop/src/composables/useInteractiveRebase.ts
@@ -1,8 +1,8 @@
 /**
- * useInteractiveRebase — composable for interactive rebase in GitWand.
+ * useInteractiveRebase — Vue composable for interactive rebase in GitWand.
  *
  * Workflow:
- *   1. User picks a base (branch or commit).
+ *   1. User picks a base (branch or commit) in the RebaseEditor UI.
  *   2. `listCommits(cwd, base)` fetches the rebase-eligible commits.
  *   3. User reorders / changes actions in the UI.
  *   4. `startRebase(cwd, base, entries)` calls a dedicated backend

--- a/apps/desktop/src/composables/useInteractiveRebase.ts
+++ b/apps/desktop/src/composables/useInteractiveRebase.ts
@@ -15,7 +15,7 @@
 import { ref, computed } from "vue";
 import { gitExec, isTauri } from "../utils/backend";
 
-const DEV_SERVER = "http://localhost:24842";
+const DEV_SERVER = "http://localhost:3001";
 
 // ─── Types ──────────────────────────────────────────────────
 

--- a/apps/desktop/src/composables/useInteractiveRebase.ts
+++ b/apps/desktop/src/composables/useInteractiveRebase.ts
@@ -94,60 +94,52 @@ export function useInteractiveRebase() {
 
   async function detectRebaseState(cwd: string): Promise<RebaseProgress | null> {
     try {
-      // Quick check: does REBASE_HEAD exist?
-      const rh = await gitExec(cwd, ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"]);
-      const hasRebaseHead = rh.exitCode === 0;
+      // Most reliable check: `git status` long-form mentions
+      // "interactive rebase in progress" (English) or
+      // "rebase interactif en cours" (French) when a rebase is active.
+      // We force English output with LC_ALL=C via a harmless -c flag.
+      const st = await gitExec(cwd, [
+        "-c", "advice.statusHints=true",
+        "status",
+      ]);
+      const statusText = st.stdout;
 
-      if (!hasRebaseHead) {
-        // Also check rebase-merge dir (rebase may be paused before first apply)
-        const dirCheck = await gitExec(cwd, [
-          "rev-parse", "--git-path", "rebase-merge/interactive",
-        ]);
-        // The file only exists during interactive rebase
-        const interactivePath = dirCheck.stdout.trim();
-        // We can't `cat` via gitExec, but we can check if rebase-merge/msgnum exists
-        const msgnumCheck = await gitExec(cwd, [
-          "rev-parse", "--git-path", "rebase-merge/msgnum",
-        ]);
-        // If these files exist in .git, ls-files won't work.
-        // Simpler: run `git status` and parse for "interactive rebase in progress"
-        const st = await gitExec(cwd, ["status"]);
-        if (!st.stdout.includes("interactive rebase in progress") && !st.stdout.includes("rebase interactif en cours")) {
-          progress.value = null;
-          return null;
-        }
+      // Match specifically the rebase-in-progress message, NOT the branch name
+      const isRebasing =
+        /interactive rebase in progress/.test(statusText) ||
+        /rebase interactif en cours/.test(statusText) ||
+        /You are currently rebasing/.test(statusText) ||
+        /Vous êtes en train de rebaser/.test(statusText);
+
+      if (!isRebasing) {
+        progress.value = null;
+        return null;
       }
 
-      // Parse step info from git status long output
-      const statusResult = await gitExec(cwd, ["status"]);
-      const statusText = statusResult.stdout;
-
+      // Parse step/total from status output
       let step = 0;
       let total = 0;
       let headName = "";
-      let hasConflict = false;
 
-      // English: "interactive rebase in progress; onto abc1234"
-      // Also: "You are currently rebasing branch 'foo' on 'abc1234'."
       const branchMatch = statusText.match(/rebasing branch '([^']+)'/);
       if (branchMatch) headName = branchMatch[1];
 
-      // "Last commands done (2 commands done):"
-      // or "Last command done (1 command done):"
       const doneMatch = statusText.match(/\((\d+) commands? done\)/);
       if (doneMatch) step = parseInt(doneMatch[1], 10);
 
-      // "Next commands to do (3 remaining commands):"
-      // or "(1 remaining command)"
       const remainMatch = statusText.match(/\((\d+) remaining commands?\)/);
       if (remainMatch) total = step + parseInt(remainMatch[1], 10);
-      else total = step; // all done, last step
+      else total = step;
 
-      // Conflict detection
+      // Get REBASE_HEAD for current hash
+      const rh = await gitExec(cwd, ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"]);
+      const currentHash = rh.exitCode === 0 ? rh.stdout.trim().slice(0, 7) : "";
+
+      // Conflict detection via porcelain status
       const conflictCheck = await gitExec(cwd, ["status", "--porcelain"]);
-      hasConflict = conflictCheck.stdout.split("\n").some((l) => l.startsWith("UU ") || l.startsWith("AA ") || l.startsWith("UD ") || l.startsWith("DU "));
-
-      const currentHash = hasRebaseHead ? rh.stdout.trim().slice(0, 7) : "";
+      const hasConflict = conflictCheck.stdout.split("\n").some(
+        (l) => l.startsWith("UU ") || l.startsWith("AA ") || l.startsWith("UD ") || l.startsWith("DU "),
+      );
 
       const state: RebaseProgress = {
         inProgress: true,

--- a/apps/desktop/src/composables/useInteractiveRebase.ts
+++ b/apps/desktop/src/composables/useInteractiveRebase.ts
@@ -1,0 +1,327 @@
+/**
+ * useInteractiveRebase — composable for interactive rebase in GitWand.
+ *
+ * Workflow:
+ *   1. User picks a base (branch or commit).
+ *   2. `listCommits(cwd, base)` fetches the rebase-eligible commits.
+ *   3. User reorders / changes actions in the UI.
+ *   4. `startRebase(cwd, base, entries)` calls a dedicated backend
+ *      endpoint that writes a temp todo file and runs
+ *      `GIT_SEQUENCE_EDITOR="cp <tmp> " git rebase -i <base>`.
+ *   5. If conflicts arise the rebase pauses — the UI shows continue / abort / skip.
+ *   6. `detectRebaseState(cwd)` checks for an in-progress rebase.
+ */
+
+import { ref, computed } from "vue";
+import { gitExec, isTauri } from "../utils/backend";
+
+const DEV_SERVER = "http://localhost:24842";
+
+// ─── Types ──────────────────────────────────────────────────
+
+export type RebaseAction = "pick" | "reword" | "squash" | "fixup" | "edit" | "drop";
+
+export interface RebaseTodoEntry {
+  action: RebaseAction;
+  /** Short hash. */
+  hash: string;
+  /** Full hash. */
+  fullHash: string;
+  /** First-line commit message. */
+  message: string;
+  /** Author name. */
+  author: string;
+  /** Relative date. */
+  date: string;
+  /** New message (used when action === "reword"). */
+  newMessage?: string;
+}
+
+export interface RebaseProgress {
+  inProgress: boolean;
+  /** 1-based current step. */
+  step: number;
+  total: number;
+  /** Short hash of REBASE_HEAD (the commit being applied). */
+  currentHash: string;
+  /** True when stopped on a conflict. */
+  hasConflict: boolean;
+  /** Branch name being rebased. */
+  headName: string;
+}
+
+// ─── Composable ─────────────────────────────────────────────
+
+export function useInteractiveRebase() {
+  const isLoading = ref(false);
+  const isRunning = ref(false);
+  const error = ref<string | null>(null);
+  const todoEntries = ref<RebaseTodoEntry[]>([]);
+  const progress = ref<RebaseProgress | null>(null);
+
+  // ── List commits ──────────────────────────────────────────
+
+  async function listCommits(cwd: string, base: string): Promise<RebaseTodoEntry[]> {
+    isLoading.value = true;
+    error.value = null;
+    try {
+      const result = await gitExec(cwd, [
+        "log", "--reverse", "--format=%h\t%H\t%s\t%an\t%cr",
+        `${base}..HEAD`,
+      ]);
+      if (result.exitCode !== 0) throw new Error(result.stderr || "git log failed");
+
+      const entries: RebaseTodoEntry[] = result.stdout
+        .trim()
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => {
+          const [hash, fullHash, message, author, date] = line.split("\t");
+          return { action: "pick" as RebaseAction, hash, fullHash, message, author, date };
+        });
+
+      todoEntries.value = entries;
+      return entries;
+    } catch (err: any) {
+      error.value = err.message;
+      return [];
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  // ── Detect in-progress rebase ─────────────────────────────
+
+  async function detectRebaseState(cwd: string): Promise<RebaseProgress | null> {
+    try {
+      // Quick check: does REBASE_HEAD exist?
+      const rh = await gitExec(cwd, ["rev-parse", "--verify", "--quiet", "REBASE_HEAD"]);
+      const hasRebaseHead = rh.exitCode === 0;
+
+      if (!hasRebaseHead) {
+        // Also check rebase-merge dir (rebase may be paused before first apply)
+        const dirCheck = await gitExec(cwd, [
+          "rev-parse", "--git-path", "rebase-merge/interactive",
+        ]);
+        // The file only exists during interactive rebase
+        const interactivePath = dirCheck.stdout.trim();
+        // We can't `cat` via gitExec, but we can check if rebase-merge/msgnum exists
+        const msgnumCheck = await gitExec(cwd, [
+          "rev-parse", "--git-path", "rebase-merge/msgnum",
+        ]);
+        // If these files exist in .git, ls-files won't work.
+        // Simpler: run `git status` and parse for "interactive rebase in progress"
+        const st = await gitExec(cwd, ["status"]);
+        if (!st.stdout.includes("interactive rebase in progress") && !st.stdout.includes("rebase interactif en cours")) {
+          progress.value = null;
+          return null;
+        }
+      }
+
+      // Parse step info from git status long output
+      const statusResult = await gitExec(cwd, ["status"]);
+      const statusText = statusResult.stdout;
+
+      let step = 0;
+      let total = 0;
+      let headName = "";
+      let hasConflict = false;
+
+      // English: "interactive rebase in progress; onto abc1234"
+      // Also: "You are currently rebasing branch 'foo' on 'abc1234'."
+      const branchMatch = statusText.match(/rebasing branch '([^']+)'/);
+      if (branchMatch) headName = branchMatch[1];
+
+      // "Last commands done (2 commands done):"
+      // or "Last command done (1 command done):"
+      const doneMatch = statusText.match(/\((\d+) commands? done\)/);
+      if (doneMatch) step = parseInt(doneMatch[1], 10);
+
+      // "Next commands to do (3 remaining commands):"
+      // or "(1 remaining command)"
+      const remainMatch = statusText.match(/\((\d+) remaining commands?\)/);
+      if (remainMatch) total = step + parseInt(remainMatch[1], 10);
+      else total = step; // all done, last step
+
+      // Conflict detection
+      const conflictCheck = await gitExec(cwd, ["status", "--porcelain"]);
+      hasConflict = conflictCheck.stdout.split("\n").some((l) => l.startsWith("UU ") || l.startsWith("AA ") || l.startsWith("UD ") || l.startsWith("DU "));
+
+      const currentHash = hasRebaseHead ? rh.stdout.trim().slice(0, 7) : "";
+
+      const state: RebaseProgress = {
+        inProgress: true,
+        step,
+        total,
+        currentHash,
+        hasConflict,
+        headName,
+      };
+      progress.value = state;
+      return state;
+    } catch {
+      progress.value = null;
+      return null;
+    }
+  }
+
+  // ── Start interactive rebase ──────────────────────────────
+
+  /**
+   * Start an interactive rebase. Uses a dedicated endpoint that writes
+   * a temp todo-file and injects it via GIT_SEQUENCE_EDITOR.
+   */
+  async function startRebase(
+    cwd: string,
+    base: string,
+    entries: RebaseTodoEntry[],
+  ): Promise<{ success: boolean; error?: string; conflict?: boolean }> {
+    isRunning.value = true;
+    error.value = null;
+
+    const todoLines = entries.map((e) => `${e.action} ${e.hash} ${e.message}`);
+
+    try {
+      // Both Tauri and dev-server use the same endpoint pattern.
+      // For Tauri we'll add a Rust command later; for dev mode we
+      // need a dedicated endpoint because GIT_SEQUENCE_EDITOR requires
+      // env-var control that gitExec doesn't support.
+      const res = await fetch(
+        isTauri() ? "/api/git-interactive-rebase" : `${DEV_SERVER}/api/git-interactive-rebase`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ cwd, base, todoLines }),
+        },
+      );
+      const data = await res.json();
+      if (data.error) throw new Error(data.error);
+      if (data.conflict) {
+        await detectRebaseState(cwd);
+        return { success: true, conflict: true };
+      }
+      progress.value = null;
+      return { success: true };
+    } catch (err: any) {
+      error.value = err.message;
+      return { success: false, error: err.message };
+    } finally {
+      isRunning.value = false;
+    }
+  }
+
+  // ── Continue / Abort / Skip ───────────────────────────────
+
+  async function rebaseContinue(cwd: string): Promise<{ success: boolean; conflict?: boolean; error?: string }> {
+    isRunning.value = true;
+    error.value = null;
+    try {
+      // Need to set sequence.editor=true to skip editor on reword commits
+      const result = await gitExec(cwd, [
+        "-c", "sequence.editor=true",
+        "rebase", "--continue",
+      ]);
+      if (result.exitCode !== 0) {
+        if (result.stderr.includes("CONFLICT") || result.stderr.includes("could not apply")) {
+          await detectRebaseState(cwd);
+          return { success: true, conflict: true };
+        }
+        throw new Error(result.stderr || "rebase --continue failed");
+      }
+      progress.value = null;
+      return { success: true };
+    } catch (err: any) {
+      error.value = err.message;
+      return { success: false, error: err.message };
+    } finally {
+      isRunning.value = false;
+    }
+  }
+
+  async function rebaseAbort(cwd: string): Promise<void> {
+    isRunning.value = true;
+    error.value = null;
+    try {
+      const result = await gitExec(cwd, ["rebase", "--abort"]);
+      if (result.exitCode !== 0) throw new Error(result.stderr || "rebase --abort failed");
+      progress.value = null;
+      todoEntries.value = [];
+    } catch (err: any) {
+      error.value = err.message;
+    } finally {
+      isRunning.value = false;
+    }
+  }
+
+  async function rebaseSkip(cwd: string): Promise<{ success: boolean; conflict?: boolean; error?: string }> {
+    isRunning.value = true;
+    error.value = null;
+    try {
+      const result = await gitExec(cwd, ["rebase", "--skip"]);
+      if (result.exitCode !== 0) {
+        if (result.stderr.includes("CONFLICT") || result.stderr.includes("could not apply")) {
+          await detectRebaseState(cwd);
+          return { success: true, conflict: true };
+        }
+        throw new Error(result.stderr || "rebase --skip failed");
+      }
+      progress.value = null;
+      return { success: true };
+    } catch (err: any) {
+      error.value = err.message;
+      return { success: false, error: err.message };
+    } finally {
+      isRunning.value = false;
+    }
+  }
+
+  // ── Todo list mutations (for the UI) ──────────────────────
+
+  function moveEntry(fromIndex: number, toIndex: number) {
+    const list = [...todoEntries.value];
+    const [moved] = list.splice(fromIndex, 1);
+    list.splice(toIndex, 0, moved);
+    todoEntries.value = list;
+  }
+
+  function setAction(index: number, action: RebaseAction) {
+    const list = [...todoEntries.value];
+    list[index] = { ...list[index], action };
+    todoEntries.value = list;
+  }
+
+  function setNewMessage(index: number, message: string) {
+    const list = [...todoEntries.value];
+    list[index] = { ...list[index], newMessage: message, action: "reword" };
+    todoEntries.value = list;
+  }
+
+  function reset() {
+    todoEntries.value = [];
+    progress.value = null;
+    error.value = null;
+  }
+
+  const hasChanges = computed(() =>
+    todoEntries.value.some((e) => e.action !== "pick"),
+  );
+
+  return {
+    isLoading,
+    isRunning,
+    error,
+    todoEntries,
+    progress,
+    hasChanges,
+    listCommits,
+    detectRebaseState,
+    startRebase,
+    rebaseContinue,
+    rebaseAbort,
+    rebaseSkip,
+    moveEntry,
+    setAction,
+    setNewMessage,
+    reset,
+  };
+}

--- a/apps/desktop/src/composables/useUndoStack.ts
+++ b/apps/desktop/src/composables/useUndoStack.ts
@@ -1,0 +1,219 @@
+import { ref, computed } from "vue";
+import { gitExec } from "../utils/backend";
+
+/**
+ * Undo stack — parses `git reflog` and provides one-click undo for
+ * common Git operations (commit, merge, cherry-pick, rebase, amend, stash, reset).
+ *
+ * Each reflog entry is categorized by type so the UI can show an
+ * appropriate icon and label, and the undo logic can pick the right
+ * strategy (soft reset for commits, hard reset for merges, etc.).
+ */
+
+// ─── Types ──────────────────────────────────────────────
+
+export type UndoOpType =
+  | "commit"
+  | "amend"
+  | "merge"
+  | "cherry-pick"
+  | "rebase"
+  | "pull"
+  | "reset"
+  | "checkout"
+  | "stash"
+  | "other";
+
+export interface UndoEntry {
+  /** Reflog index (0 = most recent). */
+  index: number;
+  /** Abbreviated commit hash AFTER the operation. */
+  hash: string;
+  /** Hash BEFORE the operation (the one to reset to for undo). */
+  prevHash: string;
+  /** Detected operation type. */
+  type: UndoOpType;
+  /** Human-readable summary from reflog. */
+  summary: string;
+  /** Raw reflog subject line. */
+  raw: string;
+  /** Relative date string from git. */
+  date: string;
+}
+
+// ─── Reflog parsing ─────────────────────────────────────
+
+/**
+ * Detect the operation type from a reflog subject line.
+ */
+function classifyReflog(subject: string): UndoOpType {
+  const s = subject.toLowerCase();
+  if (s.startsWith("commit (amend)")) return "amend";
+  if (s.startsWith("commit (merge)") || s.startsWith("merge")) return "merge";
+  if (s.startsWith("commit")) return "commit";
+  if (s.includes("cherry-pick")) return "cherry-pick";
+  if (s.startsWith("rebase")) return "rebase";
+  if (s.startsWith("pull")) return "pull";
+  if (s.startsWith("reset")) return "reset";
+  if (s.startsWith("checkout") || s.startsWith("switch")) return "checkout";
+  if (s.includes("stash")) return "stash";
+  return "other";
+}
+
+/**
+ * Summarise a reflog line into a short user-facing label.
+ */
+function summarize(subject: string, type: UndoOpType): string {
+  // Strip the reflog prefix ("commit: ", "merge: ", etc.)
+  const colonIdx = subject.indexOf(": ");
+  const tail = colonIdx >= 0 ? subject.slice(colonIdx + 2).trim() : subject;
+
+  switch (type) {
+    case "commit":
+    case "amend":
+      return tail || "commit";
+    case "merge":
+      return tail ? `merge: ${tail}` : "merge";
+    case "cherry-pick":
+      return tail ? `cherry-pick: ${tail}` : "cherry-pick";
+    case "rebase":
+      return tail || "rebase";
+    case "pull":
+      return tail || "pull";
+    case "reset":
+      return tail || "reset";
+    case "checkout":
+      return tail || "checkout";
+    case "stash":
+      return tail || "stash";
+    default:
+      return tail || subject;
+  }
+}
+
+/** Types of operations that can be undone. */
+const UNDOABLE: Set<UndoOpType> = new Set([
+  "commit",
+  "amend",
+  "merge",
+  "cherry-pick",
+  "rebase",
+  "pull",
+]);
+
+// ─── Composable ─────────────────────────────────────────
+
+const entries = ref<UndoEntry[]>([]);
+const isLoading = ref(false);
+const lastError = ref<string | null>(null);
+
+/** Max reflog entries to fetch. */
+const MAX_ENTRIES = 50;
+
+export function useUndoStack() {
+  /**
+   * Refresh the undo stack by parsing `git reflog`.
+   */
+  async function refresh(cwd: string): Promise<void> {
+    if (!cwd) return;
+    isLoading.value = true;
+    lastError.value = null;
+
+    try {
+      // Format: hash<TAB>prevHash<TAB>subject<TAB>relativeDate
+      const result = await gitExec(cwd, [
+        "reflog",
+        "--format=%h\t%gd\t%gs\t%cr",
+        `-n${MAX_ENTRIES}`,
+      ]);
+
+      if (result.exitCode !== 0) {
+        throw new Error((result.stderr ?? "").trim() || "git reflog failed");
+      }
+
+      const lines = (result.stdout ?? "").trim().split("\n").filter(Boolean);
+      const parsed: UndoEntry[] = [];
+
+      for (let i = 0; i < lines.length; i++) {
+        const parts = lines[i].split("\t");
+        if (parts.length < 4) continue;
+        const [hash, , subject, date] = parts;
+        const type = classifyReflog(subject);
+        // prevHash = the hash of the NEXT line (older state)
+        // For the last entry, prevHash stays empty (can't undo further)
+        const prevHash = i + 1 < lines.length ? lines[i + 1].split("\t")[0] : "";
+
+        parsed.push({
+          index: i,
+          hash,
+          prevHash,
+          type,
+          summary: summarize(subject, type),
+          raw: subject,
+          date,
+        });
+      }
+
+      entries.value = parsed;
+    } catch (err: unknown) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  /**
+   * Can this entry be undone?
+   */
+  function canUndo(entry: UndoEntry): boolean {
+    return UNDOABLE.has(entry.type) && !!entry.prevHash;
+  }
+
+  /**
+   * Undo a specific operation by resetting to the state before it.
+   *
+   * Strategy by type:
+   * - commit / amend → `git reset --soft <prev>` (keep changes staged)
+   * - merge / cherry-pick / rebase / pull → `git reset --hard <prev>`
+   */
+  async function undo(cwd: string, entry: UndoEntry): Promise<void> {
+    if (!canUndo(entry)) return;
+    isLoading.value = true;
+    lastError.value = null;
+
+    try {
+      const soft = entry.type === "commit" || entry.type === "amend";
+      const mode = soft ? "--soft" : "--hard";
+      const result = await gitExec(cwd, ["reset", mode, entry.prevHash]);
+
+      if (result.exitCode !== 0) {
+        throw new Error(
+          (result.stderr ?? "").trim() || `git reset ${mode} failed`,
+        );
+      }
+
+      // Refresh the stack after undo.
+      await refresh(cwd);
+    } catch (err: unknown) {
+      lastError.value = err instanceof Error ? err.message : String(err);
+      throw err;
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  /** The most recent undoable entry, if any. */
+  const lastUndoable = computed(() =>
+    entries.value.find((e) => canUndo(e)) ?? null,
+  );
+
+  return {
+    entries,
+    isLoading,
+    lastError,
+    lastUndoable,
+    refresh,
+    canUndo,
+    undo,
+  };
+}

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -404,6 +404,43 @@ const en: Locale = {
     notifications: "Notifications",
     notificationsHint: "Show toast notifications (sync, push, errors)",
   },
+
+  // ─── Undo ───────────────────────────────────────────────
+  undoStack: {
+    title: "Operation history",
+    undoButton: "Rewind",
+    undoTooltip: "Rewind last Git operation",
+    noHistory: "No recent operations",
+    undone: "Operation undone",
+    undoConfirm: "Undo this operation? Changes will be restored to staging.",
+    undoHardConfirm: "Undo this operation? \u26a0\ufe0f Uncommitted changes will be lost.",
+    // Operation types
+    opCommit: "Commit",
+    opAmend: "Amend",
+    opMerge: "Merge",
+    opCherryPick: "Cherry-pick",
+    opRebase: "Rebase",
+    opPull: "Pull",
+    opReset: "Reset",
+    opCheckout: "Checkout",
+    opStash: "Stash",
+    opOther: "Operation",
+  },
+
+  // ─── Absorb ─────────────────────────────────────────────
+  absorb: {
+    action: "Absorb",
+    tooltip: "Absorb into original commit",
+    analyzing: "Analyzing\u2026",
+    absorbing: "Absorbing\u2026",
+    noCandidate: "No target commit found \u2014 changes span multiple commits",
+    candidate: "Absorb into {0}",
+    candidateHint: "{0} hunk(s) \u2192 {1}",
+    done: "Changes absorbed into {0}",
+    confirmTitle: "Absorb into this commit?",
+    confirmDesc: "Changes in {0} will be folded into commit {1}.",
+    lines: "Lines {0}",
+  },
 } as const;
 
 export default en;

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -375,8 +375,11 @@ const en: Locale = {
   // ─── Settings ───────────────────────────────────────────
   settings: {
     title: "Settings",
-    language: "Language",
+    language: "Interface language",
     languageAuto: "Automatic (system)",
+    commitMessageLang: "Commit message language",
+    commitMessageLangAuto: "Follow interface language",
+    commitMessageLangHint: "Language used by AI to generate commit messages",
     theme: "Theme",
     themeDark: "Dark",
     themeLight: "Light",

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -278,6 +278,31 @@ const en: Locale = {
     conflictsManual: "manual conflict(s)",
   },
 
+  // ─── Interactive Rebase (Phase 1.2.1) ──────────────────
+  rebase: {
+    title: "Interactive rebase",
+    button: "Rebase",
+    baseLabel: "Target branch",
+    baseHint: "Select the branch to rebase your commits onto.",
+    basePlaceholder: "Filter branches\u2026",
+    commitsLabel: "Commits to rebase",
+    commitsHint: "Drag to reorder, click the action badge to cycle. Double-click a message to edit it.",
+    changeBase: "Change base",
+    cycleAction: "Cycle action (click)",
+    dragHint: "Drag to move",
+    start: "Start rebase",
+    running: "Rebasing\u2026",
+    inProgress: "Rebase in progress",
+    conflict: "Conflict",
+    continue: "Continue",
+    abort: "Abort",
+    skip: "Skip",
+    reword: "Edit message",
+    drop: "Drop",
+    restore: "Restore",
+    done: "Rebase completed",
+  },
+
   // ─── EmptyState ─────────────────────────────────────────
   empty: {
     title: "No repository open",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -279,6 +279,31 @@ const fr = {
     conflictsManual: "conflit(s) manuel(s)",
   },
 
+  // ─── Interactive Rebase (Phase 1.2.1) ──────────────────
+  rebase: {
+    title: "Rebase interactif",
+    button: "Rebase",
+    baseLabel: "Branche cible",
+    baseHint: "S\u00e9lectionnez la branche sur laquelle rebaser vos commits.",
+    basePlaceholder: "Filtrer les branches\u2026",
+    commitsLabel: "Commits \u00e0 rebaser",
+    commitsHint: "Glissez pour r\u00e9ordonner, cliquez sur l\u2019action pour la changer. Double-clic sur le message pour le modifier.",
+    changeBase: "Changer la base",
+    cycleAction: "Changer l\u2019action (clic)",
+    dragHint: "Glisser pour d\u00e9placer",
+    start: "Lancer le rebase",
+    running: "Rebase en cours\u2026",
+    inProgress: "Rebase en cours",
+    conflict: "Conflit",
+    continue: "Continuer",
+    abort: "Annuler",
+    skip: "Passer",
+    reword: "Modifier le message",
+    drop: "Supprimer",
+    restore: "Restaurer",
+    done: "Rebase termin\u00e9",
+  },
+
   // ─── EmptyState ─────────────────────────────────────────
   empty: {
     title: "Aucun d\u00e9p\u00f4t ouvert",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -405,6 +405,43 @@ const fr = {
     notifications: "Notifications",
     notificationsHint: "Afficher les notifications toast (sync, push, erreurs)",
   },
+
+  // ─── Undo ───────────────────────────────────────────────
+  undoStack: {
+    title: "Historique des opérations",
+    undoButton: "Rembobiner",
+    undoTooltip: "Rembobiner la dernière opération Git",
+    noHistory: "Aucune opération récente",
+    undone: "Opération annulée",
+    undoConfirm: "Annuler cette opération ? Les changements seront restaurés.",
+    undoHardConfirm: "Annuler cette opération ? ⚠️ Les modifications non committées seront perdues.",
+    // Operation types
+    opCommit: "Commit",
+    opAmend: "Amend",
+    opMerge: "Merge",
+    opCherryPick: "Cherry-pick",
+    opRebase: "Rebase",
+    opPull: "Pull",
+    opReset: "Reset",
+    opCheckout: "Checkout",
+    opStash: "Stash",
+    opOther: "Opération",
+  },
+
+  // ─── Absorb ─────────────────────────────────────────────
+  absorb: {
+    action: "Absorber",
+    tooltip: "Absorber dans le commit d'origine",
+    analyzing: "Analyse en cours\u2026",
+    absorbing: "Absorption en cours\u2026",
+    noCandidate: "Aucun commit cible trouv\u00e9 — les modifications touchent plusieurs commits",
+    candidate: "Absorber dans {0}",
+    candidateHint: "{0} hunk(s) \u2192 {1}",
+    done: "Modifications absorb\u00e9es dans {0}",
+    confirmTitle: "Absorber dans ce commit ?",
+    confirmDesc: "Les modifications de {0} seront int\u00e9gr\u00e9es dans le commit {1}.",
+    lines: "Lignes {0}",
+  },
 } as const;
 
 // Widen literal string types to plain `string` for locale compatibility

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -376,8 +376,11 @@ const fr = {
   // ─── Settings ───────────────────────────────────────────
   settings: {
     title: "Param\u00e8tres",
-    language: "Langue",
+    language: "Langue de l\u2019interface",
     languageAuto: "Automatique (syst\u00e8me)",
+    commitMessageLang: "Langue des messages de commit",
+    commitMessageLangAuto: "Suivre la langue de l\u2019interface",
+    commitMessageLangHint: "Langue utilis\u00e9e par l\u2019IA pour g\u00e9n\u00e9rer les messages de commit",
     theme: "Th\u00e8me",
     themeDark: "Sombre",
     themeLight: "Clair",


### PR DESCRIPTION
## Interactive rebase

Reorder, squash, edit or drop commits directly from the GitWand interface.

### Planned features

- [ ] Commit list visualization with drag & drop reordering
- [ ] Per-commit actions: pick, reword, squash, fixup, edit, drop
- [ ] Base point selection (target branch or commit)
- [ ] Conflict handling during rebase (continue / abort / skip)
- [ ] "Rebase in progress" indicator in the header