### PR TITLE
feat(desktop): merge duplicate git shortlog contributors

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -1973,7 +1973,7 @@ pub(crate) fn agent_session_launch(cwd: String, tool: String) -> Result<(), Stri
 #[tauri::command]
 pub(crate) fn git_shortlog(cwd: String) -> Result<Vec<ShortlogEntry>, String> {
     let output = git_cmd()
-        .args(["shortlog", "-sne", "HEAD", "--max-count=50"])
+        .args(["shortlog", "-sne", "HEAD"])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git shortlog: {}", e))?;

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -1621,17 +1621,35 @@ export interface ShortlogEntry {
  * Returns entries sorted by count descending.
  */
 export async function getGitShortlog(cwd: string): Promise<ShortlogEntry[]> {
+  let raw: ShortlogEntry[];
   if (isTauri()) {
-    return tauriInvoke<ShortlogEntry[]>("git_shortlog", { cwd });
+    raw = await tauriInvoke<ShortlogEntry[]>("git_shortlog", { cwd });
+  } else {
+    const res = await fetch(
+      `${DEV_SERVER}/api/git-shortlog?cwd=${encodeURIComponent(cwd)}`,
+    );
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as { error?: string };
+      throw new Error(body.error ?? `git shortlog failed: ${res.status}`);
+    }
+    raw = (await res.json()) as ShortlogEntry[];
   }
-  const res = await fetch(
-    `${DEV_SERVER}/api/git-shortlog?cwd=${encodeURIComponent(cwd)}`,
-  );
-  if (!res.ok) {
-    const body = (await res.json().catch(() => ({}))) as { error?: string };
-    throw new Error(body.error ?? `git shortlog failed: ${res.status}`);
+
+  // Merge contributors with the same name (case-insensitive).
+  // This handles users with multiple email addresses or different name casing.
+  const merged = new Map<string, ShortlogEntry>();
+  for (const entry of raw) {
+    const key = entry.name.toLowerCase();
+    const existing = merged.get(key);
+    if (existing) {
+      existing.count += entry.count;
+    } else {
+      merged.set(key, { ...entry });
+    }
   }
-  return (await res.json()) as ShortlogEntry[];
+
+  // Re-sort because merging might have changed the order
+  return Array.from(merged.values()).sort((a, b) => b.count - a.count);
 }
 
 // ─── Clone & Fork (v2.0) ───────────────────────────────────


### PR DESCRIPTION
## Why

Consolidates shortlog entries for the same contributor by merging counts for names that are identical ignoring casing. 

This provides a more accurate and consolidated view of contributions. The backend `git shortlog` command no longer limits results, allowing the client to process all data for merging.

## Before

<img width="1354" height="428" alt="image" src="https://github.com/user-attachments/assets/e9a20fbf-2365-4e49-bbbb-a2f24ef9d4e1" />

## After

<img width="1354" height="428" alt="image" src="https://github.com/user-attachments/assets/70d8a799-5aab-4dc0-aeb5-74405585f64f" />
