### PR TITLE
Feat/git tree side panel

### DIFF
--- a/apps/desktop/perf/bundle-check.mjs
+++ b/apps/desktop/perf/bundle-check.mjs
@@ -72,7 +72,7 @@ for (const f of files) {
 }
 
 const total = files.reduce((acc, f) => acc + f.kb, 0);
-const main = files.find((f) => /^index-[a-z0-9]+\.js$/i.test(f.name)) || files[0];
+const main = files.find((f) => /^index-[a-z0-9-]+\.js$/i.test(f.name)) || files[0];
 const otherMax = files.filter((f) => f !== main).reduce((max, f) => Math.max(max, f.kb), 0);
 
 console.log(`\nTotal:    ${total} KB`);

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -206,6 +206,45 @@ const {
   currentGitUser,
 } = useGitRepo();
 
+// ─── Git Tree panel ──────────────────────────────────────
+const showGitTree = ref(false);
+const gitTreeWidth = ref(720);
+const gitTreeResizing = ref(false);
+
+function onGitTreeMouseDown(e: MouseEvent) {
+  const startX = e.clientX;
+  const startWidth = gitTreeWidth.value;
+  let dragged = false;
+
+  const onMouseMove = (ev: MouseEvent) => {
+    const delta = startX - ev.clientX;
+    if (!dragged && Math.abs(delta) >= 4) dragged = true;
+    if (dragged) {
+      gitTreeResizing.value = true;
+      gitTreeWidth.value = Math.max(200, Math.min(1400, startWidth + delta));
+    }
+  };
+
+  const onMouseUp = (ev: MouseEvent) => {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+    document.body.style.userSelect = '';
+    document.body.style.cursor = '';
+    if (!dragged && Math.abs(ev.clientX - startX) < 4) {
+      showGitTree.value = !showGitTree.value;
+    }
+    gitTreeResizing.value = false;
+  };
+
+  if (showGitTree.value) {
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'ew-resize';
+  }
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
+  e.preventDefault();
+}
+
 // ─── Fork Point (v2.11) — graph view ─────────────────────
 // SHA of the merge-base between HEAD and the upstream tracking branch.
 // Used by CommitGraph to dim shared-history commits.
@@ -294,7 +333,7 @@ watch(
     const tab = repoTabs.value.find((t) => t.id === id);
     if (tab && tab.path !== repoFolderPath.value) {
       await openRepo(tab.path);
-      if (viewMode.value === "history" || viewMode.value === "graph") {
+      if (viewMode.value === "history" || showGitTree.value) {
         await loadLog();
       }
     }
@@ -556,7 +595,7 @@ async function handleSplitCommitRequest(entry: GitLogEntry) {
  * via the composable's `confirm()` before emitting this event.
  */
 async function handleSplitCompleted(_hashes: { firstHash: string; secondHash: string }) {
-  if (viewMode.value === "history" || viewMode.value === "graph") {
+  if (viewMode.value === "history" || showGitTree.value) {
     await loadLog();
   }
   // Refresh branches too — if we split the HEAD commit on a branch tip,
@@ -595,7 +634,7 @@ async function handleOpenFolder() {
   if (path) {
     openTab(path);
     await openRepo(path);
-    if (viewMode.value === "history" || viewMode.value === "graph") {
+    if (viewMode.value === "history" || showGitTree.value) {
       await loadLog();
     }
   }
@@ -604,7 +643,7 @@ async function handleOpenFolder() {
 async function handleOpenPath(path: string) {
   openTab(path);
   await openRepo(path);
-  if (viewMode.value === "history" || viewMode.value === "graph") {
+  if (viewMode.value === "history" || showGitTree.value) {
     await loadLog();
   }
 }
@@ -636,6 +675,10 @@ function onRepoFileSelect(path: string, staged: boolean) {
 }
 
 function onViewModeChange(mode: ViewMode) {
+  if (mode === "graph") {
+    showGitTree.value = !showGitTree.value;
+    return;
+  }
   viewMode.value = mode;
 }
 
@@ -874,7 +917,7 @@ function onPaletteAction(id: string) {
     case "view-dashboard": viewMode.value = "dashboard"; break;
     case "view-changes": viewMode.value = "changes"; break;
     case "view-log": viewMode.value = "history"; break;
-    case "view-graph": viewMode.value = "graph"; break;
+    case "view-graph": showGitTree.value = !showGitTree.value; break;
     case "open-settings": showSettings.value = true; break;
     case "open-stash": showStash.value = true; break;
     case "open-worktrees": showWorktrees.value = true; break;
@@ -944,7 +987,7 @@ const showForkModal = ref(false);
 async function onCloned(path: string) {
   openTab(path);
   await openRepo(path);
-  if (viewMode.value === "history" || viewMode.value === "graph") {
+  if (viewMode.value === "history" || showGitTree.value) {
     await loadLog();
   }
 }
@@ -954,7 +997,7 @@ async function onForked(path: string) {
   // `gh repo fork --remote-name=upstream` on the backend.
   openTab(path);
   await openRepo(path);
-  if (viewMode.value === "history" || viewMode.value === "graph") {
+  if (viewMode.value === "history" || showGitTree.value) {
     await loadLog();
   }
 }
@@ -1790,12 +1833,6 @@ onUnmounted(() => {
               :commit-info="repoLog.find(e => e.hashFull === selectedCommitHash) ?? null" :diff-mode="diffMode"
               @update:diff-mode="onDiffModeChange" />
 
-            <!-- Graph view: DAG visualization -->
-            <CommitGraph v-else-if="viewMode === 'graph'" :commits="repoLog" :selected-hash="selectedCommitHash"
-              :current-branch="branchDisplay"
-              :fork-point-sha="graphForkPointSha"
-              @select-commit="(hash) => { selectCommit(hash); viewMode = 'history'; }" />
-
             <!-- PRs view: creation form takes over when showCreateForm is true -->
             <PrCreateView v-else-if="viewMode === 'prs' && prPanel.showCreateForm.value"
               :current-branch="repoStatus?.branch ?? ''" :branches="branches" :cwd="repoFolderPath ?? ''" />
@@ -1809,6 +1846,31 @@ onUnmounted(() => {
           </template>
         </template>
       </main>
+
+      <!-- Git Tree toggle button (vertical strip between main and panel) -->
+      <button
+        v-if="hasRepo"
+        class="git-tree-toggle"
+        :class="{ 'git-tree-toggle--active': showGitTree, 'git-tree-toggle--resizing': gitTreeResizing }"
+        :style="showGitTree ? { cursor: 'ew-resize' } : {}"
+        @mousedown="onGitTreeMouseDown"
+        :title="t('sidebar.gitTree')"
+      >
+        {{ t('sidebar.gitTree') }}
+      </button>
+
+      <!-- Git Tree side panel -->
+      <Transition name="git-tree-panel">
+        <aside v-if="showGitTree && hasRepo" class="git-tree-panel" :style="{ width: gitTreeWidth + 'px', minWidth: gitTreeWidth + 'px' }">
+          <CommitGraph
+            :commits="repoLog"
+            :selected-hash="selectedCommitHash"
+            :current-branch="branchDisplay"
+            :fork-point-sha="graphForkPointSha"
+            @select-commit="(hash) => { selectCommit(hash); viewMode = 'history'; }"
+          />
+        </aside>
+      </Transition>
     </div>
 
     <!-- In-app update modal -->
@@ -2124,6 +2186,62 @@ onUnmounted(() => {
   position: relative;
 }
 
+.git-tree-toggle {
+  width: 24px;
+  min-width: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  border: none;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg-secondary);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--color-text-muted);
+  letter-spacing: 0.08em;
+  padding: 0;
+  transition: background 0.15s, color 0.15s;
+  user-select: none;
+}
+
+.git-tree-toggle:hover {
+  background: var(--color-bg-hover);
+  color: var(--color-text);
+}
+
+.git-tree-toggle--active {
+  color: var(--color-accent);
+  border-left-color: var(--color-accent);
+}
+
+.git-tree-panel {
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.git-tree-panel-enter-active,
+.git-tree-panel-leave-active {
+  transition: width 0.2s ease, min-width 0.2s ease, opacity 0.2s ease;
+  overflow: hidden;
+}
+
+.git-tree-panel-enter-from,
+.git-tree-panel-leave-to {
+  width: 0 !important;
+  min-width: 0 !important;
+  opacity: 0;
+}
+
+.git-tree-toggle--resizing {
+  background: var(--color-bg-hover);
+}
+
 .loading-overlay {
   position: absolute;
   inset: 0;
@@ -2424,7 +2542,7 @@ onUnmounted(() => {
 }
 
 .switch-stash-modal {
-  width: min(520px, 100%);
+  width: min(720px, 100%);
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -733,13 +733,6 @@ function formatActivityDate(dateStr: string): string {
         {{ t('sidebar.tabLog') }}
       </button>
       <button
-        class="view-tab"
-        :class="{ 'view-tab--active': viewMode === 'graph' }"
-        @click="emit('changeView', 'graph')"
-      >
-        {{ t('sidebar.tabGraph') }}
-      </button>
-      <button
         class="view-tab view-tab--pr"
         :class="{ 'view-tab--active': viewMode === 'prs' }"
         @click="emit('changeView', 'prs')"

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -96,7 +96,7 @@ const en = {
     paletteViewDashboard: "View: Dashboard",
     paletteViewChanges: "View: Changes",
     paletteViewLog: "View: Log",
-    paletteViewGraph: "View: Graph",
+    paletteViewGraph: "View: Git Tree",
     // Tab strip + dropdown (v2.0)
     tabStripAddTitle: "Add a tab",
     tabStripOpenFolder: "Open folder",
@@ -152,6 +152,7 @@ const en = {
     tabBranches: "Branches",
     tabLog: "Log",
     tabGraph: "Graph",
+    gitTree: "Git Tree",
     tabDashboard: "Dashboard",
     stashTitle: "Stash manager",
     // Log scope toggle (current branch vs all refs)

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -96,7 +96,7 @@ const es: Locale = {
     paletteViewDashboard: "Vista: Panel",
     paletteViewChanges: "Vista: Cambios",
     paletteViewLog: "Vista: Historial",
-    paletteViewGraph: "Vista: Gr\u00e1fico",
+    paletteViewGraph: "Vista: \u00c1rbol Git",
     // Tab strip + dropdown (v2.0)
     tabStripAddTitle: "Agregar pesta\u00f1a",
     tabStripOpenFolder: "Abrir carpeta",
@@ -152,6 +152,7 @@ const es: Locale = {
     tabBranches: "Ramas",
     tabLog: "Historial",
     tabGraph: "Gráfico",
+    gitTree: "Árbol Git",
     tabDashboard: "Panel",
     stashTitle: "Gestor de stash",
     logScopeLabel: "Ámbito del historial",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -90,7 +90,7 @@ const fr: Locale = {
     paletteViewDashboard: "Vue\u00a0: Tableau de bord",
     paletteViewChanges: "Vue\u00a0: Modifications",
     paletteViewLog: "Vue\u00a0: Historique",
-    paletteViewGraph: "Vue\u00a0: Graphe",
+    paletteViewGraph: "Vue\u00a0: Arbre Git",
     // Tab strip + dropdown (v2.0)
     tabStripAddTitle: "Ajouter un onglet",
     tabStripOpenFolder: "Ouvrir un dossier",
@@ -146,6 +146,7 @@ const fr: Locale = {
     tabBranches: "Branches",
     tabLog: "Log",
     tabGraph: "Graphe",
+    gitTree: "Arbre Git",
     tabDashboard: "Tableau de bord",
     stashTitle: "Gestionnaire de stash",
     // Log scope toggle (current branch vs all refs)

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -97,7 +97,7 @@ const ptBR: Locale = {
     paletteViewDashboard: "Vis\u00e3o: Painel",
     paletteViewChanges: "Vis\u00e3o: Altera\u00e7\u00f5es",
     paletteViewLog: "Vis\u00e3o: Hist\u00f3rico",
-    paletteViewGraph: "Vis\u00e3o: Gr\u00e1fico",
+    paletteViewGraph: "Vis\u00e3o: \u00c1rvore Git",
     // Tab strip + dropdown (v2.0)
     tabStripAddTitle: "Adicionar aba",
     tabStripOpenFolder: "Abrir pasta",
@@ -153,6 +153,7 @@ const ptBR: Locale = {
     tabBranches: "Branches",
     tabLog: "Histórico",
     tabGraph: "Grafo",
+    gitTree: "Árvore Git",
     tabDashboard: "Painel",
     stashTitle: "Gerenciador de stash",
     logScopeLabel: "Escopo do histórico",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -101,7 +101,7 @@ const zhCN: Locale = {
     paletteViewDashboard: "\u89c6\u56fe\uff1a\u4eea\u8868\u76d8",
     paletteViewChanges: "\u89c6\u56fe\uff1a\u66f4\u6539",
     paletteViewLog: "\u89c6\u56fe\uff1a\u5386\u53f2",
-    paletteViewGraph: "\u89c6\u56fe\uff1a\u56fe\u8868",
+    paletteViewGraph: "\u89c6\u56fe\uff1aGit \u6811\u56fe",
     // 标签页 + 下拉菜单 (v2.0)
     tabStripAddTitle: "添加标签页",
     tabStripOpenFolder: "打开文件夹",
@@ -156,6 +156,7 @@ const zhCN: Locale = {
     tabBranches: "分支",
     tabLog: "日志",
     tabGraph: "图谱",
+    gitTree: "Git 树图",
     tabDashboard: "概览",
     stashTitle: "储藏管理",
     logScopeLabel: "日志范围",


### PR DESCRIPTION
## Why

The commit graph is a reference view. Something you glance at while working, not a destination you navigate to. Keeping it as a tab forced a context switch and hid the rest of the UI. Promoting it to a persistent side panel lets you keep the graph visible alongside Changes, Log, or any other view, making branch topology a first-class companion to your workflow.

Moving the graph out of the tab system and into a persistent panel unlocks a class of improvements that weren't possible before. The graph can now react to and communicate with whatever view is active next to it. (Pairs naturally with the Log tab)

## What changed

  - Git Tree side panel — the commit graph now lives in a resizable aside on the right, toggled by a vertical "Git Tree" button strip, so it can stay open
  alongside any other view
  - Removed Graph tab from the navigation tabs — Dashboard, Changes, Log, and PRs remain; the graph is no longer a competing destination
  - Resizable panel — drag the "Git Tree" button to set the panel width anywhere between 200px and 1400px; click it to open/close
  - All existing graph entry points preserved — dashboard stat card, sidebar quick actions, and command palette (View: Git Tree) all open the new panel
  - i18n updated — sidebar.gitTree key added in all 5 locales (EN, FR, ES, PT-BR, ZH-CN); command palette label updated to match the new name



## How it looks like

### Now

There is a vertical "Git Tree button" to the right of the main section

#### Close

<img width="1915" height="995" alt="image" src="https://github.com/user-attachments/assets/e08cf279-78bd-49b7-a73a-2f3f6711f3b1" />

#### Open

While open, the tree view is resizable

<img width="1918" height="994" alt="image" src="https://github.com/user-attachments/assets/3bc0ec84-5835-4820-a965-bf70e01d0adf" />

### Before

<img width="1920" height="995" alt="image" src="https://github.com/user-attachments/assets/fa79963a-5d02-4e51-a577-d5a51d0b9011" />