### PR TITLE
refactor(desktop): remove Log button from the Quick Actions

### DIFF
--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -1450,21 +1450,6 @@ function formatActivityDate(dateStr: string): string {
           {{ t('sidebar.quickActions') }}
         </div>
         <div class="quick-actions">
-          <button class="qa" @click="emit('changeView', 'changes')">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-              <polyline points="14 2 14 8 20 8"/>
-            </svg>
-            {{ t('sidebar.tabChanges') }}
-          </button>
-          <button class="qa" @click="emit('changeView', 'history')">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-              <line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/>
-              <line x1="8" y1="18" x2="21" y2="18"/>
-              <circle cx="4" cy="6" r="1"/><circle cx="4" cy="12" r="1"/><circle cx="4" cy="18" r="1"/>
-            </svg>
-            {{ t('sidebar.tabLog') }}
-          </button>
           <button class="qa" @click="emit('changeView', 'graph')">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/>


### PR DESCRIPTION
## Why

We don't use "log" anymore since the git graph changes.

<img width="358" height="202" alt="image" src="https://github.com/user-attachments/assets/a351229a-2b69-43c1-a68e-a82abdf0ebc3" />

## Changes

- Remove Logs button
- Remove Changes button