### PR TITLE
test(mcp): add vitest devDependency + re-enable test script in CI

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -40,7 +40,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "test": "vitest run"
   },
   "dependencies": {
     "@gitwand/core": "workspace:*",
@@ -48,7 +49,8 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
-    "typescript": "^5.4.0"
+    "typescript": "^5.4.0",
+    "vitest": "^4.1.0"
   },
   "author": "Laurent Guitton <lb.guitton@gmail.com>",
   "license": "MIT"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ importers:
       typescript:
         specifier: ^5.4.0
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(jsdom@25.0.1)(vite@7.3.5(@types/node@25.5.0)(yaml@2.8.3))
 
   packages/vscode:
     dependencies:


### PR DESCRIPTION
During the v2.20.0 release, the @gitwand/mcp predictor tests (src/__tests__/preview.test.ts) were excluded from the build and the test script was dropped, because vitest was only symlinked locally and could not resolve under CI's --frozen-lockfile.

This adds vitest@^4.1.0 as a proper devDependency (matching core/cli) and refreshes pnpm-lock.yaml, then restores "test": "vitest run". The tsconfig exclude of src/__tests__ is kept, so tests still never compile into dist/.

Verified on Node 25 / pnpm 11.2.2:
- pnpm install --frozen-lockfile → lockfile up to date
- pnpm --filter @gitwand/mcp run build → dist has no test files
- pnpm -r run build → all workspaces green
- pnpm -r run test → core 901, cli 26, desktop 202, mcp 12 — all pass

No version bump (devDep + CI wiring only).