### PR TITLE
feat: Allow reordering repo tabs via drag and drop

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -310,6 +310,7 @@ const {
   openTab,
   closeTab,
   switchTab,
+  reorderTabs,
 } = useRepoTabs();
 
 // When tab changes, load that repo into the single useGitRepo instance.
@@ -1834,6 +1835,7 @@ onUnmounted(() => {
       :cwd="repoFolderPath ?? ''" :branches="branches" :branches-loading="branchesLoading"
       :is-switching-branch="isSwitchingBranch" :is-merging="isMerging" :tabs="repoTabs" :active-tab-id="activeTabId"
       @open-folder="handleOpenFolder" @open-repo="handleOpenPath" @switch-tab="switchTab" @close-tab="closeTab"
+      @reorder-tabs="reorderTabs"
       @new-tab="handleOpenFolder" @open-clone="showCloneModal = true" @open-fork="showForkModal = true"
       @toggle-theme="toggleTheme" @push="handlePush" @pull="() => doPull(pullMode === 'rebase')" @fetch="doFetch"
       @sync="doSync" @publish="doPublish" @rebase-onto-remote="doRebaseOntoRemote" @merge-remote="doMergeRemote"

--- a/apps/desktop/src/components/AppHeader.vue
+++ b/apps/desktop/src/components/AppHeader.vue
@@ -97,6 +97,7 @@ const emit = defineEmits<{
   newTab: [];
   openClone: [];
   openFork: [];
+  reorderTabs: [oldIndex: number, newIndex: number];
   // ── Sync / publish actions ───────────────────────────────────
   push: [];
   pull: [];
@@ -314,6 +315,7 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
         @open-clone="emit('openClone')"
         @open-fork="emit('openFork')"
         @open-recent="(path) => emit('openRepo', path)"
+        @reorder-tabs="(oldIdx, newIdx) => emit('reorderTabs', oldIdx, newIdx)"
       />
 
       <div class="app-header__tabs-spacer"></div>

--- a/apps/desktop/src/components/header/RepoTabStrip.vue
+++ b/apps/desktop/src/components/header/RepoTabStrip.vue
@@ -46,7 +46,42 @@ const emit = defineEmits<{
   openFork: [];
   openRecent: [path: string];
   closeOtherTabs: [tabId: number];
+  reorderTabs: [oldIndex: number, newIndex: number];
 }>();
+
+// ─── Drag and Drop (v2.15) ──────────────────────────────
+const draggedIndex = ref<number | null>(null);
+const hoveredIndex = ref<number | null>(null);
+
+function onDragStart(e: DragEvent, index: number) {
+  draggedIndex.value = index;
+  if (e.dataTransfer) {
+    e.dataTransfer.effectAllowed = "move";
+    // Required for some browsers to initiate drag
+    e.dataTransfer.setData("text/plain", index.toString());
+  }
+}
+
+function onDragOver(e: DragEvent, index: number) {
+  e.preventDefault(); // Required to allow drop
+  if (draggedIndex.value !== null && draggedIndex.value !== index) {
+    hoveredIndex.value = index;
+  }
+}
+
+function onDrop(e: DragEvent, index: number) {
+  e.preventDefault();
+  if (draggedIndex.value !== null && draggedIndex.value !== index) {
+    emit("reorderTabs", draggedIndex.value, index);
+  }
+  draggedIndex.value = null;
+  hoveredIndex.value = null;
+}
+
+function onDragEnd() {
+  draggedIndex.value = null;
+  hoveredIndex.value = null;
+}
 
 // Pinned and recent repos shown in the + dropdown (excludes repos already
 // open in a tab). Capped at 8 combined entries so the menu stays compact;
@@ -176,16 +211,27 @@ function onCloseClick(e: MouseEvent, tabId: number) {
     <!-- Tabs — rendered only when there are multiple repos -->
     <template v-if="showTabs">
       <button
-        v-for="tab in tabs"
+        v-for="(tab, index) in tabs"
         :key="tab.id"
         type="button"
         role="tab"
         class="repo-tab"
-        :class="{ 'repo-tab--active': tab.id === activeTabId }"
+        :class="{
+          'repo-tab--active': tab.id === activeTabId,
+          'repo-tab--dragging': draggedIndex === index,
+          'repo-tab--drag-over-left': hoveredIndex === index && draggedIndex !== null && draggedIndex > index,
+          'repo-tab--drag-over-right': hoveredIndex === index && draggedIndex !== null && draggedIndex < index
+        }"
         :aria-selected="tab.id === activeTabId ? 'true' : 'false'"
         :title="tab.path"
+        draggable="true"
         @click="emit('switchTab', tab.id)"
         @mousedown="(e) => onMiddleClick(e, tab.id)"
+        @dragstart="(e) => onDragStart(e, index)"
+        @dragover="(e) => onDragOver(e, index)"
+        @dragleave="hoveredIndex = null"
+        @drop="(e) => onDrop(e, index)"
+        @dragend="onDragEnd"
       >
         <svg class="repo-tab__icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M2 3.5A1.5 1.5 0 013.5 2h3.586a1.5 1.5 0 011.06.44l.915.914a1 1 0 00.707.293H12.5A1.5 1.5 0 0114 5.147V12.5A1.5 1.5 0 0112.5 14h-9A1.5 1.5 0 012 12.5v-9z" stroke="currentColor" stroke-width="1.2" />
@@ -354,6 +400,7 @@ function onCloseClick(e: MouseEvent, tabId: number) {
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: thin;
+  padding: 0 4px;
 }
 
 /* Tabs are pills, matching the rest of the header's chip vocabulary
@@ -389,6 +436,38 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 .repo-tab--active {
   color: var(--color-accent);
   background: var(--color-accent-soft);
+}
+
+.repo-tab--dragging {
+  opacity: 0.4;
+  cursor: grabbing;
+}
+
+.repo-tab--drag-over-left,
+.repo-tab--drag-over-right {
+  position: relative;
+}
+
+.repo-tab--drag-over-left::before,
+.repo-tab--drag-over-right::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 2px;
+  height: 24px;
+  background: var(--color-accent);
+  border-radius: var(--radius-pill);
+  transform: translateY(-50%);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.repo-tab--drag-over-left::before {
+  left: -3px;
+}
+
+.repo-tab--drag-over-right::after {
+  right: -3px;
 }
 
 .repo-tab__icon {

--- a/apps/desktop/src/composables/useRepoTabs.ts
+++ b/apps/desktop/src/composables/useRepoTabs.ts
@@ -183,11 +183,27 @@ export function useRepoTabs() {
     }
   }
 
+  /**
+   * Reorder tabs by moving a tab from one index to another.
+   */
+  function reorderTabs(oldIndex: number, newIndex: number) {
+    if (oldIndex < 0 || oldIndex >= tabs.value.length) return;
+    if (newIndex < 0 || newIndex >= tabs.value.length) return;
+    if (oldIndex === newIndex) return;
+
+    const tab = tabs.value[oldIndex];
+    tabs.value.splice(oldIndex, 1);
+    tabs.value.splice(newIndex, 0, tab);
+
+    save(tabs.value, activeTabId.value);
+  }
+
   return {
     tabs,
     activeTabId,
     openTab,
     closeTab,
     switchTab,
+    reorderTabs,
   };
 }


### PR DESCRIPTION
This is a small and simple PR that allow to reordering repo tabs via drag and drop.

As you can see in the image, there is a vertical line to show where the dragged tab will take place.

<img width="532" height="59" alt="image" src="https://github.com/user-attachments/assets/81099292-5bf4-4637-8d68-f8b541ee8f19" />
