### PR TITLE
fix(desktop): repair credentials.rs keyring doc-test (E0277)

### DIFF
--- a/apps/desktop/src-tauri/src/commands/credentials.rs
+++ b/apps/desktop/src-tauri/src/commands/credentials.rs
@@ -17,11 +17,14 @@
 //!   entries for the same service (e.g. `"workspace:username"`).
 //!
 //! **keyring 2.x API**:
-//! ```rust
+//! ```rust,no_run
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let entry = keyring::Entry::new("service", "account")?;
 //! entry.set_password("secret")?;
 //! let secret = entry.get_password()?;
 //! entry.delete_password()?;
+//! # Ok(())
+//! # }
 //! ```
 
 /// Store a credential in the OS keychain.


### PR DESCRIPTION
## Fix: credentials.rs keyring doc-test (E0277)

The module-level keyring API example in `apps/desktop/src-tauri/src/commands/credentials.rs` used the `?` operator inside the implicit doc-test `main` (which returns `()`), so `cargo test --doc` failed with **E0277**. Pre-existing, unrelated to any feature work.

**Fix:** wrap the example in a hidden `fn main() -> Result<(), Box<dyn std::error::Error>>` (so `?` is valid) and mark the fence `no_run` — the example now **compiles** as part of the doc-test suite without **executing** (it would otherwise call `set_password`/`get_password` against the real OS keychain during `cargo test --doc`, a side effect / TCC-prompt risk).

### Verification
```
Doc-tests gitwand_desktop_lib
test src/commands/credentials.rs - commands::credentials (line 20) - compile ... ok
test result: ok. 1 passed; 0 failed; 0 ignored
```
