### PR TITLE
fix(desktop): unbreak OAuth in Linux AppImage by de-polluting child env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,19 @@ jobs:
 
       - run: pnpm test
 
+  appimage-env-repro:
+    name: AppImage curl env repro (#48)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Headless regression check: reproduces issue #48 (AppRun's
+      # LD_LIBRARY_PATH pollution breaking the spawned curl) and verifies the
+      # hidden_cmd env scrub resolves it. Needs only bash + curl, both present
+      # on ubuntu-latest — no Tauri toolchain or AppImage build required.
+      - name: Reproduce issue #48 and verify the fix
+        run: bash scripts/repro-issue-48-appimage-curl.sh
+
   desktop:
     name: Desktop Build (${{ matrix.platform }})
     needs: test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitHub & Azure OAuth in the Linux AppImage** — sign-in failed in the released AppImage with `Failed to parse device-code response: EOF while parsing a value at line 1 column 0` (worked under `pnpm tauri dev`). The forge HTTP transport shells out to the system `curl`, which inherited the AppImage `AppRun`'s `LD_LIBRARY_PATH` pollution and loaded ABI-incompatible bundled libs, dying before the TLS request completed (empty body → JSON parse error). `hidden_cmd` now de-pollutes the child environment inside an AppImage (restore each `<VAR>_ORIG` saved by AppRun, else drop the override; no-op outside an AppImage), and the curl transport now adds `--show-error` and reports a non-zero curl exit as an explicit transport error instead of a misleading parse error. Reproduced and verified end-to-end on Linux via `scripts/repro-issue-48-appimage-curl.sh`. (#48)
+
 ## [2.20.0] - 2026-06-17
 
 ### Added

--- a/apps/desktop/src-tauri/src/commands/curl_util.rs
+++ b/apps/desktop/src-tauri/src/commands/curl_util.rs
@@ -51,6 +51,33 @@ pub(crate) fn run_curl(
         .map_err(|e| format!("curl failed: {}", e))
 }
 
+/// Decide whether a finished `curl` invocation represents a transport failure
+/// and, if so, build a user-facing error.
+///
+/// curl exits non-zero only on *transport* problems (DNS, connection, TLS,
+/// library-load failures) — an HTTP 4xx/5xx still exits 0 and is handled by the
+/// caller via the response status. The empty-diagnostic branch is the AppImage
+/// bundled-library case from issue #48: without this, an empty body fell
+/// through to `serde_json` as a cryptic "EOF while parsing" error.
+///
+/// `code` is the process exit code (`None` if killed by a signal); `stderr` is
+/// curl's captured standard error (populated thanks to `--show-error`).
+fn curl_transport_check(success: bool, code: Option<i32>, stderr: &str) -> Result<(), String> {
+    if success {
+        return Ok(());
+    }
+    let code_str = code.map(|c| c.to_string()).unwrap_or_else(|| "signal".to_string());
+    let detail = stderr.trim();
+    if detail.is_empty() {
+        Err(format!(
+            "curl request failed (exit {code_str}) with no diagnostic output — \
+             this often means a bundled-library conflict in the packaged app"
+        ))
+    } else {
+        Err(format!("curl request failed (exit {code_str}): {detail}"))
+    }
+}
+
 /// Execute a curl request and return `(http_status, body_text)`.
 ///
 /// Appends `-w "\n__GW_HTTP_STATUS__%{http_code}"` so the HTTP status is
@@ -69,6 +96,7 @@ pub(crate) fn curl_with_status(
     const MARKER: &str = "\n__GW_HTTP_STATUS__";
     let mut args: Vec<String> = vec![
         "-s".to_string(),
+        "-S".to_string(), // --show-error: keep stderr diagnostics under -s
         "-X".to_string(), method.to_string(),
         "-H".to_string(), format!("Accept: {}", accept),
     ];
@@ -91,6 +119,14 @@ pub(crate) fn curl_with_status(
     args.push(url.to_string());
 
     let output = run_curl(&args, auth_config)?;
+    // A non-zero curl exit is a transport failure (DNS/TLS/connection/library
+    // load) — surface it instead of letting an empty body reach the JSON
+    // parser as a cryptic "EOF" error.
+    curl_transport_check(
+        output.status.success(),
+        output.status.code(),
+        &String::from_utf8_lossy(&output.stderr),
+    )?;
     // Consume the Vec<u8> in-place — zero copy on the valid-UTF-8 fast path.
     let combined = String::from_utf8(output.stdout)
         .map_err(|e| format!("curl returned invalid UTF-8: {}", e))?;
@@ -99,4 +135,42 @@ pub(crate) fn curl_with_status(
         None => (combined, 0),
     };
     Ok((status, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transport_ok_when_curl_succeeds() {
+        assert!(curl_transport_check(true, Some(0), "").is_ok());
+        // A non-empty stderr is irrelevant when curl exited successfully.
+        assert!(curl_transport_check(true, Some(0), "Note: using HTTP/2").is_ok());
+    }
+
+    #[test]
+    fn transport_error_surfaces_curl_stderr() {
+        let err = curl_transport_check(
+            false,
+            Some(35),
+            "curl: (35) OpenSSL/3.0: error:0A000086:SSL routines",
+        )
+        .unwrap_err();
+        assert!(err.contains("exit 35"), "got: {err}");
+        assert!(err.contains("error:0A000086"), "got: {err}");
+    }
+
+    #[test]
+    fn transport_error_explains_empty_diagnostic() {
+        // The AppImage bundled-library case: curl dies with no stderr at all.
+        let err = curl_transport_check(false, Some(127), "  \n").unwrap_err();
+        assert!(err.contains("exit 127"), "got: {err}");
+        assert!(err.contains("bundled-library"), "got: {err}");
+    }
+
+    #[test]
+    fn transport_error_handles_signal_kill() {
+        let err = curl_transport_check(false, None, "").unwrap_err();
+        assert!(err.contains("signal"), "got: {err}");
+    }
 }

--- a/apps/desktop/src-tauri/src/git/cmd.rs
+++ b/apps/desktop/src-tauri/src/git/cmd.rs
@@ -116,6 +116,61 @@ pub(crate) fn git_binary() -> String {
         .clone()
 }
 
+/// Environment variables an AppImage's `AppRun` rewrites to point at the
+/// bundle's own libraries. Any external process we spawn (`curl`, `gh`,
+/// `git`…) inherits them and then loads ABI-incompatible bundled libs — e.g.
+/// the system `curl` crashing at TLS init and emitting an empty body, which
+/// surfaced as the OAuth "Failed to parse device-code response: EOF" failure
+/// in the released Linux AppImage (GitHub issue #48). We undo the pollution
+/// for child processes so they pick up the *system* libraries.
+const APPIMAGE_POLLUTED_VARS: &[&str] = &[
+    "LD_LIBRARY_PATH",
+    "LD_PRELOAD",
+    "GTK_PATH",
+    "GIO_MODULE_DIR",
+    "GSETTINGS_SCHEMA_DIR",
+    "GDK_PIXBUF_MODULE_FILE",
+    "GDK_PIXBUF_MODULEDIR",
+    "GST_PLUGIN_SYSTEM_PATH",
+    "GST_PLUGIN_PATH",
+    "QT_PLUGIN_PATH",
+    "PYTHONPATH",
+    "PYTHONHOME",
+    "PERLLIB",
+];
+
+/// One fix to apply to a spawned child's environment.
+#[derive(Debug, PartialEq, Eq)]
+enum EnvFix {
+    /// Restore the value `AppRun` saved (in `<VAR>_ORIG`) before overriding it.
+    Restore(String),
+    /// No saved original — drop the override so the system default applies.
+    Remove,
+}
+
+/// Compute the environment fixes needed so a spawned process uses *system*
+/// libraries instead of the AppImage's bundled ones.
+///
+/// `get` is the environment lookup (injected for testability). Returns no
+/// fixes when not running inside an AppImage: on a normal install
+/// `LD_LIBRARY_PATH` and friends may be set intentionally and must be left
+/// untouched. AppImage's `AppRun` always exports `APPDIR`; `APPIMAGE` points at
+/// the `.AppImage` file — either marks the bundled runtime.
+fn appimage_env_fixes(get: &dyn Fn(&str) -> Option<String>) -> Vec<(&'static str, EnvFix)> {
+    if get("APPDIR").is_none() && get("APPIMAGE").is_none() {
+        return Vec::new();
+    }
+    let mut fixes = Vec::new();
+    for &var in APPIMAGE_POLLUTED_VARS {
+        match get(&format!("{var}_ORIG")) {
+            Some(orig) => fixes.push((var, EnvFix::Restore(orig))),
+            None if get(var).is_some() => fixes.push((var, EnvFix::Remove)),
+            None => {}
+        }
+    }
+    fixes
+}
+
 /// Builds a `Command` for any binary with CREATE_NO_WINDOW on Windows.
 /// Prevents black CMD console windows from flashing when spawning child processes.
 ///
@@ -141,6 +196,18 @@ pub(crate) fn hidden_cmd(bin: &str) -> std::process::Command {
             }
         }
         cmd.env("PATH", enriched);
+    }
+    // Undo AppImage library-path pollution so the spawned binary loads system
+    // libs, not the bundle's. No-op unless we're running inside an AppImage
+    // (gated by APPDIR/APPIMAGE), so it's safe to run on every platform. See
+    // `appimage_env_fixes` — this is the fix for the Linux OAuth failure in
+    // GitHub issue #48.
+    let get_env = |k: &str| std::env::var(k).ok();
+    for (var, fix) in appimage_env_fixes(&get_env) {
+        match fix {
+            EnvFix::Restore(value) => { cmd.env(var, value); }
+            EnvFix::Remove         => { cmd.env_remove(var); }
+        }
     }
     // Defensive: propagate auth tokens explicitly to every subprocess so
     // `gh` (and any other CLI that respects these env vars) bypasses the
@@ -213,6 +280,59 @@ pub(crate) fn resolve_git_dir(cwd: &str) -> Result<PathBuf, String> {
 
     cache.lock().unwrap().insert(cwd.to_string(), path.clone());
     Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Build an env-lookup closure backed by a fixed map (no global state).
+    fn lookup<'a>(map: &'a HashMap<&'a str, &'a str>) -> impl Fn(&str) -> Option<String> + 'a {
+        move |k: &str| map.get(k).map(|s| s.to_string())
+    }
+
+    #[test]
+    fn appimage_env_fixes_left_alone_outside_appimage() {
+        // No APPDIR/APPIMAGE → a legitimately-set LD_LIBRARY_PATH is untouched.
+        let env: HashMap<&str, &str> = [("LD_LIBRARY_PATH", "/usr/lib/x86_64-linux-gnu")]
+            .into_iter()
+            .collect();
+        assert!(appimage_env_fixes(&lookup(&env)).is_empty());
+    }
+
+    #[test]
+    fn appimage_env_fixes_removes_polluted_var_without_orig() {
+        // Inside an AppImage, a bundled LD_LIBRARY_PATH with no saved original
+        // is dropped so the child falls back to the system default.
+        let env: HashMap<&str, &str> =
+            [("APPDIR", "/tmp/.mount_app"), ("LD_LIBRARY_PATH", "/tmp/.mount_app/usr/lib")]
+                .into_iter()
+                .collect();
+        assert_eq!(
+            appimage_env_fixes(&lookup(&env)),
+            vec![("LD_LIBRARY_PATH", EnvFix::Remove)]
+        );
+    }
+
+    #[test]
+    fn appimage_env_fixes_restores_apprun_saved_original() {
+        // AppRun stashes the pre-override value in <VAR>_ORIG; restore it.
+        let env: HashMap<&str, &str> = [
+            ("APPIMAGE", "/home/u/GitWand.AppImage"),
+            ("LD_LIBRARY_PATH", "/tmp/.mount_app/usr/lib"),
+            ("LD_LIBRARY_PATH_ORIG", "/usr/lib:/usr/local/lib"),
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(
+            appimage_env_fixes(&lookup(&env)),
+            vec![(
+                "LD_LIBRARY_PATH",
+                EnvFix::Restore("/usr/lib:/usr/local/lib".to_string())
+            )]
+        );
+    }
 }
 
 

--- a/scripts/repro-issue-48-appimage-curl.sh
+++ b/scripts/repro-issue-48-appimage-curl.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+#
+# Headless reproduction + regression check for GitHub issue #48:
+#   "Github & Azure Oauth | Failed to parse device-code response"
+#
+# Root cause: GitWand shells out to the system `curl` for all forge HTTP
+# traffic (github_api.rs / azure.rs -> curl_util.rs -> git/cmd.rs::hidden_cmd).
+# In the released Linux AppImage, AppRun rewrites LD_LIBRARY_PATH to point at
+# the bundle's own libraries. The spawned `curl` inherits that env, loads an
+# ABI-incompatible bundled libcurl/libssl, and dies before completing the TLS
+# request -> empty stdout -> serde_json reports the cryptic
+# "EOF while parsing a value at line 1 column 0".
+#
+# This script does NOT need the GUI, the Tauri toolchain, or an AppImage build.
+# It runs on any Linux (e.g. an OrbStack/Lima/UTM arm64 Ubuntu, or CI):
+#
+#   1. CLEAN     : run curl with a normal env                 -> must succeed
+#   2. POLLUTED  : simulate AppRun (APPDIR + a bundle dir with a *broken*
+#                  libcurl.so on LD_LIBRARY_PATH)              -> must FAIL  (== issue #48)
+#   3. SCRUBBED  : apply the exact env fix from hidden_cmd      -> must succeed (== the fix)
+#
+# Exit code 0 only if all three behave as expected, so it doubles as a test.
+#
+# Usage:  bash scripts/repro-issue-48-appimage-curl.sh
+#
+set -u
+
+# A lightweight HTTPS endpoint: any successful TLS request proves libcurl/libssl
+# loaded correctly. The real app POSTs to https://github.com/login/device/code;
+# the failure mode (curl can't complete the TLS handshake) is identical.
+PROBE_URL="${PROBE_URL:-https://api.github.com/}"
+
+# Variables AppRun pollutes — kept in lockstep with APPIMAGE_POLLUTED_VARS in
+# apps/desktop/src-tauri/src/git/cmd.rs.
+POLLUTED_VARS=(
+  LD_LIBRARY_PATH LD_PRELOAD GTK_PATH GIO_MODULE_DIR GSETTINGS_SCHEMA_DIR
+  GDK_PIXBUF_MODULE_FILE GDK_PIXBUF_MODULEDIR GST_PLUGIN_SYSTEM_PATH
+  GST_PLUGIN_PATH QT_PLUGIN_PATH PYTHONPATH PYTHONHOME PERLLIB
+)
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+command -v curl >/dev/null 2>&1 || { red "curl not found — install it first."; exit 2; }
+if [ "$(uname -s)" != "Linux" ]; then
+  red "This harness must run on Linux (it relies on LD_LIBRARY_PATH library resolution)."
+  red "Run it inside your VM, not on macOS."
+  exit 2
+fi
+
+WORK="$(mktemp -d)"
+BUNDLE="$WORK/bundle/usr/lib"
+mkdir -p "$BUNDLE"
+trap 'rm -rf "$WORK"' EXIT
+
+# ── Build a fake AppImage "bundle" whose libcurl/libssl are deliberately broken.
+# We name bogus files exactly like the sonames the system curl depends on; the
+# dynamic linker searches LD_LIBRARY_PATH first and picks our broken copy,
+# reproducing the bundled-lib ABI conflict (here as an outright load failure,
+# which is a strict superset of the real "loads then crashes at TLS init").
+mapfile -t SONAMES < <(
+  ldd "$(command -v curl)" 2>/dev/null \
+    | grep -oE '(libcurl|libssl|libcrypto)\.so[0-9.]*' \
+    | sort -u
+)
+if [ "${#SONAMES[@]}" -eq 0 ]; then
+  red "Could not detect curl's libcurl/libssl sonames via ldd — is curl statically linked?"
+  red "The pollution step may not reproduce on this system."
+  SONAMES=(libcurl.so.4)
+fi
+for so in "${SONAMES[@]}"; do
+  printf 'this is not a valid shared object\n' > "$BUNDLE/$so"
+done
+bold "Fake bundle libs planted: ${SONAMES[*]}"
+echo
+
+# Is the variable *named by $1* currently set (even to an empty value)?
+is_set()  { declare -p "$1" >/dev/null 2>&1; }
+# Value of the variable named by $1 (empty if unset). Avoids indirect
+# expansion for maximum portability across bash versions.
+get_var() { eval "printf '%s' \"\${$1:-}\""; }
+
+# ── Faithful shell port of git/cmd.rs::appimage_env_fixes + its application.
+# Mutates the current shell's env in place (caller runs it in a subshell).
+apply_appimage_env_fix() {
+  # No-op unless we look like we're inside an AppImage.
+  [ -n "${APPDIR:-}" ] || [ -n "${APPIMAGE:-}" ] || return 0
+  local var orig_name
+  for var in "${POLLUTED_VARS[@]}"; do
+    orig_name="${var}_ORIG"
+    if is_set "$orig_name"; then
+      # AppRun saved the pre-override value -> restore it.
+      export "$var=$(get_var "$orig_name")"
+    elif is_set "$var"; then
+      # No saved original -> drop the override so the system default applies.
+      unset "$var"
+    fi
+  done
+}
+
+# Mirror GitWand's transport flags: -s (silent) -S (show-error). Returns the
+# exit code; prints a one-line "exit=<n> bytes=<n>" summary and any stderr.
+run_curl_probe() {
+  local out err code
+  err="$(mktemp)"
+  out="$(curl -sS -A GitWand -o - -w '' "$PROBE_URL" 2>"$err")"
+  code=$?
+  printf '    exit=%s  body_bytes=%s\n' "$code" "${#out}"
+  if [ -s "$err" ]; then
+    printf '    stderr: %s\n' "$(head -c 300 "$err" | tr '\n' ' ')"
+  fi
+  rm -f "$err"
+  # "success" for our purposes == curl exited 0 AND returned a non-empty body.
+  [ "$code" -eq 0 ] && [ -n "$out" ]
+}
+
+PASS=0
+FAIL=0
+check() { # check <label> <expect: ok|fail> <actual-rc>
+  local label="$1" expect="$2" rc="$3"
+  if { [ "$expect" = ok ] && [ "$rc" -eq 0 ]; } || { [ "$expect" = fail ] && [ "$rc" -ne 0 ]; }; then
+    green "  ✓ $label (as expected)"; PASS=$((PASS+1))
+  else
+    red   "  ✗ $label (UNEXPECTED)"; FAIL=$((FAIL+1))
+  fi
+}
+
+bold "── 1. CLEAN env (mirrors 'pnpm tauri dev') ──────────────────────────"
+( unset APPDIR APPIMAGE LD_LIBRARY_PATH; run_curl_probe ); rc=$?
+check "curl succeeds with a normal environment" ok $rc
+echo
+
+bold "── 2. POLLUTED env (released AppImage, pre-fix) — reproduces #48 ─────"
+(
+  export APPDIR="$WORK/bundle"
+  export LD_LIBRARY_PATH_ORIG="${LD_LIBRARY_PATH:-}"   # what AppRun would stash
+  export LD_LIBRARY_PATH="$BUNDLE${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  run_curl_probe
+); rc=$?
+check "curl FAILS (empty body) — this is the EOF parse error users saw" fail $rc
+echo
+
+bold "── 3. SCRUBBED env (AppImage + hidden_cmd fix) — proves the fix ─────"
+(
+  export APPDIR="$WORK/bundle"
+  export LD_LIBRARY_PATH_ORIG="${LD_LIBRARY_PATH:-}"
+  export LD_LIBRARY_PATH="$BUNDLE${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  apply_appimage_env_fix        # <- the fix
+  run_curl_probe
+); rc=$?
+check "curl succeeds again after de-polluting the child env" ok $rc
+echo
+
+bold "── 3b. SCRUBBED with no *_ORIG (fix must unset, not restore) ─────────"
+(
+  export APPDIR="$WORK/bundle"
+  unset LD_LIBRARY_PATH_ORIG 2>/dev/null || true
+  export LD_LIBRARY_PATH="$BUNDLE"     # no original to restore
+  apply_appimage_env_fix
+  run_curl_probe
+); rc=$?
+check "curl succeeds when the polluted var is simply dropped" ok $rc
+echo
+
+bold "─────────────────────────────────────────────────────────────────────"
+if [ "$FAIL" -eq 0 ]; then
+  green "ALL $PASS CHECKS PASSED — bug reproduced and the fix resolves it."
+  exit 0
+else
+  red "$FAIL check(s) failed, $PASS passed."
+  exit 1
+fi


### PR DESCRIPTION
Fixes #48.

## Problem

In the released **Linux AppImage**, GitHub & Azure OAuth fail with:

```
Failed to parse device-code response: EOF while parsing a value at line 1 column 0
```

…but everything works under `pnpm tauri dev`. The reporter (CachyOS/Arch, AppImage) narrowed it to Linux + packaged build, and noted both providers fail identically.

## Root cause

All forge HTTP traffic (GitHub + Azure OAuth and API) shells out to the **system `curl`** via `hidden_cmd` → `run_curl`. An AppImage's `AppRun` rewrites `LD_LIBRARY_PATH` (and `LD_PRELOAD`, `GTK_PATH`, …) to point at the bundle's own libraries. The spawned `curl` inherits that environment, loads an ABI-incompatible bundled `libssl`/`libcurl`, and dies before completing the TLS request.

Because the transport used `-s` (silent) and never read curl's stderr, the failure surfaced as an **empty stdout** → `serde_json::from_str("")` → the cryptic `EOF` parse error. `tauri dev` works because there is no AppImage wrapper polluting the environment.

Both providers fail because they share the same `curl` transport — this is not a `client_id` / endpoint issue.

## Changes

- **`git/cmd.rs`** — `appimage_env_fixes()` (pure, env lookup injected for testability): when running inside an AppImage (`APPDIR`/`APPIMAGE` set), restore each polluted var from AppRun's saved `<VAR>_ORIG`, or drop the override so the system default applies. **No-op outside an AppImage**, so a legitimately-set `LD_LIBRARY_PATH` on a normal install is left untouched. Applied in `hidden_cmd` for every spawn (`curl`, `gh`, `git`).
- **`commands/curl_util.rs`** — add `-S`/`--show-error` so curl reports the real cause under `-s`, and a `curl_transport_check()` that maps a non-zero curl exit to an explicit transport error carrying curl's stderr, instead of letting an empty body become a misleading JSON parse error.

## Tests

7 new unit tests over the pure helpers (no global env mutation), TDD'd red→green. Full lib suite: **80 passing**, clean `cargo build`/`clippy` on the touched files.

## End-to-end verification

`scripts/repro-issue-48-appimage-curl.sh` is a headless harness (no GUI / Tauri toolchain / AppImage build needed) that reproduces the bug and proves the fix on any Linux. **Ran on a real arm64 Linux VM (OrbStack/Ubuntu) — all 4 stages pass:**

```
── 2. POLLUTED env (released AppImage, pre-fix) — reproduces #48 ─────
    exit=127  body_bytes=0
    stderr: curl: error while loading shared libraries: …/libcurl.so.4: file too short
  ✓ curl FAILS (empty body) — this is the EOF parse error users saw

── 3. SCRUBBED env (AppImage + hidden_cmd fix) — proves the fix ─────
    exit=0  body_bytes=2395
  ✓ curl succeeds again after de-polluting the child env
```

The empty-stdout → EOF chain is reproduced, and the env scrub restores a working request. (Full output in a comment below.)

Residual nuance: the harness breaks the bundled lib via a load failure (`file too short`), a strict superset of the real "loads then crashes at TLS init" case. The fix is agnostic to the exact failure mode — it removes the pollution upstream — so this gap doesn't affect confidence.

## Reviewer notes

- Per `AGENTS.md`, a `CHANGELOG.md` entry should be added before the next tag — not included here since this is a fix branch, happy to add it.
- Verified on arm64 Linux; the release AppImage is x86_64, but the mechanism (AppRun env pollution) is identical across both arches.