### PR TITLE
Feat/ai btn to auto generate the commit summary and message

### DIFF
--- a/apps/desktop/perf/bench.mjs
+++ b/apps/desktop/perf/bench.mjs
@@ -46,6 +46,8 @@ function makeFixture() {
   git(dir, "init", "--initial-branch=main", "--quiet");
   git(dir, "config", "user.name", "Bench Bot");
   git(dir, "config", "user.email", "bench@gitwand.local");
+  git(dir, "config", "gc.auto", "0");
+  git(dir, "config", "gc.autoDetach", "false");
 
   // 50 tracked files, 200 commits
   for (let i = 0; i < 200; i++) {

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -903,7 +903,7 @@ function formatActivityDate(dateStr: string): string {
               <circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.3"/>
               <path d="M7 1.5A5.5 5.5 0 0112.5 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>
             </svg>
-            <span v-else class="commit-ai-label">AI</span>
+            <span v-else class="commit-ai-label">{{ t('sidebar.aiLabel') }}</span>
           </button>
           <button
             class="commit-ai-chevron"

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -1973,7 +1973,7 @@ function formatActivityDate(dateStr: string): string {
   background: var(--color-ai-soft);
   color: var(--color-ai);
   border: 1px solid var(--color-ai);
-  border-radius: var(--radius-xs) 0 0 var(--radius-xs);
+  border-radius: calc(var(--radius-md) - 3px) 0 0 calc(var(--radius-md) - 3px);
   cursor: pointer;
   transition: background var(--transition-hover), border-color var(--transition-hover), color var(--transition-hover);
 }
@@ -1994,7 +1994,7 @@ function formatActivityDate(dateStr: string): string {
   color: var(--color-ai);
   border: 1px solid var(--color-ai);
   margin-left: -1px;
-  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
+  border-radius: 0 calc(var(--radius-md) - 3px) calc(var(--radius-md) - 3px) 0;
   cursor: pointer;
   transition: background var(--transition-hover), border-color var(--transition-hover);
 }

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -882,6 +882,7 @@ function formatActivityDate(dateStr: string): string {
         </div>
         <input
           class="commit-summary mono"
+          :class="{ 'commit-summary--ai': ai.isAvailable.value }"
           type="text"
           :value="commitSummary"
           @input="onSummaryInput"
@@ -889,7 +890,7 @@ function formatActivityDate(dateStr: string): string {
           @blur="templateSlashOpen = false"
           :placeholder="t('sidebar.summaryPlaceholder')"
         />
-        <!-- AI commit message: split-button with dropdown -->
+        <!-- AI commit message: overlaid split-button at top-right of summary input -->
         <div v-if="ai.isAvailable.value" class="commit-ai-wrapper">
           <button
             class="commit-ai-btn"
@@ -898,13 +899,11 @@ function formatActivityDate(dateStr: string): string {
             :title="isGenerating ? t('sidebar.aiGeneratingTooltip') : t('sidebar.aiGenerateTooltip')"
             @click="onGenerateCommitMessage"
           >
-            <svg v-if="isGenerating" class="commit-spinner" width="14" height="14" viewBox="0 0 14 14" aria-hidden="true">
+            <svg v-if="isGenerating" class="commit-spinner" width="12" height="12" viewBox="0 0 14 14" aria-hidden="true">
               <circle cx="7" cy="7" r="5.5" stroke="currentColor" stroke-width="1.5" fill="none" opacity="0.3"/>
               <path d="M7 1.5A5.5 5.5 0 0112.5 7" stroke="currentColor" stroke-width="1.5" fill="none" stroke-linecap="round"/>
             </svg>
-            <svg v-else width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-              <path d="M8 2l1.5 3.5L13 7l-3.5 1.5L8 12l-1.5-3.5L3 7l3.5-1.5L8 2z" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round" fill="none"/>
-            </svg>
+            <span v-else class="commit-ai-label">AI</span>
           </button>
           <button
             class="commit-ai-chevron"
@@ -1931,6 +1930,7 @@ function formatActivityDate(dateStr: string): string {
 }
 
 .commit-summary-row {
+  position: relative;
   display: flex;
   gap: var(--space-2);
   align-items: stretch;
@@ -1950,42 +1950,51 @@ function formatActivityDate(dateStr: string): string {
   transition: border-color var(--transition-hover);
 }
 
-.commit-ai-wrapper {
-  position: relative;
-  display: flex;
-  flex-shrink: 0;
+.commit-summary--ai {
+  padding-right: 52px;
 }
 
-/*
- * Split-button: main sparkle action + dropdown chevron for alternative AI
- * actions. We keep the split because the chevron opens a menu — the
- * global `.btn--ai` can't represent that affordance on its own. Color
- * comes from the shared `--color-ai` token so it still reads as "AI"
- * and not "brand accent".
- */
+.commit-ai-wrapper {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  bottom: 3px;
+  display: flex;
+  z-index: 1;
+  border-radius: var(--radius-xs);
+  overflow: visible;
+}
+
 .commit-ai-btn {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 28px;
+  padding: 0 5px;
   background: var(--color-ai-soft);
   color: var(--color-ai);
   border: 1px solid var(--color-ai);
-  border-radius: var(--radius-md) 0 0 var(--radius-md);
+  border-radius: var(--radius-xs) 0 0 var(--radius-xs);
   cursor: pointer;
   transition: background var(--transition-hover), border-color var(--transition-hover), color var(--transition-hover);
+}
+
+.commit-ai-label {
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  line-height: 1;
 }
 
 .commit-ai-chevron {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
+  width: 14px;
   background: var(--color-ai-soft);
   color: var(--color-ai);
   border: 1px solid var(--color-ai);
   margin-left: -1px;
-  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  border-radius: 0 var(--radius-xs) var(--radius-xs) 0;
   cursor: pointer;
   transition: background var(--transition-hover), border-color var(--transition-hover);
 }

--- a/apps/desktop/src/composables/useAIProvider.ts
+++ b/apps/desktop/src/composables/useAIProvider.ts
@@ -1,6 +1,6 @@
 import { ref, computed } from "vue";
 import type { LlmEndpoint } from "@gitwand/core";
-import { claudeCliPrompt, codexCliPrompt } from "../utils/backend";
+import { claudeCliPrompt, codexCliPrompt, detectClaudeCli } from "../utils/backend";
 import { t } from "./useI18n";
 
 /**
@@ -289,6 +289,16 @@ function parseAIResponse(raw: string): AISuggestion {
   }
 }
 
+// ─── Auto-detection ─────────────────────────────────────
+// Populated once at module load; null = detection still pending.
+const _claudeCliAvailable = ref<boolean | null>(null);
+
+detectClaudeCli().then(info => {
+  _claudeCliAvailable.value = info.found && info.logged_in;
+}).catch(() => {
+  _claudeCliAvailable.value = false;
+});
+
 // ─── Composable ─────────────────────────────────────────
 const isLoading = ref(false);
 const lastError = ref<string | null>(null);
@@ -299,17 +309,18 @@ export function useAIProvider() {
 
   const isAvailable = computed(() => {
     const s = settings.value;
-    if (!s.aiEnabled) return false;
-    if (s.aiProvider === "claude" && !s.aiApiKey) return false;
-    if (s.aiProvider === "openai-compat" && (!s.aiApiKey || !s.aiApiEndpoint)) return false;
-    if (s.aiProvider === "ollama") return true; // Ollama doesn't need a key
-    // CLI providers: availability is verified at runtime via the matching
-    // detectXxxCli() — optimistically considered available here so the
-    // first actual call surfaces a clear error if missing / not logged in.
-    if (s.aiProvider === "claude-code-cli") return true;
-    if (s.aiProvider === "codex-cli") return true;
-    if (s.aiProvider === "none") return false;
-    return true;
+    if (s.aiEnabled) {
+      if (s.aiProvider === "claude" && !s.aiApiKey) return false;
+      if (s.aiProvider === "openai-compat" && (!s.aiApiKey || !s.aiApiEndpoint)) return false;
+      if (s.aiProvider === "none") {
+        // Fall through to auto-detect below.
+      } else {
+        return true;
+      }
+    }
+    // Auto-fallback: use Claude Code CLI if installed and logged in,
+    // even when the user hasn't configured any explicit AI provider.
+    return _claudeCliAvailable.value === true;
   });
 
   /**
@@ -327,7 +338,12 @@ export function useAIProvider() {
 
       let rawResponse: string;
 
-      switch (s.aiProvider) {
+      const provider =
+        (!s.aiEnabled || s.aiProvider === "none") && _claudeCliAvailable.value
+          ? "claude-code-cli"
+          : s.aiProvider;
+
+      switch (provider) {
         case "claude":
           rawResponse = await callClaude(s, systemPrompt, userPrompt);
           break;
@@ -368,7 +384,11 @@ export function useAIProvider() {
     userPrompt: string,
   ): Promise<string> {
     const s = loadAISettings();
-    switch (s.aiProvider) {
+    const provider =
+      (!s.aiEnabled || s.aiProvider === "none") && _claudeCliAvailable.value
+        ? "claude-code-cli"
+        : s.aiProvider;
+    switch (provider) {
       case "claude":
         return callClaude(s, systemPrompt, userPrompt);
       case "claude-code-cli":

--- a/apps/desktop/src/composables/useAIProvider.ts
+++ b/apps/desktop/src/composables/useAIProvider.ts
@@ -310,13 +310,12 @@ export function useAIProvider() {
   const isAvailable = computed(() => {
     const s = settings.value;
     if (s.aiEnabled) {
-      if (s.aiProvider === "claude" && !s.aiApiKey) return false;
-      if (s.aiProvider === "openai-compat" && (!s.aiApiKey || !s.aiApiEndpoint)) return false;
-      if (s.aiProvider === "none") {
-        // Fall through to auto-detect below.
-      } else {
-        return true;
-      }
+      if (s.aiProvider === "claude" && s.aiApiKey) return true;
+      if (s.aiProvider === "openai-compat" && s.aiApiKey && s.aiApiEndpoint) return true;
+      if (s.aiProvider === "ollama") return true;
+      if (s.aiProvider === "claude-code-cli") return true;
+      if (s.aiProvider === "codex-cli") return true;
+      // misconfigured explicit provider — fall through to CLI auto-detect
     }
     // Auto-fallback: use Claude Code CLI if installed and logged in,
     // even when the user hasn't configured any explicit AI provider.
@@ -338,10 +337,14 @@ export function useAIProvider() {
 
       let rawResponse: string;
 
-      const provider =
-        (!s.aiEnabled || s.aiProvider === "none") && _claudeCliAvailable.value
-          ? "claude-code-cli"
-          : s.aiProvider;
+      const misconfigured =
+        !s.aiEnabled ||
+        s.aiProvider === "none" ||
+        (s.aiProvider === "claude" && !s.aiApiKey) ||
+        (s.aiProvider === "openai-compat" && (!s.aiApiKey || !s.aiApiEndpoint));
+      const provider = misconfigured && _claudeCliAvailable.value
+        ? "claude-code-cli"
+        : s.aiProvider;
 
       switch (provider) {
         case "claude":
@@ -384,10 +387,14 @@ export function useAIProvider() {
     userPrompt: string,
   ): Promise<string> {
     const s = loadAISettings();
-    const provider =
-      (!s.aiEnabled || s.aiProvider === "none") && _claudeCliAvailable.value
-        ? "claude-code-cli"
-        : s.aiProvider;
+    const misconfigured =
+      !s.aiEnabled ||
+      s.aiProvider === "none" ||
+      (s.aiProvider === "claude" && !s.aiApiKey) ||
+      (s.aiProvider === "openai-compat" && (!s.aiApiKey || !s.aiApiEndpoint));
+    const provider = misconfigured && _claudeCliAvailable.value
+      ? "claude-code-cli"
+      : s.aiProvider;
     switch (provider) {
       case "claude":
         return callClaude(s, systemPrompt, userPrompt);

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -408,6 +408,7 @@ const en = {
     summaryPlaceholder: "Summary (required)",
     description: "Description",
     descriptionPlaceholder: "Description (optional)",
+    templatePicker: "Templates",
     // v2.12 identity selector
     identityDefault: "Global config",
   },

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -201,6 +201,7 @@ const en = {
     trailerSobHelp: "Adds \u201cSigned-off-by: your name\u201d to the commit. Certifies you have the right to submit this code under the project\u2019s license (Developer Certificate of Origin, DCO). Required by some open-source projects (e.g. Linux kernel).",
     trailerRbLabel: "Reviewed by",
     trailerRbHelp: "Adds \u201cReviewed-by: name\u201d to the commit. Records who reviewed and approved this change. Appears in the git history for traceability.",
+    aiLabel: "AI",
     aiGenerateTooltip: "Generate message with AI",
     aiGeneratingTooltip: "Generating\u2026",
     aiRegenerate: "Regenerate",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -197,6 +197,7 @@ const es: Locale = {
     trailerSobHelp: "Añade «Signed-off-by: tu nombre» al commit. Certifica que tienes derecho a enviar este código bajo la licencia del proyecto (DCO). Requerido por algunos proyectos de código abierto.",
     trailerRbLabel: "Revisado por",
     trailerRbHelp: "Añade «Reviewed-by: nombre» al commit. Registra quién revisó y aprobó este cambio. Visible en el historial git.",
+    aiLabel: "IA",
     aiGenerateTooltip: "Generar mensaje con IA",
     aiGeneratingTooltip: "Generando…",
     aiRegenerate: "Regenerar",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -395,6 +395,7 @@ const es: Locale = {
     summaryPlaceholder: "Resumen (obligatorio)",
     description: "Descripción",
     descriptionPlaceholder: "Descripción (opcional)",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "Config global",
   },
 

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -402,6 +402,7 @@ const fr: Locale = {
     summaryPlaceholder: "R\u00e9sum\u00e9 (requis)",
     description: "Description",
     descriptionPlaceholder: "Description (optionnel)",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "Config globale",
   },
 

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -195,6 +195,7 @@ const fr: Locale = {
     trailerSobHelp: "Ajoute « Signed-off-by : ton nom» au commit. Certifie que tu as le droit de soumettre ce code sous la licence du projet (Developer Certificate of Origin, DCO). Exigé par certains projets open source comme le noyau Linux.",
     trailerRbLabel: "Relu par",
     trailerRbHelp: "Ajoute « Reviewed-by : nom» au commit. Enregistre qui a relu et approuvé ce changement. Visible dans l’historique git pour la traçabilité.",
+    aiLabel: "IA",
     aiGenerateTooltip: "Générer un message avec l'IA",
     aiGeneratingTooltip: "Génération en cours\u2026",
     aiRegenerate: "Régénérer",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -198,6 +198,7 @@ const ptBR: Locale = {
     trailerSobHelp: "Adiciona «Signed-off-by: seu nome» ao commit. Certifica que você tem o direito de enviar este código sob a licença do projeto (DCO). Exigido por alguns projetos open source.",
     trailerRbLabel: "Revisado por",
     trailerRbHelp: "Adiciona «Reviewed-by: nome» ao commit. Registra quem revisou e aprovou esta alteração. Visível no histórico git.",
+    aiLabel: "IA",
     aiGenerateTooltip: "Gerar mensagem com IA",
     aiGeneratingTooltip: "Gerando…",
     aiRegenerate: "Regenerar",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -396,6 +396,7 @@ const ptBR: Locale = {
     summaryPlaceholder: "Resumo (obrigatório)",
     description: "Descrição",
     descriptionPlaceholder: "Descrição (opcional)",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "Config global",
   },
 

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -395,6 +395,7 @@ const zhCN: Locale = {
     summaryPlaceholder: "概要（必填）",
     description: "描述",
     descriptionPlaceholder: "描述（可选）",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "全局配置",
   },
 

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -201,6 +201,7 @@ const zhCN: Locale = {
     trailerSobHelp: "向提交添加《Signed-off-by: 您的姓名》。证明您有权根将此代码按项目许可证提交（DCO）。部分开源项目要求。",
     trailerRbLabel: "由谁审查",
     trailerRbHelp: "向提交添加《Reviewed-by: 姓名》。记录谁审查并批准了此更改。在 git 历史中可见。",
+    aiLabel: "AI",
     aiGenerateTooltip: "使用 AI 生成提交信息",
     aiGeneratingTooltip: "生成中…",
     aiRegenerate: "重新生成",


### PR DESCRIPTION
Feature:
- Add an AI button on commit summary input that auto generate the commit summary and message
- Auto-detect Claude Code CLI when no provider configured

Positions an AI split-button from a flex sibling next to the summary input to an absolute overlay at its top-right corner. Replaces the sparkle SVG with a compact "AI" text label. Input gets padding-right only when AI is available to prevent text overlap.

Avoid forcing the user to configure a provider when Claude Code CLI is already installed and connected — detection at module load, transparent fallback on `claude-code-cli`.

<img width="375" height="237" alt="image" src="https://github.com/user-attachments/assets/14fe3e35-af8c-484c-ac4e-6665a88c0fc4" />

For the last commit, i directly use and test that feature using `pnpm dev:web`.
I did run the `pnpm test` too.