### PR TITLE
Add GitHub Copilot CLI support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Copilot CLI as an AI provider** — `copilot-cli` joins `claude-code-cli`, `codex-cli`, and `opencode-cli` in the `AIProvider` union. It piggybacks on the user's locally-installed `copilot` binary and their GitHub Copilot subscription — no API key required. Detection mirrors the existing CLI providers (binary discovery across PATH + common install locations) and it appears in Settings → AI with the same status/re-detect pattern. Prompts run one-shot via `copilot -p` (model selectable via the per-provider model picker, free-text since Copilot has no enumeration command). Tool permissions are deliberately restricted (`--deny-tool=shell`, `--deny-tool=write`, `--no-ask-user`, and `COPILOT_ALLOW_ALL` stripped from the child env) so Copilot only produces text and cannot edit files, run shell commands, or block on interactive prompts.
+
+### Technical
+
+- New Rust commands `detect_copilot_cli` and `copilot_cli_prompt` (`copilot --no-color --deny-tool=shell --deny-tool=write --no-ask-user [--model …] -p <prompt>`), plus a `CopilotCliInfo` type; registered in `lib.rs`. Mirrored across all three layers: `commands/ai.rs`, `dev-server.mjs`, and the `backend-ai.ts` wrapper.
+- `useAIProvider` adds `copilot-cli` to `CLI_AGENT_PROVIDERS`, dispatches it in `suggest()` / `rawPrompt()`, and forwards the per-provider model. `SettingsPanel` gains the provider option, detection state, and status block.
+- i18n: `aiProviderCopilotCli`, `aiProviderCopilotCliNotFound`, `aiCopilotCliDetectedHint`, `aiCopilotCliInfoBox` across all five locales (en, fr, es, pt-BR, zh-CN).
+- Unit tests extended in `useAIProvider-opencode.test.ts` for the Copilot dispatch and model fallback.
+
+
 ## [2.17.0] - 2026-06-04
 
 v2.17 rounds out the agent-CLI lineup with **opencode** as a first-class AI provider, and gives every CLI agent its own model picker — a second select under the provider dropdown, scoped per provider so switching back restores the previous choice.

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -3267,6 +3267,85 @@ async function handleRequest(req, res) {
       }
     }
 
+    // GET /api/copilot-cli-detect
+    if (url.pathname === "/api/copilot-cli-detect" && req.method === "GET") {
+      try {
+        const COPILOT = resolveBin("copilot");
+        const exists = (() => {
+          try { return existsSync(COPILOT); } catch { return false; }
+        })();
+        let resolved = exists ? COPILOT : "";
+        if (!resolved) {
+          try {
+            const r = spawnSync(process.platform === "win32" ? "where" : "which", ["copilot"], { encoding: "utf-8" });
+            if (r.status === 0 && r.stdout.trim()) {
+              resolved = r.stdout.split(/\r?\n/)[0].trim();
+            }
+          } catch { /* ignore */ }
+        }
+
+        if (!resolved) {
+          return jsonResponse(req, res, {
+            found: false,
+            path: "",
+            version: "",
+            logged_in: false,
+            status: "not_found",
+            detail: "Binaire `copilot` introuvable. Installez-le avec `npm install -g @github/copilot`.",
+          });
+        }
+
+        let version = "";
+        try {
+          const r = spawnSync(resolved, ["--version"], { encoding: "utf-8" });
+          if (r.status === 0) version = r.stdout.trim();
+        } catch { /* ignore */ }
+
+        return jsonResponse(req, res, {
+          found: true,
+          path: resolved,
+          version,
+          logged_in: false,
+          status: "detected",
+          detail: "",
+        });
+      } catch (err) {
+        return jsonResponse(req, res, { error: err.stderr?.toString() || err.message }, 500);
+      }
+    }
+
+    // POST /api/copilot-cli-prompt  { prompt, systemPrompt?, cwd?, model? }
+    if (url.pathname === "/api/copilot-cli-prompt" && req.method === "POST") {
+      try {
+        const body = await readBody(req);
+        const COPILOT = resolveBin("copilot");
+        const fullPrompt = body.systemPrompt && body.systemPrompt.trim()
+          ? `# System\n${body.systemPrompt.trim()}\n\n# User\n${(body.prompt || "").trim()}`
+          : (body.prompt || "");
+        const cpArgs = ["--no-color", "--deny-tool=shell", "--deny-tool=write", "--no-ask-user"];
+        if (body.model && String(body.model).trim()) {
+          cpArgs.push("--model", String(body.model).trim());
+        }
+        cpArgs.push("-p", fullPrompt);
+        const cpEnv = { ...process.env };
+        delete cpEnv.COPILOT_ALLOW_ALL;
+        const r = spawnSync(COPILOT, cpArgs, {
+          cwd: body.cwd || undefined,
+          env: cpEnv,
+          encoding: "utf-8",
+          timeout: 5 * 60 * 1000,
+          maxBuffer: 20 * 1024 * 1024,
+        });
+        if (r.status !== 0) {
+          const detail = (r.stderr || r.stdout || "").trim() || "Copilot CLI a échoué sans message";
+          return jsonResponse(req, res, { error: detail }, 500);
+        }
+        return res.writeHead(200, { ...corsHeaders(req), "Content-Type": "text/plain" }).end(r.stdout);
+      } catch (err) {
+        return jsonResponse(req, res, { error: err.stderr?.toString() || err.message }, 500);
+      }
+    }
+
     // POST /api/claude-cli-login  (opens a terminal with `claude login`)
     if (url.pathname === "/api/claude-cli-login" && req.method === "POST") {
       try {

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -495,6 +495,155 @@ pub(crate) fn opencode_list_models() -> Result<Vec<String>, String> {
     Ok(models)
 }
 
+// ─── GitHub Copilot CLI provider ─────────────────────────────────────────
+//
+// GitHub Copilot CLI (`copilot`) is an AI coding agent. Like the other CLIs
+// it exposes a non-interactive entry point:
+//   - `copilot -p "<prompt>" [--model <m>]` — run one prompt, print the
+//     response to stdout and exit. The trailing stats footer (credits /
+//     tokens) is written to stderr, so stdout stays clean.
+//
+// We deliberately run Copilot text-only: `--deny-tool=shell`,
+// `--deny-tool=write` and `--no-ask-user` block file edits, shell exec and
+// interactive prompts, and `COPILOT_ALLOW_ALL` is stripped from the child
+// env. The prompt we send is self-contained (it carries the full conflict
+// hunk), so the model only needs to produce text — never tools.
+//
+// Auth is handled by Copilot itself (`copilot` login / GitHub subscription),
+// stored on the user's machine — GitWand just shells out, same trick as the
+// other three CLIs.
+
+fn resolve_copilot_binary() -> Option<String> {
+    // 1) PATH first
+    let which_cmd = if cfg!(windows) { "where" } else { "which" };
+    if let Ok(out) = hidden_cmd(which_cmd).arg("copilot").output() {
+        if out.status.success() {
+            let raw = String::from_utf8_lossy(&out.stdout);
+            let first = raw.lines().next().unwrap_or("").trim();
+            if !first.is_empty() && std::path::Path::new(first).exists() {
+                return Some(first.to_string());
+            }
+        }
+    }
+
+    // 2) Common install locations (npm global, homebrew, local bin)
+    let home = dirs::home_dir();
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(h) = home.as_ref() {
+        candidates.push(h.join(".copilot/bin/copilot"));
+        candidates.push(h.join(".local/bin/copilot"));
+        candidates.push(h.join(".npm-global/bin/copilot"));
+        candidates.push(h.join("AppData/Roaming/npm/copilot.cmd"));
+        candidates.push(h.join("AppData/Roaming/npm/copilot"));
+    }
+    candidates.push(PathBuf::from("/opt/homebrew/bin/copilot"));
+    candidates.push(PathBuf::from("/usr/local/bin/copilot"));
+    candidates.push(PathBuf::from("/usr/bin/copilot"));
+
+    for c in candidates {
+        if c.exists() {
+            return Some(c.to_string_lossy().to_string());
+        }
+    }
+    None
+}
+
+/// Detect GitHub Copilot CLI presence and version. Same privacy stance as the
+/// Claude / Codex / opencode detectors: no prompt is sent to verify auth —
+/// that is confirmed implicitly on the first real `copilot_cli_prompt`.
+#[tauri::command]
+pub(crate) fn detect_copilot_cli() -> Result<CopilotCliInfo, String> {
+    let binary = match resolve_copilot_binary() {
+        Some(b) => b,
+        None => {
+            return Ok(CopilotCliInfo {
+                found: false,
+                path: String::new(),
+                version: String::new(),
+                logged_in: false,
+                status: "not_found".to_string(),
+                detail: "Binaire `copilot` introuvable. Installez-le avec `npm install -g @github/copilot`."
+                    .to_string(),
+            });
+        }
+    };
+
+    let version = hidden_cmd(&binary)
+        .arg("--version")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    Ok(CopilotCliInfo {
+        found: true,
+        path: binary,
+        version,
+        logged_in: false,
+        status: "detected".to_string(),
+        detail: String::new(),
+    })
+}
+
+#[tauri::command]
+pub(crate) fn copilot_cli_prompt(
+    prompt: String,
+    system_prompt: Option<String>,
+    cwd: Option<String>,
+    model: Option<String>,
+) -> Result<String, String> {
+    let binary = resolve_copilot_binary()
+        .ok_or_else(|| "Binaire `copilot` introuvable".to_string())?;
+
+    // Copilot CLI doesn't expose a separate system channel — prepend the
+    // system prompt as a Markdown section, same shape as the other flows.
+    let full_prompt = match system_prompt {
+        Some(sys) if !sys.trim().is_empty() => {
+            format!("# System\n{}\n\n# User\n{}", sys.trim(), prompt.trim())
+        }
+        _ => prompt,
+    };
+
+    let mut cmd = hidden_cmd(&binary);
+    // `--no-color` keeps stdout free of ANSI escapes. Flags precede the
+    // positional prompt passed via `-p`.
+    cmd.arg("--no-color");
+    // Safety: GitWand only wants a text answer back. Deny the tools that
+    // could mutate the user's machine (shell exec, file writes) and disable
+    // the interactive `ask_user` tool so a one-shot run can never block
+    // waiting for input. `COPILOT_ALLOW_ALL` is stripped from the inherited
+    // env so a stray variable can't silently re-enable every tool.
+    cmd.env_remove("COPILOT_ALLOW_ALL");
+    cmd.args(["--deny-tool=shell", "--deny-tool=write", "--no-ask-user"]);
+    if let Some(m) = model.as_ref() {
+        if !m.trim().is_empty() {
+            cmd.args(["--model", m.trim()]);
+        }
+    }
+    cmd.args(["-p", full_prompt.as_str()]);
+    if let Some(dir) = cwd {
+        if !dir.trim().is_empty() {
+            cmd.current_dir(dir);
+        }
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run copilot CLI: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            "Copilot CLI a échoué sans message".to_string()
+        } else {
+            detail
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 // ─── Claude OAuth login (opens a native terminal) ────────────────────────
 
 /// Launch `claude login` in the user's native terminal emulator. We don't

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -94,9 +94,10 @@ use tauri_plugin_global_shortcut::GlobalShortcutExt;
 // `pub(crate) use crate::types::*;`.
 
 // `strip_claude_auth_env` + `resolve_claude_binary` + `resolve_codex_binary`
-// + `resolve_opencode_binary` + 8 AI CLI commands (detect_claude_cli,
-// claude_cli_prompt, detect_codex_cli, codex_cli_prompt, claude_cli_login,
-// detect_opencode_cli, opencode_cli_prompt, opencode_list_models — v2.17)
+// + `resolve_opencode_binary` + `resolve_copilot_binary` + 10 AI CLI commands
+// (detect_claude_cli, claude_cli_prompt, detect_codex_cli, codex_cli_prompt,
+// claude_cli_login, detect_opencode_cli, opencode_cli_prompt,
+// opencode_list_models, detect_copilot_cli, copilot_cli_prompt)
 // migrated to `src/commands/ai.rs` (§3.4f).
 // Handler entries below route to `commands::ai::*`.
 
@@ -384,6 +385,8 @@ pub fn run() {
             commands::ai::detect_opencode_cli,
             commands::ai::opencode_cli_prompt,
             commands::ai::opencode_list_models,
+            commands::ai::detect_copilot_cli,
+            commands::ai::copilot_cli_prompt,
             commands::network::check_remote_reachable,
             commands::gitlab::detect_glab,
             commands::gitlab::gl_list_mrs,

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -550,6 +550,18 @@ pub struct OpencodeCliInfo {
     pub detail: String,
 }
 
+// ─── GitHub Copilot CLI ────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct CopilotCliInfo {
+    pub found: bool,
+    pub path: String,
+    pub version: String,
+    pub logged_in: bool,
+    pub status: String,
+    pub detail: String,
+}
+
 // ─── Git hooks ─────────────────────────────────────────────────────
 
 #[derive(Serialize)]

--- a/apps/desktop/src/__tests__/useAIProvider-opencode.test.ts
+++ b/apps/desktop/src/__tests__/useAIProvider-opencode.test.ts
@@ -26,12 +26,14 @@ const {
   claudeCliPrompt,
   codexCliPrompt,
   opencodeCliPrompt,
+  copilotCliPrompt,
   listOpencodeModels,
   detectClaudeCli,
 } = vi.hoisted(() => ({
   claudeCliPrompt: vi.fn(async () => "ok-claude"),
   codexCliPrompt: vi.fn(async () => "ok-codex"),
   opencodeCliPrompt: vi.fn(async () => "ok-opencode"),
+  copilotCliPrompt: vi.fn(async () => "ok-copilot"),
   listOpencodeModels: vi.fn(async () => ["anthropic/claude-x", "openai/gpt-y"]),
   // Keep the auto-fallback disabled so it never hijacks the explicit provider.
   detectClaudeCli: vi.fn(async () => ({
@@ -48,6 +50,7 @@ vi.mock("../utils/backend", () => ({
   claudeCliPrompt,
   codexCliPrompt,
   opencodeCliPrompt,
+  copilotCliPrompt,
   listOpencodeModels,
   detectClaudeCli,
 }));
@@ -109,6 +112,10 @@ describe("listModelsForProvider", () => {
     expect(await listModelsForProvider("codex-cli")).toEqual([]);
   });
 
+  it("returns an empty list (free-text fallback) for Copilot", async () => {
+    expect(await listModelsForProvider("copilot-cli")).toEqual([]);
+  });
+
   it("enumerates opencode models dynamically", async () => {
     const models = await listModelsForProvider("opencode-cli");
     expect(models).toEqual(["anthropic/claude-x", "openai/gpt-y"]);
@@ -144,6 +151,16 @@ describe("rawPrompt provider dispatch", () => {
     });
     await useAIProvider().rawPrompt("sys", "user");
     expect(claudeCliPrompt).toHaveBeenCalledWith("user", "sys", undefined, "text", "opus");
+  });
+
+  it("routes copilot-cli to copilotCliPrompt with the selected model", async () => {
+    setSettings({
+      aiProvider: "copilot-cli",
+      aiModelByProvider: { "copilot-cli": "gpt-5" },
+    });
+    const out = await useAIProvider().rawPrompt("sys", "user");
+    expect(out).toBe("ok-copilot");
+    expect(copilotCliPrompt).toHaveBeenCalledWith("user", "sys", undefined, "gpt-5");
   });
 
   it("passes undefined when no model is configured (CLI default)", async () => {

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -1865,7 +1865,7 @@ function savePresetForm() {
                     <div class="sp-connected-badge">
                       <span class="sp-connected-dot sp-connected-dot--neutral"></span>
                       <span>{{ t('settings.aiCliDetected', copilotCliInfo.version || 'copilot') }}</span>
-                      <button class="sp-disconnect-btn" @click="runCopilotCliDetect">{{ t('settings.aiCliRedetect')
+                      <button class="sp-disconnect-btn sp-disconnect-btn--neutral" @click="runCopilotCliDetect">{{ t('settings.aiCliRedetect')
                       }}</button>
                     </div>
                     <span class="sp-hint">{{ t('settings.aiCopilotCliDetectedHint') }}</span>
@@ -2737,6 +2737,15 @@ function savePresetForm() {
 
 .sp-disconnect-btn:hover {
   background: rgba(243, 139, 168, 0.15);
+}
+
+.sp-disconnect-btn--neutral {
+  border-color: rgba(255, 255, 255, 0.4);
+  color: #ffffff;
+}
+
+.sp-disconnect-btn--neutral:hover {
+  background: rgba(255, 255, 255, 0.15);
 }
 
 /* .sp-tab-badge removed — replaced by .sp-nav-badge in sidebar */

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -20,6 +20,8 @@ import {
   type CodexCliInfo,
   detectOpencodeCli,
   type OpencodeCliInfo,
+  detectCopilotCli,
+  type CopilotCliInfo,
   readGitwandrc,
   writeGitwandrc,
   checkForUpdates,
@@ -415,6 +417,9 @@ function onAIProviderChange(val: AIProvider) {
   } else if (val === "opencode-cli") {
     runOpencodeCliDetect();
     loadCliModels(val);
+  } else if (val === "copilot-cli") {
+    runCopilotCliDetect();
+    loadCliModels(val);
   } else if (val === "claude") {
     if (!settings.value.aiApiEndpoint || settings.value.aiApiEndpoint === "https://api.openai.com/v1") {
       updateSetting("aiApiEndpoint", "https://api.anthropic.com");
@@ -581,6 +586,28 @@ async function runOpencodeCliDetect() {
   }
 }
 
+// ─── GitHub Copilot CLI detection ───────────────────────
+const copilotCliInfo = ref<CopilotCliInfo | null>(null);
+const copilotCliDetecting = ref(false);
+
+async function runCopilotCliDetect() {
+  copilotCliDetecting.value = true;
+  try {
+    copilotCliInfo.value = await detectCopilotCli();
+  } catch (e) {
+    copilotCliInfo.value = {
+      found: false,
+      path: "",
+      version: "",
+      logged_in: false,
+      status: "error",
+      detail: (e as Error).message,
+    };
+  } finally {
+    copilotCliDetecting.value = false;
+  }
+}
+
 // ─── Per-provider model picker for CLI agents (v2.17) ───
 const cliModelOptions = ref<string[]>([]);
 const cliModelsLoading = ref(false);
@@ -655,6 +682,7 @@ type LlmFallbackProvider =
   | "claude-code-cli"
   | "codex-cli"
   | "opencode-cli"
+  | "copilot-cli"
   | "openai-compat"
   | "ollama"
   | "mcp";
@@ -821,6 +849,7 @@ onMounted(() => {
   runClaudeCliDetect();
   runCodexCliDetect();
   runOpencodeCliDetect();
+  runCopilotCliDetect();
   // Preload the model list when a CLI agent is already the active provider.
   loadCliModels();
 });
@@ -1481,6 +1510,10 @@ function savePresetForm() {
                   {{ t('settings.aiProviderOpencodeCli') }}{{ opencodeCliInfo && !opencodeCliInfo.found ?
                     t('settings.aiProviderOpencodeCliNotFound') : '' }}
                 </option>
+                <option value="copilot-cli">
+                  {{ t('settings.aiProviderCopilotCli') }}{{ copilotCliInfo && !copilotCliInfo.found ?
+                    t('settings.aiProviderCopilotCliNotFound') : '' }}
+                </option>
                 <option value="openai-compat">{{ t('settings.aiProviderOpenAiCompat') }}</option>
                 <option value="ollama" :disabled="!ollamaAvailable">
                   {{ t('settings.aiProviderOllama') }}{{ ollamaAvailable ? '' : t('settings.aiProviderOllamaNotFound')
@@ -1805,6 +1838,51 @@ function savePresetForm() {
               </div>
             </template>
 
+            <!-- GitHub Copilot CLI provider — same shape as the opencode block -->
+            <template v-if="settings.aiProvider === 'copilot-cli'">
+              <div class="sp-row">
+                <div class="sp-label">{{ t('settings.aiCliStatus') }}</div>
+                <div class="sp-cli-status">
+                  <template v-if="copilotCliDetecting">
+                    <span class="sp-hint">{{ t('settings.aiCliDetecting') }}</span>
+                  </template>
+                  <template v-else-if="!copilotCliInfo || !copilotCliInfo.found">
+                    <div class="sp-connect-error-block">
+                      <div class="sp-connect-error">
+                        {{ t('settings.aiCliNotFound') }} <code>copilot</code> {{ t('settings.aiCliNotFoundSuffix') }}
+                      </div>
+                      <span class="sp-hint">
+                        {{ t('settings.aiCliInstallHint') }}
+                        <code>npm install -g @github/copilot</code>
+                        {{ t('settings.aiCliInstallHintSuffix') }}
+                      </span>
+                      <button class="sp-text-btn" @click="runCopilotCliDetect">{{ t('settings.aiCliRedetect') }}</button>
+                    </div>
+                  </template>
+                  <template v-else>
+                    <!-- Detected. Auth is managed by Copilot itself and
+                         verified implicitly on first use; we don't ping. -->
+                    <div class="sp-connected-badge">
+                      <span class="sp-connected-dot sp-connected-dot--neutral"></span>
+                      <span>{{ t('settings.aiCliDetected', copilotCliInfo.version || 'copilot') }}</span>
+                      <button class="sp-disconnect-btn" @click="runCopilotCliDetect">{{ t('settings.aiCliRedetect')
+                      }}</button>
+                    </div>
+                    <span class="sp-hint">{{ t('settings.aiCopilotCliDetectedHint') }}</span>
+                  </template>
+                </div>
+              </div>
+
+              <div v-if="copilotCliInfo?.found" class="sp-info-box">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3">
+                  <circle cx="8" cy="8" r="7" />
+                  <path d="M8 7v4" stroke-linecap="round" />
+                  <circle cx="8" cy="5" r="0.7" fill="currentColor" stroke="none" />
+                </svg>
+                <p>{{ t('settings.aiCopilotCliInfoBox') }}</p>
+              </div>
+            </template>
+
             <!-- OpenAI-compatible provider -->
             <template v-if="settings.aiProvider === 'openai-compat'">
               <div class="sp-row">
@@ -2043,6 +2121,7 @@ function savePresetForm() {
                   <option value="claude-code-cli">{{ t('settings.aiProviderClaudeCli') }}</option>
                   <option value="codex-cli">{{ t('settings.aiProviderCodexCli') }}</option>
                   <option value="opencode-cli">{{ t('settings.aiProviderOpencodeCli') }}</option>
+                  <option value="copilot-cli">{{ t('settings.aiProviderCopilotCli') }}</option>
                   <option value="openai-compat">{{ t('settings.aiProviderOpenAiCompat') }}</option>
                   <option value="ollama">{{ t('settings.aiProviderOllama') }}</option>
                   <option value="mcp">MCP (Claude Code / Cursor)</option>

--- a/apps/desktop/src/composables/useAIProvider.ts
+++ b/apps/desktop/src/composables/useAIProvider.ts
@@ -4,6 +4,7 @@ import {
   claudeCliPrompt,
   codexCliPrompt,
   opencodeCliPrompt,
+  copilotCliPrompt,
   listOpencodeModels,
   detectClaudeCli,
 } from "../utils/backend";
@@ -21,6 +22,9 @@ import { t } from "./useI18n";
  * - `opencode-cli`   : piggyback on the user's locally-installed opencode
  *                     CLI (`opencode run`) — uses whatever provider they've
  *                     authenticated via `opencode auth login` (v2.17)
+ * - `copilot-cli`    : piggyback on the user's locally-installed GitHub
+ *                     Copilot CLI (`copilot -p`) — uses their Copilot
+ *                     subscription stored on the machine, no API key needed
  * - `openai-compat`  : any OpenAI-compatible endpoint
  * - `ollama`         : local Ollama instance
  * - `mcp`            : route the LLM call through a connected MCP agent
@@ -35,17 +39,23 @@ export type AIProvider =
   | "claude-code-cli"
   | "codex-cli"
   | "opencode-cli"
+  | "copilot-cli"
   | "openai-compat"
   | "ollama"
   | "mcp";
 
 /** CLI agent providers that support a per-provider model picker (v2.17). */
-export type CliAgentProvider = "claude-code-cli" | "codex-cli" | "opencode-cli";
+export type CliAgentProvider =
+  | "claude-code-cli"
+  | "codex-cli"
+  | "opencode-cli"
+  | "copilot-cli";
 
 export const CLI_AGENT_PROVIDERS: CliAgentProvider[] = [
   "claude-code-cli",
   "codex-cli",
   "opencode-cli",
+  "copilot-cli",
 ];
 
 export interface AISettings {
@@ -275,6 +285,19 @@ async function callOpencodeCli(
   return result ?? "";
 }
 
+/**
+ * Call the local GitHub Copilot CLI (`copilot -p`). Uses the user's Copilot
+ * subscription stored on the machine — no API key required.
+ */
+async function callCopilotCli(
+  systemPrompt: string,
+  userPrompt: string,
+  model?: string,
+): Promise<string> {
+  const result = await copilotCliPrompt(userPrompt, systemPrompt, undefined, model);
+  return result ?? "";
+}
+
 // ─── Per-provider model selection (v2.17) ───────────────
 //
 // The three CLI agents each expose a second model picker. opencode can
@@ -298,7 +321,8 @@ export function modelForProvider(
   if (
     provider === "claude-code-cli" ||
     provider === "codex-cli" ||
-    provider === "opencode-cli"
+    provider === "opencode-cli" ||
+    provider === "copilot-cli"
   ) {
     const m = s.aiModelByProvider?.[provider];
     return m && m.trim() ? m.trim() : undefined;
@@ -410,6 +434,7 @@ export function useAIProvider() {
       if (s.aiProvider === "claude-code-cli") return true;
       if (s.aiProvider === "codex-cli") return true;
       if (s.aiProvider === "opencode-cli") return true;
+      if (s.aiProvider === "copilot-cli") return true;
       // misconfigured explicit provider — fall through to CLI auto-detect
     }
     // Auto-fallback: use Claude Code CLI if installed and logged in,
@@ -454,6 +479,9 @@ export function useAIProvider() {
           break;
         case "opencode-cli":
           rawResponse = await callOpencodeCli(systemPrompt, userPrompt, model);
+          break;
+        case "copilot-cli":
+          rawResponse = await callCopilotCli(systemPrompt, userPrompt, model);
           break;
         case "openai-compat":
           rawResponse = await callOpenAICompat(s, systemPrompt, userPrompt);
@@ -504,6 +532,8 @@ export function useAIProvider() {
         return callCodexCli(systemPrompt, userPrompt, model);
       case "opencode-cli":
         return callOpencodeCli(systemPrompt, userPrompt, model);
+      case "copilot-cli":
+        return callCopilotCli(systemPrompt, userPrompt, model);
       case "openai-compat":
         return callOpenAICompat(s, systemPrompt, userPrompt);
       case "ollama":

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -1017,6 +1017,11 @@ const en = {
     aiProviderOpencodeCliNotFound: " — not detected",
     aiOpencodeCliDetectedHint: "Auth is managed by opencode (`opencode auth login`). Verified on first use.",
     aiOpencodeCliInfoBox: "GitWand runs `opencode run` locally. Authenticate your provider once with `opencode auth login`; pick a model below or keep the default.",
+    // GitHub Copilot CLI
+    aiProviderCopilotCli: "GitHub Copilot CLI (Copilot subscription)",
+    aiProviderCopilotCliNotFound: " — not detected",
+    aiCopilotCliDetectedHint: "Auth is managed by GitHub Copilot CLI. Verified on first use.",
+    aiCopilotCliInfoBox: "GitWand runs `copilot -p` locally. No API key required: it uses the GitHub Copilot authentication stored on your machine. Pick a model below or keep the default.",
     // Per-provider model picker for CLI agents (v2.17)
     aiModelCliDefault: "Default (CLI's own setting)",
     aiModelCliPlaceholder: "e.g. gpt-5-codex",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -993,6 +993,11 @@ const es: Locale = {
     aiProviderOpencodeCliNotFound: " — no detectado",
     aiOpencodeCliDetectedHint: "opencode gestiona la autenticación (`opencode auth login`). Se verifica en el primer uso.",
     aiOpencodeCliInfoBox: "GitWand ejecuta `opencode run` localmente. Autentica tu proveedor una vez con `opencode auth login`; elige un modelo abajo o deja el predeterminado.",
+    // GitHub Copilot CLI
+    aiProviderCopilotCli: "GitHub Copilot CLI (suscripción Copilot)",
+    aiProviderCopilotCliNotFound: " — no detectado",
+    aiCopilotCliDetectedHint: "La autenticación la gestiona GitHub Copilot CLI. Se verifica en el primer uso.",
+    aiCopilotCliInfoBox: "GitWand ejecuta `copilot -p` localmente. No se requiere clave API: usa la autenticación de GitHub Copilot almacenada en tu equipo. Elige un modelo abajo o deja el predeterminado.",
     // Selector de modelo por proveedor para agentes CLI (v2.17)
     aiModelCliDefault: "Predeterminado (ajuste del CLI)",
     aiModelCliPlaceholder: "p. ej. gpt-5-codex",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -1004,6 +1004,11 @@ const fr: Locale = {
     aiProviderOpencodeCliNotFound: " — non détecté",
     aiOpencodeCliDetectedHint: "L'authentification est gérée par opencode (`opencode auth login`). Vérifiée à la première utilisation.",
     aiOpencodeCliInfoBox: "GitWand exécute `opencode run` localement. Authentifiez votre fournisseur une fois avec `opencode auth login` ; choisissez un modèle ci-dessous ou laissez par défaut.",
+    // GitHub Copilot CLI
+    aiProviderCopilotCli: "GitHub Copilot CLI (abonnement Copilot)",
+    aiProviderCopilotCliNotFound: " — non détecté",
+    aiCopilotCliDetectedHint: "L'authentification est gérée par GitHub Copilot CLI. Vérifiée à la première utilisation.",
+    aiCopilotCliInfoBox: "GitWand exécute `copilot -p` localement. Aucune clé API requise : il utilise l'authentification GitHub Copilot stockée sur votre machine. Choisissez un modèle ci-dessous ou laissez par défaut.",
     // Sélecteur de modèle par fournisseur pour les agents CLI (v2.17)
     aiModelCliDefault: "Par défaut (réglage du CLI)",
     aiModelCliPlaceholder: "ex. gpt-5-codex",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -994,6 +994,11 @@ const ptBR: Locale = {
     aiProviderOpencodeCliNotFound: " — não detectado",
     aiOpencodeCliDetectedHint: "A autenticação é gerenciada pelo opencode (`opencode auth login`). Verificada no primeiro uso.",
     aiOpencodeCliInfoBox: "O GitWand executa `opencode run` localmente. Autentique seu provedor uma vez com `opencode auth login`; escolha um modelo abaixo ou mantenha o padrão.",
+    // GitHub Copilot CLI
+    aiProviderCopilotCli: "GitHub Copilot CLI (assinatura Copilot)",
+    aiProviderCopilotCliNotFound: " — não detectado",
+    aiCopilotCliDetectedHint: "A autenticação é gerenciada pelo GitHub Copilot CLI. Verificada no primeiro uso.",
+    aiCopilotCliInfoBox: "O GitWand executa `copilot -p` localmente. Nenhuma chave de API necessária: usa a autenticação do GitHub Copilot armazenada na sua máquina. Escolha um modelo abaixo ou mantenha o padrão.",
     // Seletor de modelo por provedor para agentes CLI (v2.17)
     aiModelCliDefault: "Padrão (configuração do CLI)",
     aiModelCliPlaceholder: "ex. gpt-5-codex",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -981,6 +981,11 @@ const zhCN: Locale = {
     aiProviderOpencodeCliNotFound: " — 未检测到",
     aiOpencodeCliDetectedHint: "认证由 opencode 管理（`opencode auth login`），首次使用时验证。",
     aiOpencodeCliInfoBox: "GitWand 在本地执行 `opencode run`。使用 `opencode auth login` 认证你的提供商；在下方选择模型或保留默认。",
+    // GitHub Copilot CLI
+    aiProviderCopilotCli: "GitHub Copilot CLI（Copilot 订阅）",
+    aiProviderCopilotCliNotFound: " — 未检测到",
+    aiCopilotCliDetectedHint: "身份验证由 GitHub Copilot CLI 管理，首次使用时验证。",
+    aiCopilotCliInfoBox: "GitWand 在本地执行 `copilot -p`。无需 API 密钥：它使用存储在你机器上的 GitHub Copilot 身份验证。在下方选择模型或保留默认。",
     // CLI 代理的按提供商模型选择器 (v2.17)
     aiModelCliDefault: "默认（CLI 自身设置）",
     aiModelCliPlaceholder: "例如 gpt-5-codex",

--- a/apps/desktop/src/utils/backend-ai.ts
+++ b/apps/desktop/src/utils/backend-ai.ts
@@ -261,6 +261,76 @@ export async function listOpencodeModels(): Promise<string[]> {
   return [];
 }
 
+// ─── GitHub Copilot CLI provider ───────────────────────────
+// Mirrors the Claude / Codex / opencode CLI shape. Copilot runs one-shot
+// prompts via `copilot -p "<prompt>" [--model <m>] --no-color`; the response
+// is printed to stdout while the credits/tokens footer goes to stderr.
+
+export interface CopilotCliInfo {
+  found: boolean;
+  path: string;
+  version: string;
+  logged_in: boolean;
+  status: "ok" | "not_found" | "not_logged_in" | "error" | "detected" | string;
+  detail: string;
+}
+
+/**
+ * Detect whether the GitHub Copilot CLI is installed. Safe to call on app boot.
+ */
+export async function detectCopilotCli(): Promise<CopilotCliInfo> {
+  if (isTauri()) {
+    return tauriInvoke<CopilotCliInfo>("detect_copilot_cli");
+  }
+  try {
+    const res = await devFetch(`${DEV_SERVER}/api/copilot-cli-detect`);
+    if (res.ok) return (await res.json()) as CopilotCliInfo;
+  } catch {
+    // Dev server unavailable
+  }
+  return {
+    found: false,
+    path: "",
+    version: "",
+    logged_in: false,
+    status: "not_found",
+    detail: "",
+  };
+}
+
+/**
+ * Run a prompt through the local GitHub Copilot CLI (`copilot -p`).
+ */
+export async function copilotCliPrompt(
+  prompt: string,
+  systemPrompt?: string,
+  cwd?: string,
+  model?: string,
+): Promise<string> {
+  if (isTauri()) {
+    return tauriInvoke<string>("copilot_cli_prompt", {
+      prompt,
+      systemPrompt,
+      cwd,
+      model,
+    }, IPC_TIMEOUT.NONE);
+  }
+  const res = await devFetch(`${DEV_SERVER}/api/copilot-cli-prompt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, systemPrompt, cwd, model }),
+  });
+  if (!res.ok) {
+    let msg = `copilot CLI error ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body?.error) msg = body.error;
+    } catch { /* ignore */ }
+    throw new Error(msg);
+  }
+  return await res.text();
+}
+
 /**
  * Open the native terminal with `claude login` so the user can complete
  * the OAuth-style setup. Not a PTY integration — just a one-shot bootstrap.


### PR DESCRIPTION
## Why

Added `copilot-cli` cause some are using it.
I was thinking about adding `gemini-cli` too, but it is migrating to `antigravity-cli` so i'll wait for that one.

### Added

- **GitHub Copilot CLI as an AI provider** — `copilot-cli` joins `claude-code-cli`, `codex-cli`, and `opencode-cli` in the `AIProvider` union. It piggybacks on the user's locally-installed `copilot` binary and their GitHub Copilot subscription — no API key required. Detection mirrors the existing CLI providers (binary discovery across PATH + common install locations) and it appears in Settings → AI with the same status/re-detect pattern. Prompts run one-shot via `copilot -p` (model selectable via the per-provider model picker, free-text since Copilot has no enumeration command). Tool permissions are deliberately restricted (`--deny-tool=shell`, `--deny-tool=write`, `--no-ask-user`, and `COPILOT_ALLOW_ALL` stripped from the child env) so Copilot only produces text and cannot edit files, run shell commands, or block on interactive prompts.

### Technical

- New Rust commands `detect_copilot_cli` and `copilot_cli_prompt` (`copilot --no-color --deny-tool=shell --deny-tool=write --no-ask-user [--model …] -p <prompt>`), plus a `CopilotCliInfo` type; registered in `lib.rs`. Mirrored across all three layers: `commands/ai.rs`, `dev-server.mjs`, and the `backend-ai.ts` wrapper.
- `useAIProvider` adds `copilot-cli` to `CLI_AGENT_PROVIDERS`, dispatches it in `suggest()` / `rawPrompt()`, and forwards the per-provider model. `SettingsPanel` gains the provider option, detection state, and status block.
- i18n: `aiProviderCopilotCli`, `aiProviderCopilotCliNotFound`, `aiCopilotCliDetectedHint`, `aiCopilotCliInfoBox` across all five locales (en, fr, es, pt-BR, zh-CN).
- Unit tests extended in `useAIProvider-opencode.test.ts` for the Copilot dispatch and model fallback.

<img width="1237" height="833" alt="image" src="https://github.com/user-attachments/assets/f9b7485c-c503-42df-9ac6-96bf1a24b9b2" />
