### PR TITLE
fix(desktop): remove release/develop lane pinning from commit graph

### DIFF
--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -453,12 +453,6 @@ let _pinHeadHash = "";
 let _pinTrunkHash: string | undefined = undefined;
 let _pinSecondaryHashes: string[] = [];
 
-function isReleaseBranch(name: string): boolean {
-  // Strip remote prefix (e.g. "origin/release/…" → "release/…") before testing.
-  const base = name.includes("/") ? name.slice(name.indexOf("/") + 1) : name;
-  return base.startsWith("release");
-}
-
 const layout = computed<DagLayout>(() => {
   const commits = displayCommits.value;
   const n = commits.length;
@@ -482,8 +476,6 @@ const layout = computed<DagLayout>(() => {
 
     // Trunk = the lineage to pin on lane 0 (far left).
     // Priority 1: main / master (local or remote) — always lane 0 regardless of current branch.
-    // Priority 2: current HEAD branch (if no main/master in view).
-    // Priority 3: WIP (edge case: detached HEAD with no trunk branch).
     let trunkHash: string | undefined;
     for (const commit of commits) {
       const refs = parseRefs(commit.refs);
@@ -495,47 +487,8 @@ const layout = computed<DagLayout>(() => {
         break;
       }
     }
-    if (!trunkHash) {
-      for (const commit of commits) {
-        const refs = parseRefs(commit.refs);
-        if (props.currentBranch && refs.some((r) => (r.type === "branch" || r.type === "head") && r.name === props.currentBranch)) {
-          trunkHash = commit.hashFull;
-          break;
-        }
-      }
-    }
-    if (!trunkHash && hasChanges.value) trunkHash = "WIP";
     _pinTrunkHash = trunkHash;
-
-    // Release branches: pinned to lanes 1, 2, … (immediately after trunk).
-    // Collect one head commit per release branch, in order of appearance
-    // (newest first). Deduplicate by hash — multiple refs on the same commit
-    // (local + remote tracking) should count as one lane.
-    const releaseHashes: string[] = [];
-    const seenReleaseHashes = new Set<string>();
-    for (const commit of commits) {
-      if (seenReleaseHashes.has(commit.hashFull)) continue;
-      const refs = parseRefs(commit.refs);
-      if (refs.some((r) => (r.type === "branch" || r.type === "remote") && isReleaseBranch(r.name))) {
-        releaseHashes.push(commit.hashFull);
-        seenReleaseHashes.add(commit.hashFull);
-      }
-    }
-
-    // develop branch: pinned immediately after release/* branches.
-    const developCommit = commits.find((commit) => {
-      if (seenReleaseHashes.has(commit.hashFull)) return false;
-      const refs = parseRefs(commit.refs);
-      return refs.some((r) =>
-        (r.type === "branch" || r.type === "remote") &&
-        (r.name === "develop" || r.name.endsWith("/develop"))
-      );
-    });
-
-    _pinSecondaryHashes = [
-      ...releaseHashes,
-      ...(developCommit ? [developCommit.hashFull] : []),
-    ];
+    _pinSecondaryHashes = [];
   }
   // When only more commits are appended (infinite scroll), _pinTrunkHash and
   // _pinSecondaryHashes are reused unchanged so lanesAllocated stays constant

--- a/apps/desktop/src/utils/dagLayout.ts
+++ b/apps/desktop/src/utils/dagLayout.ts
@@ -10,8 +10,7 @@
  *
  * Lane priority:
  *   0          — main / master (trunk)
- *   1, 2, …    — release/* branches (one lane each, in appearance order)
- *   next slots — all other branches, allocated on demand
+ *   next slots — all other branches, allocated on demand (greedy)
  */
 
 export interface DagNode {
@@ -48,7 +47,7 @@ export interface DagLayout {
  * Commits must be in reverse chronological order (newest first).
  *
  * @param trunkHash     Head of main/master — pinned to lane 0.
- * @param secondaryHashes Heads of release/* branches — pinned to lanes 1, 2, …
+ * @param secondaryHashes Heads of other branches to pin to lanes 1, 2, …
  *                        in the order supplied. Commits on their first-parent
  *                        chains are kept on those lanes throughout the graph.
  */


### PR DESCRIPTION
## Why

I found a visual bug for a specific case scenario where the git-tree path/spacing was a bit broken.

I was reserving space for `release` and `develop` branches but in some situations is was really weird as you can see.

So now I simply remove it to only reserved space is for `main/master`.

It is way simple like that and now in every situations it looks great.

#### Before

<img width="394" height="380" alt="image" src="https://github.com/user-attachments/assets/ae16e387-51dd-4c4f-9d63-53cff78df539" />

#### After

<img width="394" height="380" alt="image" src="https://github.com/user-attachments/assets/bf157b32-5108-44a3-8a26-d16ca006e7f5" />
