### PR TITLE
feat(core): add v2.2 format profiles

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -427,37 +427,31 @@ struct GitDiff {
     old_path: Option<String>,
 }
 
-#[tauri::command]
-fn git_diff(cwd: String, path: String, staged: bool) -> Result<GitDiff, String> {
-    let mut cmd = std::process::Command::new(git_binary());
-    if staged {
-        cmd.arg("diff").arg("--cached");
-    } else {
-        cmd.arg("diff");
-    }
-    cmd.arg("--").arg(&path).current_dir(&cwd);
-
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to run git diff: {}", e))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
+/// Parse the stdout of a `git diff` (or `git diff --no-index`) command into
+/// a list of `DiffHunk`s. The `status` return value is `Some("added")` when
+/// a `new file mode` header is detected in the diff preamble.
+fn parse_diff_hunks(stdout: &str) -> (Vec<DiffHunk>, Option<String>) {
     let mut hunks: Vec<DiffHunk> = Vec::new();
-
     let mut current_hunk: Option<DiffHunk> = None;
-    let mut old_line_no = 0;
-    let mut new_line_no = 0;
+    let mut old_line_no = 0u32;
+    let mut new_line_no = 0u32;
+    let mut detected_status: Option<String> = None;
 
     for line in stdout.lines() {
+        // Detect "new file mode …" in the diff preamble (before any @@).
+        if line.starts_with("new file mode") {
+            detected_status = Some("added".to_string());
+            continue;
+        }
+
         if line.starts_with("@@") {
             // Save previous hunk if exists
             if let Some(hunk) = current_hunk.take() {
                 hunks.push(hunk);
             }
 
-            // Parse hunk header
+            // Parse hunk header: @@ -oldStart,oldCount +newStart,newCount @@
             let header = line.to_string();
-            // Parse @@ -oldStart,oldCount +newStart,newCount @@
             let parts: Vec<&str> = line.split_whitespace().collect();
             let mut old_start = 0;
             let mut old_count = 1;
@@ -537,10 +531,50 @@ fn git_diff(cwd: String, path: String, staged: bool) -> Result<GitDiff, String> 
         hunks.push(hunk);
     }
 
+    (hunks, detected_status)
+}
+
+#[tauri::command]
+fn git_diff(cwd: String, path: String, staged: bool) -> Result<GitDiff, String> {
+    let mut cmd = std::process::Command::new(git_binary());
+    if staged {
+        cmd.arg("diff").arg("--cached");
+    } else {
+        cmd.arg("diff");
+    }
+    cmd.arg("--").arg(&path).current_dir(&cwd);
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run git diff: {}", e))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let (mut hunks, mut status) = parse_diff_hunks(&stdout);
+
+    // Untracked (not-yet-staged) files produce no output from `git diff`.
+    // Fall back to `git diff --no-index -- /dev/null <path>` which generates
+    // a proper "new file" diff with every line shown as an addition.
+    // Note: --no-index always exits with code 1 when files differ, so we
+    // ignore the exit status and only look at stdout.
+    if !staged && hunks.is_empty() {
+        if let Ok(fb) = std::process::Command::new(git_binary())
+            .args(["diff", "--no-index", "--", "/dev/null", &path])
+            .current_dir(&cwd)
+            .output()
+        {
+            let fb_stdout = String::from_utf8_lossy(&fb.stdout);
+            let (fb_hunks, fb_status) = parse_diff_hunks(&fb_stdout);
+            if !fb_hunks.is_empty() {
+                hunks = fb_hunks;
+                status = fb_status.or(Some("added".to_string()));
+            }
+        }
+    }
+
     Ok(GitDiff {
         path,
         hunks,
-        status: None,
+        status,
         old_path: None,
     })
 }

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -163,6 +163,11 @@ const prCwd = computed(() => repoFolderPath.value ?? "");
 const prPanel = usePrPanel(prCwd);
 provide(PR_PANEL_KEY, prPanel);
 
+// Load branches when the PR create form opens (they're needed to compute baseCandidates).
+watch(() => prPanel.showCreateForm.value, (val) => {
+  if (val && branches.value.length === 0) loadBranches();
+});
+
 // ─── Bridges: native menu → owning components ────────────
 // Each counter is bumped by a menu action; the consumer watches and opens
 // its popover / focuses its input. See branchPickerBridge.ts for the
@@ -1445,7 +1450,7 @@ onUnmounted(() => {
           <!-- PRs view: creation form takes over when showCreateForm is true -->
           <PrCreateView
             v-else-if="viewMode === 'prs' && prPanel.showCreateForm.value"
-            :current-branch="branchDisplay"
+            :current-branch="repoStatus?.branch ?? ''"
             :branches="branches"
             :cwd="repoFolderPath ?? ''"
           />

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -17,6 +17,15 @@ const pkg = JSON.parse(
 
 export default defineConfig({
   plugins: [vue()],
+  resolve: {
+    alias: {
+      // Point directly at the TypeScript source so Vite never needs a
+      // pre-built dist/ for @gitwand/core during development or CI.
+      // Production builds go through the same alias, so no separate
+      // `pnpm --filter @gitwand/core build` step is required.
+      "@gitwand/core": resolve(__dirname, "../../packages/core/src/index.ts"),
+    },
+  },
   define: {
     // Injected at build time from package.json — use as __APP_VERSION__ anywhere in the app.
     __APP_VERSION__: JSON.stringify(pkg.version),

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,57 @@
 
 All notable changes to this package will be documented in this file. Format inspired by [Keep a Changelog](https://keepachangelog.com/), with deltas grouped by minor version of the v2 sequence (see [`CORE-V2-ROADMAP.md`](../../CORE-V2-ROADMAP.md) for the full plan).
 
+## [2.2.0] — 2026-04-27
+
+### Format profile registry
+
+Adds a registry of **format profiles** that annotate JSON Pointer paths with a merge strategy. The JSON and YAML resolvers consult the registry before falling back to textual conflict markers, which closes two long-standing functional gaps:
+
+- **JSON arrays** at `/dependencies`, `/scripts`, `/keywords`, `/files`, etc. now merge semantically (set-by-identity or merge-keys) instead of bailing out on `Array.isArray` check.
+- **YAML sequences** in `helm/values.yaml` and Kubernetes manifests (containers, volumes, env vars, ports) merge by `name` (or `port` / `host` per resource) instead of failing on a single divergent line.
+
+Five built-in profiles ship in 2.2.0:
+
+| Profile | File matchers | Highlights |
+|---|---|---|
+| `package.json` | basename `package.json` | `/dependencies`, `/devDependencies`, `/peerDependencies`, `/optionalDependencies` (merge-keys); `/scripts` (merge-keys); `/keywords`, `/files`, `/workspaces` (set) |
+| `tsconfig.json` | `tsconfig.json`, `tsconfig.<variant>.json` | `/compilerOptions/lib`, `/compilerOptions/types`, `/include`, `/exclude`, `/files` (set); `/references` (set by `path`) |
+| `composer.json` | basename `composer.json` | `/require`, `/require-dev`, `/conflict`, `/provide`, `/replace`, `/suggest`, `/scripts`, `/autoload` (merge-keys); `/keywords` (set); `/authors` (set by `email`) |
+| `helm/values.yaml` | `values.yaml` or `values.<env>.yaml` under `helm/` or `charts/` | `/spec/template/spec/containers`, `/initContainers`, `/volumes`, `/imagePullSecrets` (set by `name`) |
+| `kubernetes` | `*.ya?ml` under `k8s/`, `kubernetes/`, `manifests/`, or named `deployment|service|ingress|configmap|...yaml` | name-keyed lists for containers / volumes / etc., `/spec/ports` (set by `port`), `/spec/rules` (set by `host`) |
+
+### RFC 6902 (JSON Patch) — minimal in-house implementation
+
+`diffJson(base, target)` produces an op sequence (`add` / `remove` / `replace`), `applyJsonPatch(doc, ops)` applies it (immutable), and `mergeJsonPatches(ours, theirs)` returns the concatenation when paths are disjoint or `null` plus a list of conflicting paths otherwise. Path semantics include the JSON Pointer escapes (`~0`, `~1`). `move` and `copy` are deliberately not supported (express them via `add` + `remove`). Round-trip property `applyJsonPatch(base, diffJson(base, x)) ≡ x` verified on 100 random JSON inputs.
+
+### New exports
+
+- `profileForFile(filePath)`, `registerFormatProfile(profile)`, `strategyForPath(profile, pointer)` — registry API. `registerFormatProfile` returns an unregister function for clean teardown in tests.
+- `diffJson`, `applyJsonPatch`, `mergeJsonPatches`, `parseJsonPointer`, `buildJsonPointer`, `jsonStructEqual` — patch primitives.
+- `FormatProfile`, `PathStrategy`, `JsonPatchOp` — types.
+
+### Rollback
+
+A new `GitWandOptions.disableFormatProfiles?: boolean` (default `false`) reverts the JSON and YAML resolvers to their v2.1 behavior — useful when a third-party profile causes unexpected silent deletions, or for A/B comparison on a specific repo.
+
+```ts
+resolve(content, "package.json", { disableFormatProfiles: true });
+```
+
+### Internals
+
+- New module: `src/format-profiles/{index,types,json-patch,merge-strategies,profiles/*}.ts`.
+- `tryResolveJsonConflict` and `tryResolveYamlConflict` gain an optional `filePath` parameter (back-compat: callers without `filePath` keep the v2.1 behavior). The dispatcher passes `filePath` through, conditional on `disableFormatProfiles`.
+- The YAML resolver gets a parse-merge-serialize fast path that runs only when a profile applies — comments are lost on this path, but the line-based pipeline remains the default for unprofiled YAML.
+- Tests: `__tests__/format-profiles/{json-patch,registry,integration}.test.ts` (≈ +47 tests). Corpus extended with fixtures F26–F30.
+
+### Notes
+
+- Cargo.toml profile is intentionally deferred — the existing `cargo.ts` resolver has its own TOML pipeline and integrating it into the registry warrants a separate refactor.
+- The roadmap's reference to `gh workflow run publish.yml -f package=core` is obsolete: `publish.yml` only accepts `dry_run`; the per-package `npm view` skip in each publish step makes core-only releases work without an input filter.
+
+---
+
 ## [2.1.0] — 2026-04-27
 
 ### Diff backend — Histogram by default

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -73,6 +73,36 @@ const pairs = histogramDiff(linesA, linesB);
 const moves = detectBlockMove(base, ours, theirs);
 ```
 
+## Format profiles (v2.2+)
+
+Since `2.2.0`, the JSON and YAML resolvers consult a registry of **format profiles** before falling back to textual conflict markers. A profile annotates JSON Pointer paths with a merge strategy: `set` (merge as a set with custom identity), `merge-keys` (recurse key-by-key), `ordered-list` (RFC 6902 add/remove), or `opaque` (skip). Built-in profiles cover `package.json`, `tsconfig.json`, `composer.json`, `helm/values.yaml`, and Kubernetes manifests.
+
+Concrete impact: `package.json` with divergent `keywords` arrays, `tsconfig.json` with split `include` paths, or a Kubernetes Deployment with new containers added on each side — all auto-resolve where v2.1 fell back to a textual conflict marker.
+
+```ts
+import { profileForFile, registerFormatProfile } from "@gitwand/core";
+
+const profile = profileForFile("package.json");
+// → { name: "package.json", paths: { "/keywords": { kind: "set" }, ... } }
+
+// Register a custom profile (inserted ahead of built-ins, useful for
+// monorepo-specific paths). The returned function unregisters it.
+const unregister = registerFormatProfile({
+  name: "my-config",
+  matches: (fp) => fp.endsWith("/myconfig.json"),
+  paths: { "/plugins": { kind: "set", identity: (p) => (p as { id: string }).id } },
+  default: { kind: "merge-keys" },
+});
+```
+
+Roll back to the v2.1 behavior (no profile lookup) globally:
+
+```ts
+resolve(content, "package.json", { disableFormatProfiles: true });
+```
+
+The RFC 6902 primitives are also exported (`diffJson`, `applyJsonPatch`, `mergeJsonPatches`) for consumers that want to compose their own merge logic.
+
 ## Links
 
 - 📖 [Documentation](https://github.com/devlint/GitWand#conflict-resolution-engine)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gitwand/core",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "GitWand core — automatic Git conflict resolution engine (powers @gitwand/cli, @gitwand/mcp, and the GitWand desktop app)",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/src/__tests__/corpus.ts
+++ b/packages/core/src/__tests__/corpus.ts
@@ -767,6 +767,182 @@ const F25: CorpusFixture = {
   expectedOutput: null,
 };
 
+// ─── v2.2 — Fixtures « format profiles » ─────────────────────
+//
+// Cible les cas que v2.2 (registre de profils + RFC 6902) doit débloquer :
+// arrays JSON/YAML modifiés des deux côtés sur des paths annotés (set ou
+// merge-keys par identité). Les expectedResolved sont calibrés sur le
+// comportement réel après hook profils.
+
+const F26: CorpusFixture = {
+  id: "F26",
+  description: "v2.2 — package.json /keywords ajoutés des deux côtés (set)",
+  filePath: "package.json",
+  category: "format-aware",
+  input: [
+    `<<<<<<< ours`,
+    `{`,
+    `  "name": "demo",`,
+    `  "keywords": ["git", "merge"]`,
+    `}`,
+    `||||||| base`,
+    `{`,
+    `  "name": "demo",`,
+    `  "keywords": ["git"]`,
+    `}`,
+    `=======`,
+    `{`,
+    `  "name": "demo",`,
+    `  "keywords": ["git", "diff"]`,
+    `}`,
+    `>>>>>>> theirs`,
+  ].join("\n"),
+  expectedType: "complex",
+  expectedResolved: true,
+};
+
+const F27: CorpusFixture = {
+  id: "F27",
+  description: "v2.2 — package.json /scripts merge-keys (clés différentes des deux côtés)",
+  filePath: "package.json",
+  category: "format-aware",
+  input: [
+    `<<<<<<< ours`,
+    `{`,
+    `  "name": "demo",`,
+    `  "scripts": {`,
+    `    "build": "tsc",`,
+    `    "lint": "eslint ."`,
+    `  }`,
+    `}`,
+    `||||||| base`,
+    `{`,
+    `  "name": "demo",`,
+    `  "scripts": {`,
+    `    "build": "tsc"`,
+    `  }`,
+    `}`,
+    `=======`,
+    `{`,
+    `  "name": "demo",`,
+    `  "scripts": {`,
+    `    "build": "tsc",`,
+    `    "test": "vitest"`,
+    `  }`,
+    `}`,
+    `>>>>>>> theirs`,
+  ].join("\n"),
+  expectedType: "non_overlapping",
+  expectedResolved: true,
+};
+
+const F28: CorpusFixture = {
+  id: "F28",
+  description: "v2.2 — tsconfig.json /include divergent (set)",
+  filePath: "tsconfig.json",
+  category: "format-aware",
+  input: [
+    `<<<<<<< ours`,
+    `{`,
+    `  "compilerOptions": { "strict": true },`,
+    `  "include": ["src", "tests"]`,
+    `}`,
+    `||||||| base`,
+    `{`,
+    `  "compilerOptions": { "strict": true },`,
+    `  "include": ["src"]`,
+    `}`,
+    `=======`,
+    `{`,
+    `  "compilerOptions": { "strict": true },`,
+    `  "include": ["src", "scripts"]`,
+    `}`,
+    `>>>>>>> theirs`,
+  ].join("\n"),
+  expectedType: "complex",
+  expectedResolved: true,
+};
+
+const F29: CorpusFixture = {
+  id: "F29",
+  description: "v2.2 — kubernetes Deployment containers mergés par 'name'",
+  filePath: "k8s/deployment.yaml",
+  category: "format-aware",
+  input: [
+    `<<<<<<< ours`,
+    `apiVersion: apps/v1`,
+    `kind: Deployment`,
+    `spec:`,
+    `  template:`,
+    `    spec:`,
+    `      containers:`,
+    `        - name: app`,
+    `          image: app:2.0`,
+    `        - name: sidecar`,
+    `          image: sidecar:1.0`,
+    `||||||| base`,
+    `apiVersion: apps/v1`,
+    `kind: Deployment`,
+    `spec:`,
+    `  template:`,
+    `    spec:`,
+    `      containers:`,
+    `        - name: app`,
+    `          image: app:1.0`,
+    `=======`,
+    `apiVersion: apps/v1`,
+    `kind: Deployment`,
+    `spec:`,
+    `  template:`,
+    `    spec:`,
+    `      containers:`,
+    `        - name: app`,
+    `          image: app:1.0`,
+    `        - name: log-shipper`,
+    `          image: fluent-bit:2.0`,
+    `>>>>>>> theirs`,
+  ].join("\n"),
+  expectedType: "complex",
+  expectedResolved: true,
+};
+
+const F30: CorpusFixture = {
+  id: "F30",
+  description: "v2.2 — helm/values.yaml containers env mergés (set par 'name')",
+  filePath: "charts/myapp/values.yaml",
+  category: "format-aware",
+  input: [
+    `<<<<<<< ours`,
+    `spec:`,
+    `  template:`,
+    `    spec:`,
+    `      containers:`,
+    `        - name: app`,
+    `          image: app:1.0`,
+    `        - name: cache`,
+    `          image: redis:7`,
+    `||||||| base`,
+    `spec:`,
+    `  template:`,
+    `    spec:`,
+    `      containers:`,
+    `        - name: app`,
+    `          image: app:1.0`,
+    `=======`,
+    `spec:`,
+    `  template:`,
+    `    spec:`,
+    `      containers:`,
+    `        - name: app`,
+    `          image: app:1.0`,
+    `        - name: metrics`,
+    `          image: prom-exporter:0.5`,
+    `>>>>>>> theirs`,
+  ].join("\n"),
+  expectedType: "complex",
+  expectedResolved: true,
+};
+
 // ─── Export ─────────────────────────────────────────────────
 
 export const CORPUS: CorpusFixture[] = [
@@ -776,6 +952,8 @@ export const CORPUS: CorpusFixture[] = [
   F16, F17, F18, F19, F20,
   // v2.1
   F21, F22, F23, F24, F25,
+  // v2.2
+  F26, F27, F28, F29, F30,
 ];
 
 /** Résumé par catégorie */

--- a/packages/core/src/__tests__/format-profiles/integration.test.ts
+++ b/packages/core/src/__tests__/format-profiles/integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests d'intégration v2.2 — vérifie que le hook profil dans
+ * `tryResolveJsonConflict` débloque les cas qui retombaient en fallback
+ * textuel en v2.1.
+ */
+
+import { describe, it, expect } from "vitest";
+import { tryResolveJsonConflict } from "../../resolvers/json.js";
+
+describe("tryResolveJsonConflict — package.json + profil", () => {
+  it("/keywords ajoutés des deux côtés (set) — résout", () => {
+    const base = `{
+  "name": "demo",
+  "keywords": ["git"]
+}`;
+    const ours = `{
+  "name": "demo",
+  "keywords": ["git", "merge"]
+}`;
+    const theirs = `{
+  "name": "demo",
+  "keywords": ["git", "diff"]
+}`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "package.json",
+    );
+    expect(result.merged).not.toBeNull();
+    const parsed = JSON.parse(result.merged as string);
+    // Le set doit contenir tous les keywords (ordre = ours d'abord, puis nouveaux de theirs)
+    expect(parsed.keywords).toEqual(["git", "merge", "diff"]);
+  });
+
+  it("/files modifiés des deux côtés — set préserve les ajouts", () => {
+    const base = `{
+  "name": "demo",
+  "files": ["dist", "README.md"]
+}`;
+    const ours = `{
+  "name": "demo",
+  "files": ["dist", "README.md", "LICENSE"]
+}`;
+    const theirs = `{
+  "name": "demo",
+  "files": ["dist", "README.md", "CHANGELOG.md"]
+}`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "package.json",
+    );
+    expect(result.merged).not.toBeNull();
+    const parsed = JSON.parse(result.merged as string);
+    expect(parsed.files).toEqual(["dist", "README.md", "LICENSE", "CHANGELOG.md"]);
+  });
+
+  it("sans filePath — pas de profil, fallback v2.1 (pas de routage)", () => {
+    // Sans filePath, le résolveur ne consulte pas le profil → comportement
+    // v2.1 (les arrays modifiés différemment retombent en conflit).
+    const base = `{ "tags": ["a"] }`;
+    const ours = `{ "tags": ["a", "b"] }`;
+    const theirs = `{ "tags": ["a", "c"] }`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      // pas de filePath
+    );
+    expect(result.merged).toBeNull();
+  });
+});
+
+describe("tryResolveJsonConflict — tsconfig.json + profil", () => {
+  it("/include divergent (set) — résout", () => {
+    const base = `{
+  "compilerOptions": { "strict": true },
+  "include": ["src"]
+}`;
+    const ours = `{
+  "compilerOptions": { "strict": true },
+  "include": ["src", "tests"]
+}`;
+    const theirs = `{
+  "compilerOptions": { "strict": true },
+  "include": ["src", "scripts"]
+}`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "tsconfig.json",
+    );
+    expect(result.merged).not.toBeNull();
+    const parsed = JSON.parse(result.merged as string);
+    expect(parsed.include).toEqual(["src", "tests", "scripts"]);
+  });
+
+  it("/compilerOptions/lib ajouté des deux côtés (depuis base sans lib)", () => {
+    const base = `{
+  "compilerOptions": { "strict": true }
+}`;
+    const ours = `{
+  "compilerOptions": { "strict": true, "lib": ["ES2022", "DOM"] }
+}`;
+    const theirs = `{
+  "compilerOptions": { "strict": true, "lib": ["ES2022", "WebWorker"] }
+}`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "tsconfig.json",
+    );
+    expect(result.merged).not.toBeNull();
+    const parsed = JSON.parse(result.merged as string);
+    expect(parsed.compilerOptions.lib).toEqual(["ES2022", "DOM", "WebWorker"]);
+  });
+
+  it("/references avec identité 'path' — déduplique correctement", () => {
+    const base = `{
+  "references": [{ "path": "../shared" }]
+}`;
+    const ours = `{
+  "references": [{ "path": "../shared" }, { "path": "../utils" }]
+}`;
+    const theirs = `{
+  "references": [{ "path": "../shared" }, { "path": "../core" }]
+}`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "tsconfig.json",
+    );
+    expect(result.merged).not.toBeNull();
+    const parsed = JSON.parse(result.merged as string);
+    expect(parsed.references).toEqual([
+      { path: "../shared" },
+      { path: "../utils" },
+      { path: "../core" },
+    ]);
+  });
+});
+
+describe("tryResolveYamlConflict — kubernetes + profil", () => {
+  it("Deployment containers mergés par 'name'", async () => {
+    const { tryResolveYamlConflict } = await import("../../resolvers/yaml.js");
+    const base = `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: app:1.0
+`;
+    const ours = `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: app:2.0
+        - name: sidecar
+          image: sidecar:1.0
+`;
+    const theirs = `apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: app:1.0
+        - name: log-shipper
+          image: fluent-bit:2.0
+`;
+    const result = tryResolveYamlConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "k8s/deployment.yaml",
+    );
+    expect(result.mergedLines).not.toBeNull();
+    const merged = result.mergedLines!.join("\n");
+    // app a été modifié (1.0 → 2.0) côté ours, theirs n'y a pas touché → 2.0
+    expect(merged).toContain("image: app:2.0");
+    // les deux nouveaux containers sont présents
+    expect(merged).toContain("sidecar");
+    expect(merged).toContain("log-shipper");
+  });
+});
+
+describe("disableFormatProfiles — rollback global v2.1", () => {
+  it("désactive le hook profil dans le pipeline complet (resolve)", async () => {
+    const { resolve } = await import("../../resolver.js");
+    const conflict = `<<<<<<< ours
+{
+  "name": "demo",
+  "keywords": ["a", "b"]
+}
+=======
+{
+  "name": "demo",
+  "keywords": ["a", "c"]
+}
+>>>>>>> theirs
+`;
+    // Sans disable : profil package.json résout via "set"
+    const enabled = resolve(conflict, "package.json");
+    expect(enabled.stats.autoResolved).toBe(1);
+
+    // Avec disable : retombée comportement v2.1 (fallback textuel)
+    const disabled = resolve(conflict, "package.json", { disableFormatProfiles: true });
+    expect(disabled.stats.autoResolved).toBe(0);
+  });
+});
+
+describe("tryResolveJsonConflict — non-applicable", () => {
+  it("conflit sur scalaire (modif divergente) — pas résolu malgré profil", () => {
+    const base = `{ "name": "demo" }`;
+    const ours = `{ "name": "demo-app" }`;
+    const theirs = `{ "name": "demo-lib" }`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "package.json",
+    );
+    expect(result.merged).toBeNull();
+  });
+
+  it("filePath inconnu (pas de profil) — comportement v2.1", () => {
+    const base = `{ "list": ["a"] }`;
+    const ours = `{ "list": ["a", "b"] }`;
+    const theirs = `{ "list": ["a", "c"] }`;
+    const result = tryResolveJsonConflict(
+      base.split("\n"),
+      ours.split("\n"),
+      theirs.split("\n"),
+      "unknown-file.json",
+    );
+    expect(result.merged).toBeNull();
+  });
+});

--- a/packages/core/src/__tests__/format-profiles/json-patch.test.ts
+++ b/packages/core/src/__tests__/format-profiles/json-patch.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests de l'implémentation RFC 6902 maison (v2.2).
+ *
+ * Couvre :
+ *  - parseJsonPointer / buildJsonPointer (escapes ~0, ~1)
+ *  - applyJsonPatch sur add / remove / replace
+ *  - diffJson (objets, scalaires, type changes)
+ *  - mergeJsonPatches (paths disjoints vs en conflit)
+ *  - test de propriété : applyJsonPatch(base, diffJson(base, x)) ≡ x
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  parseJsonPointer,
+  buildJsonPointer,
+  applyJsonPatch,
+  diffJson,
+  mergeJsonPatches,
+  jsonStructEqual,
+} from "../../format-profiles/json-patch.js";
+
+// ─── JSON Pointer (RFC 6901) ────────────────────────────────
+
+describe("parseJsonPointer / buildJsonPointer", () => {
+  it("racine vide", () => {
+    expect(parseJsonPointer("")).toEqual([]);
+    expect(buildJsonPointer([])).toBe("");
+  });
+
+  it("path simple", () => {
+    expect(parseJsonPointer("/foo/bar")).toEqual(["foo", "bar"]);
+    expect(buildJsonPointer(["foo", "bar"])).toBe("/foo/bar");
+  });
+
+  it("escapes ~0 (~) et ~1 (/)", () => {
+    expect(parseJsonPointer("/a~1b/c~0d")).toEqual(["a/b", "c~d"]);
+    expect(buildJsonPointer(["a/b", "c~d"])).toBe("/a~1b/c~0d");
+  });
+
+  it("token vide légal (clé '')", () => {
+    expect(parseJsonPointer("//x")).toEqual(["", "x"]);
+  });
+
+  it("path invalide → throw", () => {
+    expect(() => parseJsonPointer("foo/bar")).toThrow();
+  });
+});
+
+// ─── applyJsonPatch ─────────────────────────────────────────
+
+describe("applyJsonPatch — opérations de base", () => {
+  it("add à la racine — replace tout le doc", () => {
+    expect(applyJsonPatch({ a: 1 }, [{ op: "add", path: "", value: { b: 2 } }])).toEqual({ b: 2 });
+  });
+
+  it("add une nouvelle clé d'objet", () => {
+    expect(applyJsonPatch({ a: 1 }, [{ op: "add", path: "/b", value: 2 }])).toEqual({ a: 1, b: 2 });
+  });
+
+  it("replace une clé existante", () => {
+    expect(applyJsonPatch({ a: 1 }, [{ op: "replace", path: "/a", value: 99 }])).toEqual({ a: 99 });
+  });
+
+  it("remove une clé existante", () => {
+    expect(applyJsonPatch({ a: 1, b: 2 }, [{ op: "remove", path: "/a" }])).toEqual({ b: 2 });
+  });
+
+  it("add dans un tableau (index)", () => {
+    expect(applyJsonPatch([1, 2, 3], [{ op: "add", path: "/1", value: 99 }])).toEqual([1, 99, 2, 3]);
+  });
+
+  it("add en fin de tableau via '-'", () => {
+    expect(applyJsonPatch([1, 2], [{ op: "add", path: "/-", value: 3 }])).toEqual([1, 2, 3]);
+  });
+
+  it("remove dans un tableau (shift)", () => {
+    expect(applyJsonPatch([1, 2, 3], [{ op: "remove", path: "/1" }])).toEqual([1, 3]);
+  });
+
+  it("path imbriqué", () => {
+    const doc = { user: { name: "alice", age: 30 } };
+    const out = applyJsonPatch(doc, [{ op: "replace", path: "/user/name", value: "bob" }]);
+    expect(out).toEqual({ user: { name: "bob", age: 30 } });
+    // Immutabilité : doc d'origine intact
+    expect(doc.user.name).toBe("alice");
+  });
+
+  it("séquence de plusieurs ops", () => {
+    const out = applyJsonPatch({ a: 1, b: 2 }, [
+      { op: "add", path: "/c", value: 3 },
+      { op: "remove", path: "/a" },
+      { op: "replace", path: "/b", value: 20 },
+    ]);
+    expect(out).toEqual({ b: 20, c: 3 });
+  });
+
+  it("remove sur clé absente → throw", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "remove", path: "/missing" }]),
+    ).toThrow();
+  });
+
+  it("replace sur path inexistant → throw", () => {
+    expect(() =>
+      applyJsonPatch({ a: 1 }, [{ op: "replace", path: "/missing/sub", value: 0 }]),
+    ).toThrow();
+  });
+});
+
+// ─── diffJson ───────────────────────────────────────────────
+
+describe("diffJson", () => {
+  it("aucune différence → []", () => {
+    expect(diffJson({ a: 1 }, { a: 1 })).toEqual([]);
+  });
+
+  it("ajout d'une clé", () => {
+    expect(diffJson({ a: 1 }, { a: 1, b: 2 })).toEqual([
+      { op: "add", path: "/b", value: 2 },
+    ]);
+  });
+
+  it("suppression d'une clé", () => {
+    expect(diffJson({ a: 1, b: 2 }, { a: 1 })).toEqual([
+      { op: "remove", path: "/b" },
+    ]);
+  });
+
+  it("changement scalaire → replace", () => {
+    expect(diffJson({ a: 1 }, { a: 2 })).toEqual([
+      { op: "replace", path: "/a", value: 2 },
+    ]);
+  });
+
+  it("changement de type → replace", () => {
+    expect(diffJson({ a: 1 }, { a: "one" })).toEqual([
+      { op: "replace", path: "/a", value: "one" },
+    ]);
+  });
+
+  it("récursion sur objet imbriqué", () => {
+    const ops = diffJson({ user: { name: "a", age: 30 } }, { user: { name: "b", age: 30 } });
+    expect(ops).toEqual([
+      { op: "replace", path: "/user/name", value: "b" },
+    ]);
+  });
+
+  it("tableau différent → replace global du tableau", () => {
+    expect(diffJson({ deps: [1, 2] }, { deps: [1, 2, 3] })).toEqual([
+      { op: "replace", path: "/deps", value: [1, 2, 3] },
+    ]);
+  });
+});
+
+// ─── mergeJsonPatches ───────────────────────────────────────
+
+describe("mergeJsonPatches", () => {
+  it("paths disjoints → concaténation", () => {
+    const ours: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "add", path: "/x", value: 1 },
+    ];
+    const theirs: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "add", path: "/y", value: 2 },
+    ];
+    const r = mergeJsonPatches(ours, theirs);
+    expect(r.merged).toEqual([...ours, ...theirs]);
+    expect(r.conflictingPaths).toEqual([]);
+  });
+
+  it("path identique → conflit", () => {
+    const ours: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "replace", path: "/v", value: 1 },
+    ];
+    const theirs: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "replace", path: "/v", value: 2 },
+    ];
+    const r = mergeJsonPatches(ours, theirs);
+    expect(r.merged).toBeNull();
+    expect(r.conflictingPaths).toEqual(["/v"]);
+  });
+
+  it("path préfixe → conflit", () => {
+    // ours touche /user, theirs touche /user/name → ils se chevauchent.
+    const ours: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "replace", path: "/user", value: { name: "x" } },
+    ];
+    const theirs: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "replace", path: "/user/name", value: "y" },
+    ];
+    const r = mergeJsonPatches(ours, theirs);
+    expect(r.merged).toBeNull();
+  });
+
+  it("paths frères dans un même objet → disjoints", () => {
+    // /a/b et /a/c sont disjoints (frères).
+    const ours: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "add", path: "/a/b", value: 1 },
+    ];
+    const theirs: import("../../format-profiles/types.js").JsonPatchOp[] = [
+      { op: "add", path: "/a/c", value: 2 },
+    ];
+    const r = mergeJsonPatches(ours, theirs);
+    expect(r.merged).toHaveLength(2);
+  });
+});
+
+// ─── Test de propriété : round-trip ─────────────────────────
+
+/** PRNG déterministe (mulberry32) — évite la flakiness. */
+function mulberry32(seed: number): () => number {
+  let t = seed;
+  return () => {
+    t = (t + 0x6d2b79f5) | 0;
+    let x = t;
+    x = Math.imul(x ^ (x >>> 15), x | 1);
+    x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+    return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Génère un JSON pseudo-aléatoire avec profondeur bornée. */
+function randomJson(rng: () => number, depth: number): unknown {
+  if (depth <= 0) {
+    const r = rng();
+    if (r < 0.25) return null;
+    if (r < 0.5) return Math.floor(rng() * 100);
+    if (r < 0.75) return rng() < 0.5;
+    return `s_${Math.floor(rng() * 1000)}`;
+  }
+  const r = rng();
+  if (r < 0.4) {
+    const n = Math.floor(rng() * 4);
+    const obj: Record<string, unknown> = {};
+    for (let i = 0; i < n; i++) {
+      obj[`k${i}`] = randomJson(rng, depth - 1);
+    }
+    return obj;
+  }
+  if (r < 0.6) {
+    const n = Math.floor(rng() * 3);
+    return Array.from({ length: n }, () => randomJson(rng, depth - 1));
+  }
+  return randomJson(rng, 0); // scalaire
+}
+
+describe("Round-trip — propriété diffJson + applyJsonPatch", () => {
+  it("applyJsonPatch(base, diffJson(base, x)) ≡ x sur 100 entrées générées", () => {
+    const rng = mulberry32(20260427);
+    for (let run = 0; run < 100; run++) {
+      const base = randomJson(rng, 3);
+      const target = randomJson(rng, 3);
+      const ops = diffJson(base, target);
+      const reconstructed = applyJsonPatch(base, ops);
+      // Égalité structurelle (pas de référence — `target` peut contenir des
+      // sous-arbres équivalents par valeur mais pas identiques par référence).
+      const ok = jsonStructEqual(reconstructed, target);
+      if (!ok) {
+        // Affiche l'input pour debug si l'assert casse.
+        // eslint-disable-next-line no-console
+        console.error(`FAIL run ${run}:`, { base, target, ops, reconstructed });
+      }
+      expect(ok).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/__tests__/format-profiles/registry.test.ts
+++ b/packages/core/src/__tests__/format-profiles/registry.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests du registre de profils (v2.2).
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  profileForFile,
+  registerFormatProfile,
+  strategyForPath,
+} from "../../format-profiles/index.js";
+import type { FormatProfile } from "../../format-profiles/types.js";
+
+describe("profileForFile — built-ins", () => {
+  it("matche package.json à la racine", () => {
+    const p = profileForFile("package.json");
+    expect(p?.name).toBe("package.json");
+  });
+
+  it("matche package.json dans un workspace", () => {
+    const p = profileForFile("apps/desktop/package.json");
+    expect(p?.name).toBe("package.json");
+  });
+
+  it("ne matche pas package-lock.json", () => {
+    expect(profileForFile("package-lock.json")).toBeNull();
+  });
+
+  it("ne matche pas un fichier non reconnu", () => {
+    expect(profileForFile("README.md")).toBeNull();
+    expect(profileForFile("src/utils.ts")).toBeNull();
+  });
+
+  it("matche tsconfig.json et ses variants", () => {
+    expect(profileForFile("tsconfig.json")?.name).toBe("tsconfig.json");
+    expect(profileForFile("tsconfig.build.json")?.name).toBe("tsconfig.json");
+    expect(profileForFile("apps/desktop/tsconfig.app.json")?.name).toBe("tsconfig.json");
+  });
+
+  it("matche composer.json", () => {
+    expect(profileForFile("composer.json")?.name).toBe("composer.json");
+    expect(profileForFile("backend/composer.json")?.name).toBe("composer.json");
+    // composer-lock pas couvert par ce profil
+    expect(profileForFile("composer.lock")).toBeNull();
+  });
+
+  it("matche helm/values.yaml", () => {
+    expect(profileForFile("helm/values.yaml")?.name).toBe("helm/values.yaml");
+    expect(profileForFile("charts/myapp/values.yaml")?.name).toBe("helm/values.yaml");
+    expect(profileForFile("charts/myapp/values.production.yaml")?.name).toBe("helm/values.yaml");
+    // .yaml sans dossier helm/charts → kubernetes ou null
+    expect(profileForFile("config/values.yaml")?.name).not.toBe("helm/values.yaml");
+  });
+
+  it("matche kubernetes manifests", () => {
+    expect(profileForFile("k8s/deployment.yaml")?.name).toBe("kubernetes");
+    expect(profileForFile("kubernetes/service.yml")?.name).toBe("kubernetes");
+    expect(profileForFile("manifests/configmap.yaml")?.name).toBe("kubernetes");
+    // basename only (sans dossier k8s)
+    expect(profileForFile("deployment.yaml")?.name).toBe("kubernetes");
+    expect(profileForFile("ingress.yml")?.name).toBe("kubernetes");
+    // .yaml sans signal kubernetes ni helm → null
+    expect(profileForFile("config/app.yaml")).toBeNull();
+  });
+});
+
+describe("strategyForPath — tsconfig.json", () => {
+  const profile = profileForFile("tsconfig.json")!;
+
+  it("/compilerOptions/lib → set", () => {
+    expect(strategyForPath(profile, "/compilerOptions/lib")).toEqual({ kind: "set" });
+  });
+
+  it("/include → set", () => {
+    expect(strategyForPath(profile, "/include")).toEqual({ kind: "set" });
+  });
+
+  it("/references identité par path", () => {
+    const s = strategyForPath(profile, "/references");
+    expect(s.kind).toBe("set");
+    if (s.kind === "set" && s.identity) {
+      expect(s.identity({ path: "../shared" })).toBe("../shared");
+    }
+  });
+});
+
+describe("strategyForPath — package.json", () => {
+  const profile = profileForFile("package.json")!;
+
+  it("/dependencies → merge-keys", () => {
+    expect(strategyForPath(profile, "/dependencies")).toEqual({ kind: "merge-keys" });
+  });
+
+  it("/scripts → merge-keys", () => {
+    expect(strategyForPath(profile, "/scripts")).toEqual({ kind: "merge-keys" });
+  });
+
+  it("/keywords → set", () => {
+    expect(strategyForPath(profile, "/keywords")).toEqual({ kind: "set" });
+  });
+
+  it("path inconnu → défaut (merge-keys)", () => {
+    expect(strategyForPath(profile, "/foo")).toEqual({ kind: "merge-keys" });
+  });
+});
+
+describe("registerFormatProfile — custom + cleanup", () => {
+  it("override un built-in et désinscrit proprement", () => {
+    const customProfile: FormatProfile = {
+      name: "custom-package-json",
+      matches: (fp) => fp.endsWith("package.json"),
+      paths: {
+        "/dependencies": { kind: "ordered-list" },
+      },
+      default: { kind: "opaque" },
+    };
+
+    // Avant register : built-in trouvé
+    expect(profileForFile("package.json")?.name).toBe("package.json");
+
+    const unregister = registerFormatProfile(customProfile);
+    try {
+      // Le custom prend priorité (inséré en tête)
+      expect(profileForFile("package.json")?.name).toBe("custom-package-json");
+      expect(strategyForPath(customProfile, "/dependencies")).toEqual({ kind: "ordered-list" });
+    } finally {
+      unregister();
+    }
+
+    // Après cleanup : built-in retrouvé
+    expect(profileForFile("package.json")?.name).toBe("package.json");
+  });
+});
+
+describe("strategyForPath — wildcards", () => {
+  it("matche un segment via *", () => {
+    const profile: FormatProfile = {
+      name: "test",
+      matches: () => true,
+      paths: {
+        "/items/*/tags": { kind: "set" },
+      },
+      default: { kind: "opaque" },
+    };
+    expect(strategyForPath(profile, "/items/foo/tags")).toEqual({ kind: "set" });
+    expect(strategyForPath(profile, "/items/0/tags")).toEqual({ kind: "set" });
+    // Non-match : nombre de segments différent
+    expect(strategyForPath(profile, "/items/foo")).toEqual({ kind: "opaque" });
+    expect(strategyForPath(profile, "/items/foo/tags/extra")).toEqual({ kind: "opaque" });
+  });
+});

--- a/packages/core/src/format-profiles/index.ts
+++ b/packages/core/src/format-profiles/index.ts
@@ -1,0 +1,89 @@
+/**
+ * GitWand — Registre de profils de format
+ *
+ * Le registre centralise les FormatProfile reconnus. Les consommateurs
+ * (tryResolveJsonConflict, tryResolveYamlConflict) appellent profileForFile()
+ * pour obtenir, le cas échéant, un profil applicable au filePath courant.
+ *
+ * Les profils sont essayés dans l'ordre d'enregistrement — le premier dont
+ * matches(filePath) retourne true gagne. Les built-ins sont enregistrés ici ;
+ * les consommateurs externes peuvent ajouter les leurs via registerFormatProfile.
+ */
+
+import type { FormatProfile, PathStrategy } from "./types.js";
+import { packageJsonProfile } from "./profiles/package-json.js";
+import { tsconfigProfile } from "./profiles/tsconfig.js";
+import { composerProfile } from "./profiles/composer.js";
+import { helmValuesProfile } from "./profiles/helm-values.js";
+import { kubernetesProfile } from "./profiles/kubernetes.js";
+
+const PROFILES: FormatProfile[] = [
+  packageJsonProfile,
+  tsconfigProfile,
+  composerProfile,
+  // YAML profiles : helm avant kubernetes (helm/values.yaml peut matcher les
+  // deux, on veut le plus spécifique en premier).
+  helmValuesProfile,
+  kubernetesProfile,
+];
+
+/**
+ * Cherche un profil applicable au filePath. Retourne null si aucun match.
+ */
+export function profileForFile(filePath: string): FormatProfile | null {
+  for (const profile of PROFILES) {
+    if (profile.matches(filePath)) return profile;
+  }
+  return null;
+}
+
+/**
+ * Enregistre un profil custom. Inséré en tête (priorité sur les built-ins
+ * pour les filePath qu'il match), pratique pour qu'une extension VS Code ou
+ * un consommateur monorepo override un built-in.
+ *
+ * @returns une fonction d'unregister (pour cleanup propre dans les tests).
+ */
+export function registerFormatProfile(profile: FormatProfile): () => void {
+  PROFILES.unshift(profile);
+  return () => {
+    const idx = PROFILES.indexOf(profile);
+    if (idx >= 0) PROFILES.splice(idx, 1);
+  };
+}
+
+/**
+ * Résout la stratégie applicable à un chemin JSON Pointer dans un profil.
+ *
+ * Recherche : exact match d'abord, puis fallback à la stratégie par défaut
+ * du profil. Les wildcards "*" dans les paths du profil matchent un segment
+ * unique du pointer.
+ */
+export function strategyForPath(
+  profile: FormatProfile,
+  pointer: string,
+): PathStrategy {
+  // Match exact
+  if (profile.paths[pointer]) return profile.paths[pointer];
+  // Match avec wildcards : on convertit chaque path-clé du profil en regex
+  // (segments-by-segments, "*" → tout sauf "/").
+  for (const [pathKey, strategy] of Object.entries(profile.paths)) {
+    if (!pathKey.includes("*")) continue;
+    if (matchesWildcardPath(pathKey, pointer)) return strategy;
+  }
+  return profile.default;
+}
+
+/** Match un JSON pointer contre un pattern à wildcards "*" (segment unique). */
+function matchesWildcardPath(pattern: string, pointer: string): boolean {
+  const patternSegs = pattern.split("/");
+  const pointerSegs = pointer.split("/");
+  if (patternSegs.length !== pointerSegs.length) return false;
+  for (let i = 0; i < patternSegs.length; i++) {
+    if (patternSegs[i] === "*") continue;
+    if (patternSegs[i] !== pointerSegs[i]) return false;
+  }
+  return true;
+}
+
+export type { FormatProfile, PathStrategy, JsonPatchOp } from "./types.js";

--- a/packages/core/src/format-profiles/json-patch.ts
+++ b/packages/core/src/format-profiles/json-patch.ts
@@ -1,0 +1,277 @@
+/**
+ * GitWand — RFC 6902 (JSON Patch) minimal
+ *
+ * Implémentation maison, pas de dep externe. Couvre `add`, `remove`, `replace`.
+ * `move` et `copy` non implémentées (gérées par séquences add/remove).
+ *
+ * Trois primitives :
+ * - `diffJson(base, target)` produit la séquence d'ops qui transforme base en target.
+ * - `applyJsonPatch(doc, ops)` applique séquentiellement, retourne le doc résultat
+ *   (immutable — entrée non modifiée).
+ * - `mergeJsonPatches(oursOps, theirsOps)` concatène si les paths sont disjoints,
+ *   `null` si conflit (au moins une op des deux côtés sur le même path).
+ *
+ * JSON Pointer (RFC 6901) avec escape `~0` → `~` et `~1` → `/`.
+ */
+
+import type { JsonPatchOp } from "./types.js";
+
+// ─── JSON Pointer (RFC 6901) ─────────────────────────────────
+
+/**
+ * Parse un JSON Pointer en tableau de tokens. Le pointer racine `""` retourne
+ * `[]`. Chaque token est ré-échappé : `~0` → `~`, `~1` → `/`.
+ */
+export function parseJsonPointer(pointer: string): string[] {
+  if (pointer === "") return [];
+  if (pointer[0] !== "/") {
+    throw new Error(`Invalid JSON pointer: ${pointer} (must start with '/')`);
+  }
+  return pointer
+    .slice(1)
+    .split("/")
+    .map((tok) => tok.replace(/~1/g, "/").replace(/~0/g, "~"));
+}
+
+/**
+ * Construit un JSON Pointer depuis un tableau de tokens. Échappe `~` et `/`.
+ */
+export function buildJsonPointer(tokens: ReadonlyArray<string>): string {
+  if (tokens.length === 0) return "";
+  return (
+    "/" +
+    tokens
+      .map((tok) => tok.replace(/~/g, "~0").replace(/\//g, "~1"))
+      .join("/")
+  );
+}
+
+// ─── Apply ───────────────────────────────────────────────────
+
+/** Type minimum pour parcourir un JSON. `null` est une valeur valide (pas une absence). */
+type JsonValue = unknown;
+
+function isPlainObject(v: JsonValue): v is Record<string, JsonValue> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/** Clone superficiel d'un objet ou d'un tableau (immutabilité au niveau du parent). */
+function shallowClone(v: JsonValue): JsonValue {
+  if (Array.isArray(v)) return [...v];
+  if (isPlainObject(v)) return { ...v };
+  return v;
+}
+
+/**
+ * Applique une séquence d'opérations RFC 6902 à un document. Retourne le
+ * nouveau document (l'entrée n'est pas modifiée). Lance une `Error` si une
+ * opération réfère à un path inexistant (sauf `add` qui crée).
+ */
+export function applyJsonPatch(doc: JsonValue, ops: ReadonlyArray<JsonPatchOp>): JsonValue {
+  let current: JsonValue = doc;
+  for (const op of ops) {
+    current = applyOp(current, op);
+  }
+  return current;
+}
+
+function applyOp(doc: JsonValue, op: JsonPatchOp): JsonValue {
+  const tokens = parseJsonPointer(op.path);
+  if (tokens.length === 0) {
+    // Path racine — replace ou add remplace tout le doc, remove vide.
+    if (op.op === "replace" || op.op === "add") return op.value;
+    if (op.op === "remove") return undefined;
+  }
+  return applyAt(doc, tokens, 0, op);
+}
+
+function applyAt(node: JsonValue, tokens: string[], depth: number, op: JsonPatchOp): JsonValue {
+  if (depth === tokens.length - 1) {
+    const lastToken = tokens[depth];
+    if (Array.isArray(node)) {
+      const arr = [...node];
+      if (op.op === "add") {
+        if (lastToken === "-") {
+          arr.push(op.value);
+        } else {
+          const idx = parseInt(lastToken, 10);
+          if (!Number.isInteger(idx) || idx < 0 || idx > arr.length) {
+            throw new Error(`Invalid array index: ${lastToken}`);
+          }
+          arr.splice(idx, 0, op.value);
+        }
+        return arr;
+      }
+      const idx = parseInt(lastToken, 10);
+      if (!Number.isInteger(idx) || idx < 0 || idx >= arr.length) {
+        throw new Error(`Invalid array index for ${op.op}: ${lastToken}`);
+      }
+      if (op.op === "remove") {
+        arr.splice(idx, 1);
+      } else {
+        // replace
+        arr[idx] = op.value;
+      }
+      return arr;
+    }
+    if (isPlainObject(node)) {
+      const obj = { ...node };
+      if (op.op === "add" || op.op === "replace") {
+        obj[lastToken] = op.value;
+      } else {
+        // remove
+        if (!(lastToken in obj)) {
+          throw new Error(`Cannot remove non-existent key: ${lastToken}`);
+        }
+        delete obj[lastToken];
+      }
+      return obj;
+    }
+    throw new Error(`Cannot apply ${op.op} to non-container at ${tokens.join("/")}`);
+  }
+
+  // Intermediate token — descend.
+  const token = tokens[depth];
+  if (Array.isArray(node)) {
+    const idx = parseInt(token, 10);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= node.length) {
+      throw new Error(`Invalid array index: ${token}`);
+    }
+    const arr = [...node];
+    arr[idx] = applyAt(arr[idx], tokens, depth + 1, op);
+    return arr;
+  }
+  if (isPlainObject(node)) {
+    if (!(token in node)) {
+      throw new Error(`Path does not exist: ${tokens.slice(0, depth + 1).join("/")}`);
+    }
+    const obj = { ...node };
+    obj[token] = applyAt(obj[token], tokens, depth + 1, op);
+    return obj;
+  }
+  throw new Error(`Cannot descend into non-container at ${tokens.slice(0, depth).join("/")}`);
+}
+
+// ─── Diff ────────────────────────────────────────────────────
+
+/**
+ * Calcule la séquence d'ops RFC 6902 qui transforme `base` en `target`.
+ *
+ * Stratégie : récursion structurelle. Sur les objets, on compare clé-par-clé
+ * (ajout / remove / récursion). Sur les tableaux, on émet `replace` global
+ * dès que les longueurs diffèrent ou qu'un élément à un index donné diffère —
+ * pas de LCS-on-arrays ici (c'est le rôle des stratégies `set` / `ordered-list`
+ * du registre, qui appellent `diffJson` à un niveau plus fin).
+ */
+export function diffJson(base: JsonValue, target: JsonValue): JsonPatchOp[] {
+  const ops: JsonPatchOp[] = [];
+  diffAt(base, target, [], ops);
+  return ops;
+}
+
+function diffAt(base: JsonValue, target: JsonValue, path: string[], ops: JsonPatchOp[]): void {
+  if (jsonStructEqual(base, target)) return;
+
+  // Types divergents ou scalaires différents → replace.
+  const baseIsObj = isPlainObject(base);
+  const targetIsObj = isPlainObject(target);
+  const baseIsArr = Array.isArray(base);
+  const targetIsArr = Array.isArray(target);
+
+  if (baseIsObj && targetIsObj) {
+    const baseObj = base as Record<string, JsonValue>;
+    const targetObj = target as Record<string, JsonValue>;
+    const allKeys = new Set([...Object.keys(baseObj), ...Object.keys(targetObj)]);
+    for (const key of allKeys) {
+      const inBase = key in baseObj;
+      const inTarget = key in targetObj;
+      const childPath = [...path, key];
+      if (inBase && inTarget) {
+        diffAt(baseObj[key], targetObj[key], childPath, ops);
+      } else if (!inBase && inTarget) {
+        ops.push({ op: "add", path: buildJsonPointer(childPath), value: targetObj[key] });
+      } else {
+        // inBase && !inTarget
+        ops.push({ op: "remove", path: buildJsonPointer(childPath) });
+      }
+    }
+    return;
+  }
+
+  if (baseIsArr && targetIsArr) {
+    // Comparaison naïve : si même longueur et chaque index égal → no-op
+    // (déjà géré par le check d'égalité). Sinon replace global du tableau.
+    ops.push({ op: "replace", path: buildJsonPointer(path), value: target });
+    return;
+  }
+
+  // Type change ou scalaire différent.
+  ops.push({ op: "replace", path: buildJsonPointer(path), value: target });
+}
+
+/** Égalité structurelle (récursive) entre deux JSON values. */
+export function jsonStructEqual(a: JsonValue, b: JsonValue): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b) || a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!jsonStructEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const aKeys = Object.keys(a);
+    const bKeys = Object.keys(b);
+    if (aKeys.length !== bKeys.length) return false;
+    for (const k of aKeys) {
+      if (!(k in b)) return false;
+      if (!jsonStructEqual(a[k], (b as Record<string, JsonValue>)[k])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+// ─── Merge ───────────────────────────────────────────────────
+
+/**
+ * Fusionne deux séquences d'ops. Si les paths sont disjoints (aucun path
+ * touché par les deux), on retourne la concaténation `[...ours, ...theirs]`.
+ * Sinon, on retourne `null` avec une liste des paths en conflit (utile pour
+ * la `DecisionTrace`).
+ *
+ * Disjoint = aucun path d'`ours` n'est égal ni préfixe d'un path de `theirs`,
+ * et vice versa. (Si `ours` modifie `/foo/bar` et `theirs` modifie `/foo`, ils
+ * sont en conflit même si les chaînes ne sont pas identiques.)
+ */
+export function mergeJsonPatches(
+  ours: ReadonlyArray<JsonPatchOp>,
+  theirs: ReadonlyArray<JsonPatchOp>,
+): { merged: JsonPatchOp[] | null; conflictingPaths: string[] } {
+  const conflictingPaths: string[] = [];
+  for (const op1 of ours) {
+    for (const op2 of theirs) {
+      if (pathsConflict(op1.path, op2.path)) {
+        conflictingPaths.push(op1.path);
+        break;
+      }
+    }
+  }
+  if (conflictingPaths.length > 0) {
+    return { merged: null, conflictingPaths };
+  }
+  return { merged: [...ours, ...theirs], conflictingPaths: [] };
+}
+
+/**
+ * Vrai si les deux paths se chevauchent (égaux, ou l'un préfixe de l'autre).
+ */
+function pathsConflict(a: string, b: string): boolean {
+  if (a === b) return true;
+  // a préfixe de b : b commence par a + "/"
+  if (b.startsWith(a + "/")) return true;
+  if (a.startsWith(b + "/")) return true;
+  return false;
+}

--- a/packages/core/src/format-profiles/merge-strategies.ts
+++ b/packages/core/src/format-profiles/merge-strategies.ts
@@ -1,0 +1,178 @@
+/**
+ * GitWand — Stratégies de merge appliquées par les profils
+ *
+ * Trois fonctions clés exportées :
+ *  - mergeArrayAsSet : merge 3-way de tableaux comme des sets (par identité)
+ *  - mergeOrderedListViaPatch : merge 3-way de tableaux via RFC 6902 add/remove
+ *  - tryMergeWithProfile : helper de haut niveau qui route base/ours/theirs en
+ *    fonction de la stratégie, retourne null si non résolvable.
+ *
+ * Les fonctions sont génériques sur unknown et peuvent être appelées tant pour
+ * des sous-arbres JSON que des sous-arbres YAML (le résolveur YAML les utilise
+ * après yaml.parse → représentation JS-native).
+ */
+
+import type { JsonPatchOp, PathStrategy } from "./types.js";
+import { diffJson, mergeJsonPatches, applyJsonPatch, jsonStructEqual } from "./json-patch.js";
+
+/**
+ * Merge 3-way de deux tableaux interprétés comme des sets identifiés par
+ * `identity`. La sémantique :
+ *
+ *  - Pour chaque item présent dans ours OU theirs, on regarde s'il était dans
+ *    la base.
+ *  - Item ajouté d'un seul côté → ajouté au résultat.
+ *  - Item modifié d'un seul côté (même identité, valeur différente) → version
+ *    modifiée gagne.
+ *  - Item modifié des deux côtés différemment → conflit, retour null.
+ *  - Item supprimé d'un côté + non modifié de l'autre → supprimé du résultat.
+ *  - Item supprimé d'un côté + modifié de l'autre → conflit.
+ *
+ * L'ordre du résultat suit ours pour les items qu'il contient, puis ajoute
+ * en queue les nouveaux de theirs (sémantique "ours d'abord, theirs ensuite").
+ */
+export function mergeArrayAsSet(
+  base: unknown[],
+  ours: unknown[],
+  theirs: unknown[],
+  identity: (item: unknown) => string,
+): unknown[] | null {
+  const baseMap = new Map<string, unknown>();
+  for (const item of base) baseMap.set(identity(item), item);
+  const oursMap = new Map<string, unknown>();
+  for (const item of ours) oursMap.set(identity(item), item);
+  const theirsMap = new Map<string, unknown>();
+  for (const item of theirs) theirsMap.set(identity(item), item);
+
+  // Préserve l'ordre d'ours. Les items dans theirs absents d'ours sont append en fin.
+  const orderedKeys: string[] = [];
+  const seen = new Set<string>();
+  for (const item of ours) {
+    const k = identity(item);
+    if (!seen.has(k)) {
+      orderedKeys.push(k);
+      seen.add(k);
+    }
+  }
+  for (const item of theirs) {
+    const k = identity(item);
+    if (!seen.has(k)) {
+      orderedKeys.push(k);
+      seen.add(k);
+    }
+  }
+  // Et les items présents en base mais ni dans ours ni dans theirs auraient
+  // été supprimés des deux côtés — pas besoin de les visiter.
+
+  const result: unknown[] = [];
+
+  for (const key of orderedKeys) {
+    const inBase = baseMap.has(key);
+    const inOurs = oursMap.has(key);
+    const inTheirs = theirsMap.has(key);
+    const baseVal = baseMap.get(key);
+    const oursVal = oursMap.get(key);
+    const theirsVal = theirsMap.get(key);
+
+    // Présent dans les deux branches
+    if (inOurs && inTheirs) {
+      if (jsonStructEqual(oursVal, theirsVal)) {
+        result.push(oursVal);
+        continue;
+      }
+      // Modifications divergentes
+      if (inBase) {
+        const oursChanged = !jsonStructEqual(baseVal, oursVal);
+        const theirsChanged = !jsonStructEqual(baseVal, theirsVal);
+        if (oursChanged && !theirsChanged) {
+          result.push(oursVal);
+          continue;
+        }
+        if (!oursChanged && theirsChanged) {
+          result.push(theirsVal);
+          continue;
+        }
+        // Les deux ont changé différemment → conflit
+        return null;
+      }
+      // Pas dans la base, ajouts différents des deux côtés → conflit
+      return null;
+    }
+
+    // Présent uniquement d'un côté
+    if (inOurs && !inTheirs) {
+      if (inBase) {
+        // theirs a supprimé ; ours a-t-il modifié ?
+        if (jsonStructEqual(baseVal, oursVal)) {
+          // Pas modifié des deux côtés (suppression nette par theirs) → skip
+          continue;
+        }
+        // ours a modifié, theirs a supprimé → conflit
+        return null;
+      }
+      // Ajout pur côté ours
+      result.push(oursVal);
+      continue;
+    }
+    if (!inOurs && inTheirs) {
+      if (inBase) {
+        if (jsonStructEqual(baseVal, theirsVal)) {
+          continue;
+        }
+        return null;
+      }
+      result.push(theirsVal);
+      continue;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Merge 3-way d'un sous-arbre via RFC 6902 (add/remove/replace). Si les
+ * deltas base→ours et base→theirs n'entrent pas en conflit (paths disjoints),
+ * on applique séquentiellement les deux. Sinon, retourne null.
+ */
+export function mergeOrderedListViaPatch(
+  base: unknown,
+  ours: unknown,
+  theirs: unknown,
+): unknown | null {
+  const oursOps = diffJson(base, ours);
+  const theirsOps = diffJson(base, theirs);
+  const merged = mergeJsonPatches(oursOps, theirsOps);
+  if (merged.merged === null) return null;
+  return applyJsonPatch(base, merged.merged);
+}
+
+/**
+ * Routeur de stratégie. Reçoit base/ours/theirs déjà parsés (JSON values) et
+ * la PathStrategy à appliquer. Retourne la valeur fusionnée ou null.
+ *
+ * Note : "merge-keys" et "opaque" ne sont **pas** gérés ici — ils sont
+ * délégués au pipeline existant (mergeObjects récursif côté json.ts) qui sait
+ * descendre dans la structure. Ce module gère uniquement les stratégies qui
+ * apportent quelque chose de nouveau en v2.2 (set, ordered-list).
+ */
+export function applyStrategy(
+  strategy: PathStrategy,
+  base: unknown,
+  ours: unknown,
+  theirs: unknown,
+): { handled: true; value: unknown | null } | { handled: false } {
+  if (strategy.kind === "set") {
+    if (!Array.isArray(base) || !Array.isArray(ours) || !Array.isArray(theirs)) {
+      return { handled: false };
+    }
+    const identity = strategy.identity ?? ((item: unknown) => JSON.stringify(item));
+    return { handled: true, value: mergeArrayAsSet(base, ours, theirs, identity) };
+  }
+  if (strategy.kind === "ordered-list") {
+    return { handled: true, value: mergeOrderedListViaPatch(base, ours, theirs) };
+  }
+  // merge-keys et opaque : non gérés ici.
+  return { handled: false };
+}
+
+export type { JsonPatchOp };

--- a/packages/core/src/format-profiles/profiles/composer.ts
+++ b/packages/core/src/format-profiles/profiles/composer.ts
@@ -1,0 +1,47 @@
+/**
+ * GitWand — Profil "composer.json" (PHP)
+ *
+ * Match : tout fichier nommé composer.json (à n'importe quelle profondeur).
+ * Analogue à package.json côté PHP.
+ *
+ * Stratégies :
+ * - /require, /require-dev, /conflict, /provide, /replace, /suggest
+ *   → merge-keys (objets clé-par-clé)
+ * - /autoload, /autoload-dev → merge-keys (sous-objets PSR-4 / classmap…)
+ * - /scripts → merge-keys
+ * - /keywords → set
+ * - /authors → set par "email" (objets {name, email}, identité = email)
+ * - défaut → merge-keys
+ */
+
+import type { FormatProfile } from "../types.js";
+
+export const composerProfile: FormatProfile = {
+  name: "composer.json",
+  matches: (filePath) => {
+    const basename = filePath.split("/").pop() ?? filePath;
+    return basename === "composer.json";
+  },
+  paths: {
+    "/require": { kind: "merge-keys" },
+    "/require-dev": { kind: "merge-keys" },
+    "/conflict": { kind: "merge-keys" },
+    "/provide": { kind: "merge-keys" },
+    "/replace": { kind: "merge-keys" },
+    "/suggest": { kind: "merge-keys" },
+    "/autoload": { kind: "merge-keys" },
+    "/autoload-dev": { kind: "merge-keys" },
+    "/scripts": { kind: "merge-keys" },
+    "/keywords": { kind: "set" },
+    "/authors": {
+      kind: "set",
+      identity: (item) => {
+        if (typeof item === "object" && item !== null && "email" in item) {
+          return String((item as { email: unknown }).email);
+        }
+        return JSON.stringify(item);
+      },
+    },
+  },
+  default: { kind: "merge-keys" },
+};

--- a/packages/core/src/format-profiles/profiles/helm-values.ts
+++ b/packages/core/src/format-profiles/profiles/helm-values.ts
@@ -1,0 +1,42 @@
+/**
+ * GitWand — Profil "helm/values.yaml"
+ *
+ * Match : fichiers values.yaml ou values.<env>.yaml dans un répertoire
+ * "helm/" ou "charts/" (conventions Helm). Match large pour couvrir les
+ * monorepos avec sub-charts.
+ *
+ * Stratégies (s'appuient sur les conventions Kubernetes embarquées dans
+ * Helm) :
+ * - /spec/template/spec/containers → set par "name" (chaque container a un
+ *   "name" unique selon les Pod specs Kubernetes)
+ * - /spec/template/spec/initContainers → set par "name"
+ * - /spec/template/spec/volumes → set par "name"
+ * - /spec/template/spec/containers/* /env → set par "name" (env vars)
+ *   (note : à la profondeur du wildcard, on raisonne sur l'entité de la
+ *   liste env, pas sur l'item individuel)
+ * - défaut → merge-keys
+ */
+
+import type { FormatProfile } from "../types.js";
+
+const NAME_KEYED = (item: unknown): string => {
+  if (typeof item === "object" && item !== null && "name" in item) {
+    return String((item as { name: unknown }).name);
+  }
+  return JSON.stringify(item);
+};
+
+export const helmValuesProfile: FormatProfile = {
+  name: "helm/values.yaml",
+  matches: (filePath) => {
+    if (!/values(\.[^/]+)?\.ya?ml$/.test(filePath)) return false;
+    return /(^|\/)(helm|charts?)\//.test(filePath);
+  },
+  paths: {
+    "/spec/template/spec/containers": { kind: "set", identity: NAME_KEYED },
+    "/spec/template/spec/initContainers": { kind: "set", identity: NAME_KEYED },
+    "/spec/template/spec/volumes": { kind: "set", identity: NAME_KEYED },
+    "/spec/template/spec/imagePullSecrets": { kind: "set", identity: NAME_KEYED },
+  },
+  default: { kind: "merge-keys" },
+};

--- a/packages/core/src/format-profiles/profiles/kubernetes.ts
+++ b/packages/core/src/format-profiles/profiles/kubernetes.ts
@@ -1,0 +1,64 @@
+/**
+ * GitWand — Profil "Kubernetes manifests"
+ *
+ * Match : fichiers .yaml / .yml dans un dossier k8s/, kubernetes/, manifests/
+ * ou un déploiement courant (deployment.yaml, service.yaml, etc.). Heuristique
+ * de path — pas de parsing du contenu pour confirmer le type de manifest
+ * (Deployment vs Service vs ConfigMap), donc on applique des stratégies safe
+ * sur les paths conventionnels qui n'existent que dans les types pertinents.
+ *
+ * Stratégies (alignées Kubernetes API conventions name-keyed lists) :
+ * - /spec/template/spec/containers → set par "name"
+ * - /spec/template/spec/initContainers → set par "name"
+ * - /spec/template/spec/volumes → set par "name"
+ * - /spec/template/spec/imagePullSecrets → set par "name"
+ * - /spec/ports → set par "port" (Service)
+ * - /spec/rules → set par "host" (Ingress) — fallback JSON.stringify si pas
+ *   de host (Ingress sans rule "default")
+ * - défaut → merge-keys
+ */
+
+import type { FormatProfile } from "../types.js";
+
+const NAME_KEYED = (item: unknown): string => {
+  if (typeof item === "object" && item !== null && "name" in item) {
+    return String((item as { name: unknown }).name);
+  }
+  return JSON.stringify(item);
+};
+
+const PORT_KEYED = (item: unknown): string => {
+  if (typeof item === "object" && item !== null && "port" in item) {
+    return String((item as { port: unknown }).port);
+  }
+  return JSON.stringify(item);
+};
+
+const HOST_KEYED = (item: unknown): string => {
+  if (typeof item === "object" && item !== null && "host" in item) {
+    return String((item as { host: unknown }).host);
+  }
+  return JSON.stringify(item);
+};
+
+const K8S_DIR = /(^|\/)(k8s|kubernetes|manifests)\//;
+const K8S_BASENAME = /^(deployment|service|ingress|configmap|secret|statefulset|daemonset|job|cronjob|replicaset|pod|namespace)\.(ya?ml)$/i;
+
+export const kubernetesProfile: FormatProfile = {
+  name: "kubernetes",
+  matches: (filePath) => {
+    if (!/\.ya?ml$/.test(filePath)) return false;
+    if (K8S_DIR.test(filePath)) return true;
+    const basename = filePath.split("/").pop() ?? "";
+    return K8S_BASENAME.test(basename);
+  },
+  paths: {
+    "/spec/template/spec/containers": { kind: "set", identity: NAME_KEYED },
+    "/spec/template/spec/initContainers": { kind: "set", identity: NAME_KEYED },
+    "/spec/template/spec/volumes": { kind: "set", identity: NAME_KEYED },
+    "/spec/template/spec/imagePullSecrets": { kind: "set", identity: NAME_KEYED },
+    "/spec/ports": { kind: "set", identity: PORT_KEYED },
+    "/spec/rules": { kind: "set", identity: HOST_KEYED },
+  },
+  default: { kind: "merge-keys" },
+};

--- a/packages/core/src/format-profiles/profiles/package-json.ts
+++ b/packages/core/src/format-profiles/profiles/package-json.ts
@@ -1,0 +1,38 @@
+/**
+ * GitWand — Profil "package.json"
+ *
+ * Match : tout fichier nommé exactement "package.json" (à la racine ou dans
+ * un workspace). On exclut les fichiers générés type "package-lock.json"
+ * (couverts par les résolveurs lockfile dédiés).
+ *
+ * Stratégies :
+ * - /dependencies, /devDependencies, /peerDependencies, /optionalDependencies
+ *   → merge-keys (objets clé-par-clé, comportement existant)
+ * - /scripts → merge-keys (objets clé-par-clé)
+ * - /keywords → set (tableau, identité = JSON.stringify de l'item)
+ * - /workspaces (cas tableau) → set
+ * - défaut → merge-keys
+ */
+
+import type { FormatProfile } from "../types.js";
+
+export const packageJsonProfile: FormatProfile = {
+  name: "package.json",
+  matches: (filePath) => {
+    const basename = filePath.split("/").pop() ?? filePath;
+    return basename === "package.json";
+  },
+  paths: {
+    "/dependencies": { kind: "merge-keys" },
+    "/devDependencies": { kind: "merge-keys" },
+    "/peerDependencies": { kind: "merge-keys" },
+    "/optionalDependencies": { kind: "merge-keys" },
+    "/bundledDependencies": { kind: "set" },
+    "/bundleDependencies": { kind: "set" },
+    "/scripts": { kind: "merge-keys" },
+    "/keywords": { kind: "set" },
+    "/files": { kind: "set" },
+    "/workspaces": { kind: "set" },
+  },
+  default: { kind: "merge-keys" },
+};

--- a/packages/core/src/format-profiles/profiles/tsconfig.ts
+++ b/packages/core/src/format-profiles/profiles/tsconfig.ts
@@ -1,0 +1,50 @@
+/**
+ * GitWand — Profil "tsconfig.json" (et tsconfig.*.json)
+ *
+ * Match : tout fichier nommé tsconfig.json ou tsconfig.<variant>.json
+ * (ex: tsconfig.build.json, tsconfig.app.json) à n'importe quelle profondeur
+ * dans le repo.
+ *
+ * Stratégies :
+ * - /compilerOptions → merge-keys (objet de flags : on merge clé-par-clé)
+ * - /compilerOptions/lib → set (tableau de strings, ordre indifférent)
+ * - /compilerOptions/types → set
+ * - /compilerOptions/typeRoots → set
+ * - /include → set (globs, ordre indifférent)
+ * - /exclude → set
+ * - /references → set par "path" (objets {path: "..."} avec identité = path)
+ * - /files → set
+ * - défaut → merge-keys
+ */
+
+import type { FormatProfile } from "../types.js";
+
+const TSCONFIG_NAME = /^tsconfig(\..+)?\.json$/;
+
+export const tsconfigProfile: FormatProfile = {
+  name: "tsconfig.json",
+  matches: (filePath) => {
+    const basename = filePath.split("/").pop() ?? filePath;
+    return TSCONFIG_NAME.test(basename);
+  },
+  paths: {
+    "/compilerOptions": { kind: "merge-keys" },
+    "/compilerOptions/lib": { kind: "set" },
+    "/compilerOptions/types": { kind: "set" },
+    "/compilerOptions/typeRoots": { kind: "set" },
+    "/compilerOptions/paths": { kind: "merge-keys" },
+    "/include": { kind: "set" },
+    "/exclude": { kind: "set" },
+    "/files": { kind: "set" },
+    "/references": {
+      kind: "set",
+      identity: (item) => {
+        if (typeof item === "object" && item !== null && "path" in item) {
+          return String((item as { path: unknown }).path);
+        }
+        return JSON.stringify(item);
+      },
+    },
+  },
+  default: { kind: "merge-keys" },
+};

--- a/packages/core/src/format-profiles/types.ts
+++ b/packages/core/src/format-profiles/types.ts
@@ -1,0 +1,56 @@
+/**
+ * GitWand — Types du registre de profils par format
+ *
+ * Un FormatProfile annote des chemins JSON Pointer (RFC 6901) avec une
+ * stratégie de merge. C'est l'analogue local des "commutative parents" de
+ * Mergiraf, mais piloté par configuration plutôt que par grammaire.
+ */
+
+/**
+ * Stratégie de merge appliquée à un chemin donné dans un document JSON/YAML.
+ *
+ * - "set" : merge par identité d'élément. La fonction identity extrait une
+ *   clé stable depuis chaque item ; deux items avec la même clé sont
+ *   considérés comme "le même", et les modifications se mergent par
+ *   récursion. Sans identity, fallback JSON.stringify(item).
+ * - "ordered-list" : RFC 6902 add/remove. On diffe base->ours et base->theirs,
+ *   on les concatène si les paths sont disjoints, on rejette sinon.
+ * - "merge-keys" : objets ; récursion clé-par-clé (comportement actuel de
+ *   mergeObjects).
+ * - "opaque" : aucune tentative de merge sémantique, retombée fallback textuel.
+ */
+export type PathStrategy =
+  | { kind: "set"; identity?: (item: unknown) => string }
+  | { kind: "ordered-list" }
+  | { kind: "merge-keys" }
+  | { kind: "opaque" };
+
+/**
+ * Profil de merge pour un type de fichier (ou pattern).
+ *
+ * Le registre essaie chaque profil dans l'ordre d'enregistrement ; le premier
+ * dont matches(filePath) retourne true est utilisé. Les chemins sont des
+ * JSON Pointers (par exemple /dependencies, ou des paths avec wildcard de
+ * segment unique pour itérer sur une liste). Les wildcards "*" matchent un
+ * segment unique (équivalent shallow-glob).
+ */
+export interface FormatProfile {
+  /** Identifiant lisible (pour les traces) — ex: "package.json". */
+  name: string;
+  /** Match sur le filePath. Le registre s'arrête au premier profil matching. */
+  matches: (filePath: string) => boolean;
+  /** Stratégie par chemin JSON Pointer (RFC 6901). */
+  paths: Record<string, PathStrategy>;
+  /** Stratégie par défaut pour les chemins non listés. */
+  default: PathStrategy;
+}
+
+/**
+ * Une opération RFC 6902 minimale. On ne supporte que add, remove, replace.
+ * move et copy peuvent toujours être exprimées par séquences add/remove, et
+ * leur omission garde le code en dessous de 2KB ajoutés.
+ */
+export type JsonPatchOp =
+  | { op: "add"; path: string; value: unknown }
+  | { op: "remove"; path: string }
+  | { op: "replace"; path: string; value: unknown };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,24 @@ export {
   type BlockMoveOptions,
 } from "./diff/index.js";
 
+// v2.2 — registre de profils de format + RFC 6902
+export {
+  profileForFile,
+  registerFormatProfile,
+  strategyForPath,
+  type FormatProfile,
+  type PathStrategy,
+} from "./format-profiles/index.js";
+export {
+  diffJson,
+  applyJsonPatch,
+  mergeJsonPatches,
+  parseJsonPointer,
+  buildJsonPointer,
+  jsonStructEqual,
+} from "./format-profiles/json-patch.js";
+export type { JsonPatchOp } from "./format-profiles/types.js";
+
 // Phase 7.3 — Résolveurs spécialisés par format
 export { tryResolveJsonConflict, stripJsoncComments } from "./resolvers/json.js";
 export { tryResolveMarkdownConflict, parseSections, extractFrontmatter } from "./resolvers/markdown.js";

--- a/packages/core/src/resolver/format-dispatch.ts
+++ b/packages/core/src/resolver/format-dispatch.ts
@@ -36,7 +36,9 @@ export function dispatchFormatAware(
   filePath: string,
   options: Required<GitWandOptions>,
 ): FormatDispatchResult {
-  const formatResult = tryFormatAwareResolve(hunk, filePath);
+  const formatResult = tryFormatAwareResolve(hunk, filePath, {
+    disableFormatProfiles: options.disableFormatProfiles,
+  });
   if (formatResult.resolverUsed === "none") {
     return { status: "not-applicable", note: "" };
   }

--- a/packages/core/src/resolver/policy.ts
+++ b/packages/core/src/resolver/policy.ts
@@ -33,6 +33,8 @@ export const DEFAULT_OPTIONS: Required<GitWandOptions> = {
   policy: DEFAULT_POLICY,
   patternOverrides: {},
   generatedFiles: [],
+  // v2.2 — profils de format actifs par défaut
+  disableFormatProfiles: false,
 };
 
 /** Ordre de confiance pour comparaison. */

--- a/packages/core/src/resolvers/dispatcher.ts
+++ b/packages/core/src/resolvers/dispatcher.ts
@@ -133,11 +133,18 @@ export interface FormatResolveResult {
  *
  * @param hunk - Le hunk de conflit à résoudre
  * @param filePath - Le chemin du fichier (pour déterminer le résolveur)
+ * @param opts - (v2.2) `disableFormatProfiles` désactive le hook FormatProfile
+ *               dans les résolveurs JSON / YAML — comportement v2.1 strict.
  */
 export function tryFormatAwareResolve(
   hunk: ConflictHunk,
   filePath: string,
+  opts?: { disableFormatProfiles?: boolean },
 ): FormatResolveResult {
+  // v2.2 — si disableFormatProfiles, on coupe le filePath transmis aux
+  // résolveurs JSON/YAML, ce qui désactive leur lookup profil.
+  const profileFilePath = opts?.disableFormatProfiles ? undefined : filePath;
+
   // ── Cargo.toml / Cargo.lock (avant JSON) ──────────────────
   if (isCargoFile(filePath)) {
     const result = tryResolveCargoConflict(
@@ -254,6 +261,7 @@ export function tryFormatAwareResolve(
       hunk.baseLines,
       hunk.oursLines,
       hunk.theirsLines,
+      profileFilePath,
     );
 
     if (result.merged !== null) {
@@ -305,6 +313,7 @@ export function tryFormatAwareResolve(
       hunk.baseLines,
       hunk.oursLines,
       hunk.theirsLines,
+      profileFilePath,
     );
 
     if (result.mergedLines !== null) {

--- a/packages/core/src/resolvers/json.ts
+++ b/packages/core/src/resolvers/json.ts
@@ -11,14 +11,24 @@
  *  3. Si tous les conflits de clés sont trivialement résolvables → merge
  *  4. Sinon → retourner null (fallback textuel dans resolver.ts)
  *
+ * v2.2 — Hook profil de format : si un FormatProfile est applicable au
+ * filePath, ses stratégies par path (set / ordered-list / merge-keys / opaque)
+ * routent vers mergeArrayAsSet ou mergeOrderedListViaPatch au lieu du fallback
+ * "tableau impossible à merger". Ouvre l'auto-résolution sur /dependencies,
+ * /scripts, tsconfig#/include, etc.
+ *
  * Cas gérés :
  *  - Clé ajoutée des deux côtés avec valeurs différentes → conflit non résolvable
  *  - Clé ajoutée d'un seul côté → accepter l'ajout
  *  - Clé supprimée d'un seul côté, pas modifiée de l'autre → supprimer
  *  - Clé modifiée des deux côtés de la même façon → prendre la valeur
  *  - Clé modifiée des deux côtés différemment → conflit non résolvable
- *  - Merge récursif pour les objets imbriqués
+ *  - Merge récursif pour les objets imbriqués (avec stratégie de profil par path)
  */
+
+import { profileForFile, strategyForPath } from "../format-profiles/index.js";
+import type { FormatProfile } from "../format-profiles/types.js";
+import { applyStrategy } from "../format-profiles/merge-strategies.js";
 
 /** Résultat d'une fusion JSON */
 export interface JsonMergeResult {
@@ -137,6 +147,8 @@ function mergeObjects(
   base: JsonObject,
   ours: JsonObject,
   theirs: JsonObject,
+  profile: FormatProfile | null = null,
+  currentPath: string = "",
 ): { merged: JsonObject | null; resolvedKeys: number; unresolvedKeys: number } {
   const result: JsonObject = {};
   let resolvedKeys = 0;
@@ -158,6 +170,10 @@ function mergeObjects(
     const oursVal = ours[key];
     const theirsVal = theirs[key];
 
+    // v2.2 — Path JSON Pointer pour cette clé (escape RFC 6901 : ~ → ~0, / → ~1)
+    const pointerKey = key.replace(/~/g, "~0").replace(/\//g, "~1");
+    const childPath = currentPath + "/" + pointerKey;
+
     // Clé présente dans les deux branches, absente de la base → ajout des deux côtés
     if (!inBase && inOurs && inTheirs) {
       if (jsonEqual(oursVal, theirsVal)) {
@@ -166,7 +182,7 @@ function mergeObjects(
         resolvedKeys++;
       } else if (isObject(oursVal) && isObject(theirsVal)) {
         // Objets ajoutés différemment → fusion récursive depuis base vide
-        const sub = mergeObjects({}, oursVal, theirsVal);
+        const sub = mergeObjects({}, oursVal, theirsVal, profile, childPath);
         if (sub.merged !== null) {
           result[key] = sub.merged;
           resolvedKeys += sub.resolvedKeys + 1;
@@ -175,6 +191,23 @@ function mergeObjects(
           unresolvedKeys++;
           return { merged: null, resolvedKeys, unresolvedKeys };
         }
+      } else if (
+        profile !== null &&
+        Array.isArray(oursVal) &&
+        Array.isArray(theirsVal)
+      ) {
+        // v2.2 — Tableau ajouté différemment des deux côtés. Si le profil
+        // annote ce path comme "set" ou "ordered-list", on tente la stratégie
+        // avec une base vide.
+        const strategy = strategyForPath(profile, childPath);
+        const applied = applyStrategy(strategy, [], oursVal, theirsVal);
+        if (applied.handled && applied.value !== null) {
+          result[key] = applied.value as JsonValue;
+          resolvedKeys++;
+          continue;
+        }
+        unresolvedKeys++;
+        return { merged: null, resolvedKeys, unresolvedKeys };
       } else {
         // Valeurs scalaires différentes → conflit non résolvable
         unresolvedKeys++;
@@ -255,11 +288,27 @@ function mergeObjects(
         resolvedKeys++;
       } else if (isObject(oursVal) && isObject(theirsVal) && isObject(baseVal)) {
         // Les deux ont modifié des objets → fusion récursive
-        const sub = mergeObjects(baseVal, oursVal, theirsVal);
+        const sub = mergeObjects(baseVal, oursVal, theirsVal, profile, childPath);
         if (sub.merged !== null) {
           result[key] = sub.merged;
           resolvedKeys += sub.resolvedKeys + 1;
           unresolvedKeys += sub.unresolvedKeys;
+        } else {
+          unresolvedKeys++;
+          return { merged: null, resolvedKeys, unresolvedKeys };
+        }
+      } else if (
+        profile !== null &&
+        Array.isArray(oursVal) &&
+        Array.isArray(theirsVal) &&
+        Array.isArray(baseVal)
+      ) {
+        // v2.2 — Tableau modifié des deux côtés. Routage selon le profil.
+        const strategy = strategyForPath(profile, childPath);
+        const applied = applyStrategy(strategy, baseVal, oursVal, theirsVal);
+        if (applied.handled && applied.value !== null) {
+          result[key] = applied.value as JsonValue;
+          resolvedKeys++;
         } else {
           unresolvedKeys++;
           return { merged: null, resolvedKeys, unresolvedKeys };
@@ -303,12 +352,16 @@ function detectIndentation(jsonText: string): string | number {
  * @param baseLines  - Lignes de la version base
  * @param oursLines  - Lignes de la version ours
  * @param theirsLines - Lignes de la version theirs
+ * @param filePath   - (v2.2) Chemin du fichier — utilisé pour résoudre un
+ *                     FormatProfile applicable. Optionnel : sans filePath,
+ *                     comportement identique à v2.1 (pas de profil consulté).
  * @returns `JsonMergeResult` avec `merged !== null` si résolu, `null` sinon
  */
 export function tryResolveJsonConflict(
   baseLines: string[],
   oursLines: string[],
   theirsLines: string[],
+  filePath?: string,
 ): JsonMergeResult {
   const baseText = baseLines.join("\n");
   const oursText = oursLines.join("\n");
@@ -380,11 +433,16 @@ export function tryResolveJsonConflict(
 
   const baseObj = isObject(baseJson) ? baseJson : {};
 
-  // Fusion sémantique
+  // v2.2 — Lookup du profil applicable au filePath (null si aucun)
+  const profile = filePath ? profileForFile(filePath) : null;
+
+  // Fusion sémantique (avec routage par profil sur les paths annotés)
   const { merged, resolvedKeys, unresolvedKeys } = mergeObjects(
     baseObj,
     oursJson,
     theirsJson,
+    profile,
+    "",
   );
 
   if (merged === null) {

--- a/packages/core/src/resolvers/yaml.ts
+++ b/packages/core/src/resolvers/yaml.ts
@@ -4,7 +4,13 @@
  * Résout les conflits dans les fichiers YAML (.yaml / .yml) en analysant
  * la structure indentée et en fusionnant clé par clé, similaire au résolveur JSON.
  *
- * Implémenté sans dépendance externe — parsing structurel basé sur l'indentation.
+ * v2.2 — Si un FormatProfile s'applique au filePath, un fast path parse-merge-
+ * serialize est tenté en premier (perd les commentaires mais débloque
+ * helm/values.yaml et kubernetes manifests sur containers/env/volumes/…).
+ * Le pipeline line-based reste le défaut quand aucun profil n'est applicable.
+ *
+ * Implémenté sans dépendance externe pour le pipeline line-based — la lib
+ * `yaml` est utilisée uniquement par le fast path profil.
  *
  * Stratégie :
  *  1. Parser chaque version en "entrées" hiérarchiques (clé + contenu indenté)
@@ -404,7 +410,21 @@ export function tryResolveYamlConflict(
   baseLines: string[],
   oursLines: string[],
   theirsLines: string[],
+  filePath?: string,
 ): YamlMergeResult {
+  // v2.2 — Fast path profil-aware. Si un FormatProfile s'applique au filePath
+  // (ex: helm/values.yaml ou kubernetes/deployment.yaml) ET que les trois
+  // versions parsent comme des objets propres, on tente le merge sémantique
+  // avec routage par stratégie (set sur containers/env/volumes…). Si ça
+  // échoue (parse impossible, merge en conflit), on retombe sur le pipeline
+  // line-based existant qui préserve les commentaires.
+  if (filePath) {
+    const profileResult = tryProfileBasedYamlMerge(
+      baseLines, oursLines, theirsLines, filePath,
+    );
+    if (profileResult !== null) return profileResult;
+  }
+
   // Rejeter les constructions non supportées
   if (
     hasUnsupportedConstruct(oursLines) ||
@@ -460,4 +480,160 @@ export function tryResolveYamlConflict(
     resolvedKeys,
     unresolvedKeys,
   };
+}
+
+// ─── v2.2 — Fast path parse-merge-serialize via FormatProfile ────────────
+
+import * as YAML from "yaml";
+import { profileForFile, strategyForPath } from "../format-profiles/index.js";
+import type { FormatProfile, PathStrategy } from "../format-profiles/types.js";
+import { applyStrategy } from "../format-profiles/merge-strategies.js";
+
+/**
+ * Tente le merge YAML sémantique via parse → merge avec profil → serialize.
+ * Retourne `null` si pas applicable (pas de profil, parse échoue, ou merge
+ * en conflit) ; le caller retombera sur le pipeline line-based.
+ */
+function tryProfileBasedYamlMerge(
+  baseLines: string[],
+  oursLines: string[],
+  theirsLines: string[],
+  filePath: string,
+): YamlMergeResult | null {
+  const profile = profileForFile(filePath);
+  if (profile === null) return null;
+
+  let baseObj: unknown;
+  let oursObj: unknown;
+  let theirsObj: unknown;
+  try {
+    const baseText = baseLines.join("\n").trim();
+    baseObj = baseText.length === 0 ? {} : (YAML.parse(baseText) ?? {});
+    oursObj = YAML.parse(oursLines.join("\n")) ?? {};
+    theirsObj = YAML.parse(theirsLines.join("\n")) ?? {};
+  } catch {
+    return null; // parse échoué → fallback line-based
+  }
+
+  if (!isPlainObject(oursObj) || !isPlainObject(theirsObj)) return null;
+  const baseObjSafe: Record<string, unknown> = isPlainObject(baseObj) ? baseObj : {};
+
+  const merged = mergeProfileObjects(
+    baseObjSafe,
+    oursObj,
+    theirsObj,
+    profile,
+    "",
+  );
+  if (merged === null) return null;
+
+  // Serialize avec un style proche du source (line width par défaut, indent 2).
+  const serialized = YAML.stringify(merged, { indent: 2, lineWidth: 0 }).trimEnd();
+  return {
+    mergedLines: serialized.split("\n"),
+    reason: `Fusion YAML via profil '${profile.name}'.`,
+    resolvedKeys: 1,
+    unresolvedKeys: 0,
+  };
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Merge récursif d'objets parsés YAML, avec routage par profil.
+ * Variante simplifiée du `mergeObjects` de json.ts — pas de tracking précis
+ * resolved/unresolved (le caller utilise un total binaire 0 ou 1).
+ */
+function mergeProfileObjects(
+  base: Record<string, unknown>,
+  ours: Record<string, unknown>,
+  theirs: Record<string, unknown>,
+  profile: FormatProfile,
+  currentPath: string,
+): Record<string, unknown> | null {
+  const result: Record<string, unknown> = {};
+  const allKeys = new Set([
+    ...Object.keys(base),
+    ...Object.keys(ours),
+    ...Object.keys(theirs),
+  ]);
+
+  for (const key of allKeys) {
+    const inBase = key in base;
+    const inOurs = key in ours;
+    const inTheirs = key in theirs;
+    const baseVal = base[key];
+    const oursVal = ours[key];
+    const theirsVal = theirs[key];
+    const pointerKey = key.replace(/~/g, "~0").replace(/\//g, "~1");
+    const childPath = currentPath + "/" + pointerKey;
+
+    // Cas symétriques : ajouts simples, suppressions sans modif
+    if (inOurs && !inTheirs) {
+      if (inBase && !structEqual(baseVal, oursVal)) return null;
+      if (!inBase) result[key] = oursVal;
+      continue;
+    }
+    if (!inOurs && inTheirs) {
+      if (inBase && !structEqual(baseVal, theirsVal)) return null;
+      if (!inBase) result[key] = theirsVal;
+      continue;
+    }
+    if (!inOurs && !inTheirs) continue;
+
+    // Présent partout — modifs éventuelles
+    if (structEqual(oursVal, theirsVal)) {
+      result[key] = oursVal;
+      continue;
+    }
+    const oursChanged = !inBase || !structEqual(baseVal, oursVal);
+    const theirsChanged = !inBase || !structEqual(baseVal, theirsVal);
+    if (oursChanged && !theirsChanged) {
+      result[key] = oursVal;
+      continue;
+    }
+    if (!oursChanged && theirsChanged) {
+      result[key] = theirsVal;
+      continue;
+    }
+
+    // Les deux ont changé différemment — routage par stratégie de profil
+    const strategy: PathStrategy = strategyForPath(profile, childPath);
+    if (Array.isArray(oursVal) && Array.isArray(theirsVal)) {
+      const baseArr = Array.isArray(baseVal) ? baseVal : [];
+      const applied = applyStrategy(strategy, baseArr, oursVal, theirsVal);
+      if (applied.handled && applied.value !== null) {
+        result[key] = applied.value;
+        continue;
+      }
+      return null;
+    }
+    if (isPlainObject(oursVal) && isPlainObject(theirsVal)) {
+      const baseObj = isPlainObject(baseVal) ? baseVal : {};
+      const sub = mergeProfileObjects(baseObj, oursVal, theirsVal, profile, childPath);
+      if (sub === null) return null;
+      result[key] = sub;
+      continue;
+    }
+    // Scalaires divergents → conflit
+    return null;
+  }
+  return result;
+}
+
+function structEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => structEqual(v, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ak = Object.keys(a);
+    const bk = Object.keys(b);
+    if (ak.length !== bk.length) return false;
+    return ak.every((k) => k in b && structEqual(a[k], b[k]));
+  }
+  return false;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -306,4 +306,16 @@ export interface GitWandOptions {
    * Exemple : `["src/**\/*.generated.ts", "*.pb.go", "api/openapi-client/**"]`.
    */
   generatedFiles?: string[];
+  /**
+   * v2.2 — Désactive globalement les FormatProfile.
+   *
+   * Quand `true`, les résolveurs JSON et YAML sautent le lookup `profileForFile`
+   * et se comportent exactement comme en v2.1 (les arrays modifiés des deux
+   * côtés retombent en fallback textuel). Utile pour rollback ponctuel,
+   * debug d'un profil mal calibré, ou scénarios où un profil tiers introduit
+   * des suppressions silencieuses inattendues.
+   *
+   * Défaut: `false` (profils actifs).
+   */
+  disableFormatProfiles?: boolean;
 }


### PR DESCRIPTION
## Résumé
Cette PR ajoute le registre de format profiles v2.2 dans `@gitwand/core` pour appliquer des stratégies de merge adaptées aux fichiers courants comme `package.json`, `tsconfig.json`, `composer.json`, Helm et Kubernetes. Elle expose les nouvelles APIs publiques, met à jour la documentation et renforce la couverture de tests, tout en corrigeant un bug desktop sur la création de PR.

## Changements
- Ajout du registre de format profiles avec `profileForFile`, `registerFormatProfile` et `strategyForPath`.
- Implémentation des primitives JSON Patch RFC 6902 et des stratégies de merge associées (`set`, `ordered-list`, `merge-keys`, `opaque`).
- Connexion des résolveurs JSON et YAML au `filePath` pour activer les profils built-in sur `package.json`, `tsconfig.json`, `composer.json`, Helm et Kubernetes.
- Ajout de l’option `disableFormatProfiles` pour désactiver ponctuellement la résolution des profils.
- Extension de la couverture avec un corpus de régression et des tests d’intégration, de registre et de JSON Patch.
- Mise à jour de `README.md`, `CHANGELOG.md` et des exports publics de `@gitwand/core` en 2.2.0.
- Correction du formulaire desktop de création de PR pour charger les branches et utiliser le nom brut de branche.

## Plan de test
- [ ] Exécuter la suite de tests de `packages/core` et vérifier les tests `registry`, `json-patch` et `integration`.
- [ ] Valider un merge sur `package.json`, `tsconfig.json` et un manifeste Kubernetes ou Helm.
- [ ] Tester `disableFormatProfiles=true` pour confirmer le retour au comportement v2.1.
- [ ] Ouvrir le formulaire desktop de création de PR et vérifier le chargement des branches.