### PR TITLE
fix(settings): use string values for attribution fields

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,7 @@
 {
   "attribution": {
-    "commit": false,
-    "pr": false
+    "commit": "disabled",
+    "pr": "disabled"
   },
   "permissions": {
     "deny": [


### PR DESCRIPTION
Doctor flagged attribution.commit and attribution.pr as boolean;
Schema expects "disabled" | "enabled" strings.

That's the first small warning i saw when opening the project using Claude.