### PR TITLE
feat(sidebar): discard-all button per file section

### DIFF
--- a/apps/desktop/perf/bench.mjs
+++ b/apps/desktop/perf/bench.mjs
@@ -46,6 +46,8 @@ function makeFixture() {
   git(dir, "init", "--initial-branch=main", "--quiet");
   git(dir, "config", "user.name", "Bench Bot");
   git(dir, "config", "user.email", "bench@gitwand.local");
+  git(dir, "config", "gc.auto", "0");
+  git(dir, "config", "gc.autoDetach", "false");
 
   // 50 tracked files, 200 commits
   for (let i = 0; i < 200; i++) {

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -639,6 +639,11 @@ function onViewModeChange(mode: ViewMode) {
   viewMode.value = mode;
 }
 
+async function onDiscardSection(paths: string[], untracked: boolean) {
+  if (!window.confirm(t('sidebar.discardAllConfirm', paths.length))) return;
+  await discardFiles(paths, untracked);
+}
+
 // ─── File history viewer ────────────────────────────────
 const fileHistoryPath = ref<string | null>(null);
 
@@ -1661,6 +1666,7 @@ onUnmounted(() => {
           @tag-commit="handleTagCommit" @cherry-pick-commit="handleCherryPickCommit" @view-on-forge="handleViewOnForge"
           @update:log-scope="setLogScope" @update:log-author-filter="setLogAuthorFilter"
           @discard="(path, section) => discardFiles([path], section === 'untracked')"
+          @discard-section="onDiscardSection"
           @add-to-gitignore="(path) => addToGitignore(path)" @refresh="repoRefresh()" @open-stash="showStash = true"
           @open-tags="showTags = true" @open-workspace="showWorkspace = true" @open-agents="showAgents = true"
           @open-launchpad="handleLaunchpadShortcut" />

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -639,9 +639,12 @@ function onViewModeChange(mode: ViewMode) {
   viewMode.value = mode;
 }
 
-async function onDiscardSection(paths: string[], untracked: boolean) {
+async function onDiscardSection(sectionKey: string, paths: string[]) {
   if (!window.confirm(t('sidebar.discardAllConfirm', paths.length))) return;
-  await discardFiles(paths, untracked);
+  if (sectionKey === 'staged') {
+    await unstageFiles(paths);
+  }
+  await discardFiles(paths, sectionKey === 'untracked');
 }
 
 // ─── File history viewer ────────────────────────────────

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -763,19 +763,8 @@ function formatActivityDate(dateStr: string): string {
             </span>
             <span class="section-label">{{ sectionMeta[sectionKey].label }}</span>
             <span class="section-count">{{ sections[sectionKey].length }}</span>
-            <!-- Stage all / Unstage all buttons -->
-            <button
-              v-if="sectionKey === 'unstaged' || sectionKey === 'untracked'"
-              class="section-action"
-              @click="emit('stagePaths', sections[sectionKey].map(f => f.path))"
-              :title="t('sidebar.stageAll')"
-            >+</button>
-            <button
-              v-if="sectionKey === 'staged'"
-              class="section-action"
-              @click="emit('unstageAll')"
-              :title="t('sidebar.unstageAll')"
-            >-</button>
+            <span class="section-spacer"></span>
+            <!-- Discard all / Stage all / Unstage all buttons -->
             <button
               v-if="sectionKey === 'staged' || sectionKey === 'unstaged' || sectionKey === 'untracked'"
               class="section-action section-action--danger"
@@ -790,6 +779,18 @@ function formatActivityDate(dateStr: string): string {
                 <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
               </svg>
             </button>
+            <button
+              v-if="sectionKey === 'unstaged' || sectionKey === 'untracked'"
+              class="section-action"
+              @click="emit('stagePaths', sections[sectionKey].map(f => f.path))"
+              :title="t('sidebar.stageAll')"
+            >+</button>
+            <button
+              v-if="sectionKey === 'staged'"
+              class="section-action"
+              @click="emit('unstageAll')"
+              :title="t('sidebar.unstageAll')"
+            >-</button>
           </div>
 
           <ul class="file-items" role="listbox">
@@ -1754,6 +1755,7 @@ function formatActivityDate(dateStr: string): string {
   padding: var(--space-4) var(--space-6);
   font-size: var(--font-size-sm);
   font-weight: var(--font-weight-semibold);
+  line-height: 1;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--color-text-muted);
@@ -1772,14 +1774,20 @@ function formatActivityDate(dateStr: string): string {
 }
 
 .section-label {
+}
+
+.section-spacer {
   flex: 1;
 }
 
 .section-count {
   font-variant-numeric: tabular-nums;
   background: var(--color-bg-tertiary);
-  padding: var(--space-1) var(--space-3);
+  padding: 0 var(--space-3);
   border-radius: var(--radius-pill);
+  height: 16px;
+  display: flex;
+  align-items: center;
 }
 
 .section-action {
@@ -1792,6 +1800,7 @@ function formatActivityDate(dateStr: string): string {
   font-family: var(--font-mono);
   font-size: var(--font-size-lg);
   font-weight: var(--font-weight-bold);
+  line-height: 1;
   color: var(--color-text-muted);
   background: none;
   transition: background var(--transition-hover), color var(--transition-hover);

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -85,8 +85,8 @@ const emit = defineEmits<{
   "select-dir-file": [path: string];
   /** Discard changes to a file (tracked: restore, untracked: delete) */
   discard: [path: string, section: string];
-  /** Discard all changes in a section (paths, whether all files are untracked) */
-  discardSection: [paths: string[], untracked: boolean];
+  /** Discard all changes in a section */
+  discardSection: [sectionKey: string, paths: string[]];
   /** Append file path to .gitignore */
   addToGitignore: [path: string];
   /** Request a full repo state refresh (after absorb, etc.) */
@@ -779,7 +779,7 @@ function formatActivityDate(dateStr: string): string {
             <button
               v-if="sectionKey === 'staged' || sectionKey === 'unstaged' || sectionKey === 'untracked'"
               class="section-action section-action--danger"
-              @click.stop="emit('discardSection', sections[sectionKey].map(f => f.path), sectionKey === 'untracked')"
+              @click.stop="emit('discardSection', sectionKey, sections[sectionKey].map(f => f.path))"
               :title="t('sidebar.discardAll')"
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -85,6 +85,8 @@ const emit = defineEmits<{
   "select-dir-file": [path: string];
   /** Discard changes to a file (tracked: restore, untracked: delete) */
   discard: [path: string, section: string];
+  /** Discard all changes in a section (paths, whether all files are untracked) */
+  discardSection: [paths: string[], untracked: boolean];
   /** Append file path to .gitignore */
   addToGitignore: [path: string];
   /** Request a full repo state refresh (after absorb, etc.) */
@@ -774,6 +776,20 @@ function formatActivityDate(dateStr: string): string {
               @click="emit('unstageAll')"
               :title="t('sidebar.unstageAll')"
             >-</button>
+            <button
+              v-if="sectionKey === 'staged' || sectionKey === 'unstaged' || sectionKey === 'untracked'"
+              class="section-action section-action--danger"
+              @click.stop="emit('discardSection', sections[sectionKey].map(f => f.path), sectionKey === 'untracked')"
+              :title="t('sidebar.discardAll')"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <polyline points="3 6 5 6 21 6"/>
+                <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                <path d="M10 11v6"/>
+                <path d="M14 11v6"/>
+                <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2"/>
+              </svg>
+            </button>
           </div>
 
           <ul class="file-items" role="listbox">
@@ -1784,6 +1800,11 @@ function formatActivityDate(dateStr: string): string {
 .section-action:hover {
   background: var(--color-bg-tertiary);
   color: var(--color-text);
+}
+
+.section-action--danger:hover {
+  background: color-mix(in srgb, var(--color-danger) 15%, transparent);
+  color: var(--color-danger);
 }
 
 .file-items {

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -1773,9 +1773,6 @@ function formatActivityDate(dateStr: string): string {
   text-align: center;
 }
 
-.section-label {
-}
-
 .section-spacer {
   flex: 1;
 }

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -172,6 +172,8 @@ const en = {
     // Actions
     stageAll: "Stage all",
     unstageAll: "Unstage all",
+    discardAll: "Discard all",
+    discardAllConfirm: "Discard all {0} file(s)? This cannot be undone.",
     stage: "Stage",
     unstage: "Unstage",
     // Commit panel

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -409,6 +409,7 @@ const en = {
     summaryPlaceholder: "Summary (required)",
     description: "Description",
     descriptionPlaceholder: "Description (optional)",
+    templatePicker: "Templates",
     // v2.12 identity selector
     identityDefault: "Global config",
   },

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -168,6 +168,8 @@ const es: Locale = {
     sectionUntracked: "Sin seguimiento",
     stageAll: "Preparar todo",
     unstageAll: "Quitar todo de preparados",
+    discardAll: "Descartar todo",
+    discardAllConfirm: "¿Descartar {0} archivo(s)? Esta acción no se puede deshacer.",
     stage: "Preparar",
     unstage: "Quitar de preparados",
     stageAllButton: "Preparar todo ({0})",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -396,6 +396,7 @@ const es: Locale = {
     summaryPlaceholder: "Resumen (obligatorio)",
     description: "Descripción",
     descriptionPlaceholder: "Descripción (opcional)",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "Config global",
   },
 

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -403,6 +403,7 @@ const fr: Locale = {
     summaryPlaceholder: "R\u00e9sum\u00e9 (requis)",
     description: "Description",
     descriptionPlaceholder: "Description (optionnel)",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "Config globale",
   },
 

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -165,6 +165,8 @@ const fr: Locale = {
     // Actions
     stageAll: "Tout indexer",
     unstageAll: "Tout désindexer",
+    discardAll: "Tout supprimer",
+    discardAllConfirm: "Supprimer {0} fichier(s) ? Cette action est irréversible.",
     stage: "Indexer",
     unstage: "Désindexer",
     // Commit panel

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -397,6 +397,7 @@ const ptBR: Locale = {
     summaryPlaceholder: "Resumo (obrigatório)",
     description: "Descrição",
     descriptionPlaceholder: "Descrição (opcional)",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "Config global",
   },
 

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -169,6 +169,8 @@ const ptBR: Locale = {
     sectionUntracked: "Não rastreados",
     stageAll: "Stage em tudo",
     unstageAll: "Tirar tudo do stage",
+    discardAll: "Descartar tudo",
+    discardAllConfirm: "Descartar {0} arquivo(s)? Esta ação não pode ser desfeita.",
     stage: "Stage",
     unstage: "Tirar do stage",
     stageAllButton: "Stage em tudo ({0})",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -172,6 +172,8 @@ const zhCN: Locale = {
     sectionUntracked: "未跟踪",
     stageAll: "全部暂存",
     unstageAll: "全部取消暂存",
+    discardAll: "全部丢弃",
+    discardAllConfirm: "丢弃 {0} 个文件？此操作无法撤销。",
     stage: "暂存",
     unstage: "取消暂存",
     stageAllButton: "全部暂存 ({0})",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -396,6 +396,7 @@ const zhCN: Locale = {
     summaryPlaceholder: "概要（必填）",
     description: "描述",
     descriptionPlaceholder: "描述（可选）",
+    templatePicker: "Templates", // TODO: translate
     identityDefault: "全局配置",
   },
 


### PR DESCRIPTION
## Why?

Bulk discard before this: open context menu → click discard → repeat for every file. 10 staged files = 10 clicks minimum.

**Now:** One click on the trash, confirm once, done. Saves the flow where you want to nuke an entire section and start fresh — common after a bad experiment or
  before switching branches.

## Key points

  1. Trash bin button per section (Staged / Modified / Untracked) — sits left of the existing +/- action, red hover to signal destructive action
  2. Confirmation guard — window.confirm before any bulk discard, shows file count
  3. Staged section handled correctly — unstages first (git restore --staged), then discards working tree (git checkout --). Plain discard alone would only restore
   working tree, leaving changes staged
  4. Count badge repositioned — moved next to section label instead of floating right, improves scannability
  5. i18n — discardAll + discardAllConfirm keys in all 5 locales (EN, FR, ES, PT-BR, ZH-CN)

## Final result example
<img width="498" height="276" alt="image" src="https://github.com/user-attachments/assets/e54ea15c-b8b5-4d41-a34e-1f744ed15061" />
