### PR TITLE
Fix/git interactive rebase command

### DIFF
--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -2292,7 +2292,7 @@ async function handleRequest(req, res) {
           return "main";
         })();
 
-        const format = `%(HEAD)%(refname:short)\x1f%(upstream:short)\x1f%(upstream:track,nobracket)\x1f%(objectname:short) %(subject)\x1f%(creatordate:iso)\x1f%(ahead-behind:${mainName})`;
+        const format = `%(HEAD)%(refname:short)\x1f%(upstream:short)\x1f%(upstream:track,nobracket)\x1f%(objectname:short) %(subject)\x1f%(committerdate:iso-strict)\x1f%(ahead-behind:${mainName})`;
         const stdout = execSync(`git branch -a --format="${format}"`, {
           cwd: resolvedCwd,
           encoding: "utf-8",

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -537,6 +537,93 @@ pub(crate) async fn git_rebase_action(cwd: String, action: String) -> Result<(),
     Ok(())
 }
 
+/// Result of starting an interactive rebase. `conflict` is true when the rebase
+/// halted on a merge conflict (the frontend then drives continue/abort/skip).
+#[derive(serde::Serialize)]
+pub(crate) struct InteractiveRebaseResult {
+    pub conflict: bool,
+}
+
+/// Start an interactive rebase with a caller-supplied todo list.
+///
+/// Git's interactive rebase normally opens `$GIT_SEQUENCE_EDITOR` on the todo
+/// file. We bypass the editor by pointing `GIT_SEQUENCE_EDITOR` at a `cp`/`copy`
+/// command that overwrites the todo file with `todo_lines` (written to a temp
+/// file we control). `GIT_EDITOR=true` neutralises any reword/commit-message
+/// editor so the command never blocks waiting for input.
+///
+/// Security: `base` and the todo content are passed as discrete args / file
+/// content — never interpolated into a shell. The only shell string is
+/// `GIT_SEQUENCE_EDITOR`, and the path it embeds is a temp file *we* generate
+/// (pid + nanos), not user input, so there is no injection surface.
+#[tauri::command]
+pub(crate) async fn git_interactive_rebase(
+    cwd: String,
+    base: String,
+    todo_lines: Vec<String>,
+) -> Result<InteractiveRebaseResult, String> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let tmp_file = std::env::temp_dir().join(format!(
+        "gitwand-rebase-todo-{}-{}.txt",
+        std::process::id(),
+        nanos
+    ));
+
+    let mut content = todo_lines.join("\n");
+    content.push('\n');
+    std::fs::write(&tmp_file, &content)
+        .map_err(|e| format!("Failed to write rebase todo file: {}", e))?;
+
+    // GIT_SEQUENCE_EDITOR is invoked as `<editor> <todo-path>`. Use cp/copy to
+    // overwrite the sequencer's todo file with ours.
+    let tmp_str = tmp_file.to_string_lossy();
+    let editor_cmd = if cfg!(windows) {
+        format!("copy /Y \"{}\"", tmp_str)
+    } else {
+        format!("cp \"{}\"", tmp_str)
+    };
+
+    let _t0 = Instant::now();
+    let result = git_cmd()
+        .args(["rebase", "-i", &base])
+        .env("GIT_SEQUENCE_EDITOR", &editor_cmd)
+        .env("GIT_EDITOR", "true")
+        .env("EDITOR", "true")
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .current_dir(&cwd)
+        .output();
+
+    // Best-effort cleanup; the temp file holds no secrets but shouldn't linger.
+    let _ = std::fs::remove_file(&tmp_file);
+
+    let output = result.map_err(|e| format!("Failed to run git rebase -i: {}", e))?;
+    record_cmd(
+        "git rebase -i",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
+
+    if output.status.success() {
+        return Ok(InteractiveRebaseResult { conflict: false });
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if stderr.contains("CONFLICT") || stderr.contains("could not apply")
+        || stdout.contains("CONFLICT") || stdout.contains("could not apply")
+    {
+        return Ok(InteractiveRebaseResult { conflict: true });
+    }
+    let msg = if stderr.is_empty() { stdout } else { stderr };
+    Err(format!("git rebase -i failed: {}", msg))
+}
+
 // ─── Git discard ───────────────────────────────────────────────
 
 #[tauri::command]

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -662,7 +662,7 @@ pub(crate) async fn git_branches(cwd: String) -> Result<Vec<GitBranch>, String> 
     let output = git_cmd()
         .args([
             "branch", "-a",
-            &format!("--format=%(HEAD)%(refname:short)\x1f%(upstream:short)\x1f%(upstream:track,nobracket)\x1f%(objectname:short) %(subject)\x1f%(creatordate:iso)\x1f%(ahead-behind:{})", main_name),
+            &format!("--format=%(HEAD)%(refname:short)\x1f%(upstream:short)\x1f%(upstream:track,nobracket)\x1f%(objectname:short) %(subject)\x1f%(committerdate:iso-strict)\x1f%(ahead-behind:{})", main_name),
         ])
         .current_dir(&cwd)
         .output()

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -298,6 +298,7 @@ pub fn run() {
             commands::ops::git_merge_continue,
             commands::read::git_repo_state,
             commands::ops::git_rebase_action,
+            commands::ops::git_interactive_rebase,
             commands::ops::git_discard,
             commands::read::git_show,
             commands::ops::git_branches,

--- a/apps/desktop/src/components/RebaseEditor.vue
+++ b/apps/desktop/src/components/RebaseEditor.vue
@@ -100,6 +100,13 @@ const baseCandidates = computed(() => {
         !b.isRemote &&
         b.name.toLowerCase().includes(filter),
     )
+    // Most recently committed branch first (committerdate:iso-strict → sortable).
+    .slice()
+    .sort((a, b) => {
+      const ta = Date.parse(a.lastCommitDate) || 0;
+      const tb = Date.parse(b.lastCommitDate) || 0;
+      return tb - ta;
+    })
     .map((b) => b.name);
 });
 
@@ -422,7 +429,7 @@ const hasTodo = computed(
       <!-- Base selection -->
       <template v-if="showBasePicker && !inProgress">
         <div class="rb-section">
-          <label class="rb-label" for="rb-base-input">{{ t('rebase.baseLabel') }}</label>
+          <label class="rb-label rb-label--base" for="rb-base-input">{{ t('rebase.baseLabel') }}</label>
           <p class="rb-hint">{{ t('rebase.baseHint') }}</p>
           <input
             id="rb-base-input"
@@ -438,10 +445,8 @@ const hasTodo = computed(
               class="rb-base-item"
               @click="selectBase(name)"
             >
-              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                <circle cx="5" cy="4" r="2" stroke="currentColor" stroke-width="1.3"/>
-                <circle cx="5" cy="12" r="2" stroke="currentColor" stroke-width="1.3"/>
-                <path d="M5 6v4" stroke="currentColor" stroke-width="1.3"/>
+              <svg class="rb-base-icon" width="15" height="15" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                <path d="M9.5 3.25a2.25 2.25 0 1 1 3 2.122V6A2.5 2.5 0 0 1 10 8.5H6a1 1 0 0 0-1 1v1.128a2.251 2.251 0 1 1-1.5 0V5.372a2.25 2.25 0 1 1 1.5 0v1.836A2.492 2.492 0 0 1 6 7h4a1 1 0 0 0 1-1v-.628A2.25 2.25 0 0 1 9.5 3.25Zm-6 0a.75.75 0 1 0 1.5 0 .75.75 0 0 0-1.5 0Zm8.25-.75a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5ZM4.25 12a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z"/>
               </svg>
               <span class="mono">{{ name }}</span>
             </li>
@@ -887,13 +892,19 @@ const hasTodo = computed(
 .rb-squash-cancel:hover { background: var(--color-bg-secondary); }
 
 /* ─── Base picker ──────────────────────────────────────────── */
+.rb-label--base {
+  font-size: var(--font-size-md);
+}
+
 .rb-base-input {
   width: 100%;
+  margin-top: var(--space-3);
   padding: var(--space-3) var(--space-5);
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-md);
+  line-height: 1.5;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-pill);
+  border-radius: var(--radius-md);
   color: var(--color-text);
   outline: none;
   transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
@@ -906,23 +917,46 @@ const hasTodo = computed(
 .rb-base-list {
   list-style: none;
   padding: 0;
-  margin: 6px 0 0;
-  max-height: 200px;
+  margin: var(--space-3) 0 0;
+  /* Tall enough to show many branches; capped to viewport so the modal
+     itself grows toward its 85vh ceiling instead of an inner 200px scroll. */
+  max-height: min(64vh, 580px);
   overflow-y: auto;
+  /* Breathing room so branch rows don't butt against the scrollbar. */
+  padding-right: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
 }
 
 .rb-base-item {
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  padding: 6px var(--space-3);
+  padding: var(--space-2) var(--space-3);
   font-size: var(--font-size-sm);
   cursor: pointer;
-  border-radius: var(--radius-sm);
-  transition: background 0.1s;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg);
+  transition: background var(--transition-fast), border-color var(--transition-fast),
+    color var(--transition-fast), transform var(--transition-fast);
+}
+.rb-base-icon {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+  transition: color var(--transition-fast);
 }
 .rb-base-item:hover {
-  background: var(--color-bg-secondary);
+  background: var(--color-accent-soft, rgba(124, 58, 237, 0.14));
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.rb-base-item:hover .rb-base-icon {
+  color: var(--color-accent);
+}
+.rb-base-item:active {
+  transform: translateY(1px);
 }
 
 /* ─── Todo list ────────────────────────────────────────────── */

--- a/apps/desktop/src/composables/useInteractiveRebase.ts
+++ b/apps/desktop/src/composables/useInteractiveRebase.ts
@@ -13,9 +13,7 @@
  */
 
 import { ref, computed } from "vue";
-import { gitExec, isTauri } from "../utils/backend";
-
-const DEV_SERVER = "http://localhost:3001";
+import { gitExec, gitInteractiveRebase } from "../utils/backend";
 
 // ─── Types ──────────────────────────────────────────────────
 
@@ -254,20 +252,11 @@ export function useInteractiveRebase() {
     pendingSplits.value = nextPending;
 
     try {
-      // Both Tauri and dev-server use the same endpoint pattern.
-      // For Tauri we'll add a Rust command later; for dev mode we
-      // need a dedicated endpoint because GIT_SEQUENCE_EDITOR requires
-      // env-var control that gitExec doesn't support.
-      const res = await fetch(
-        isTauri() ? "/api/git-interactive-rebase" : `${DEV_SERVER}/api/git-interactive-rebase`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ cwd, base, todoLines }),
-        },
-      );
-      const data = await res.json();
-      if (data.error) throw new Error(data.error);
+      // `gitInteractiveRebase` writes a temp todo file and injects it via
+      // GIT_SEQUENCE_EDITOR. In Tauri it routes through the `git_interactive_rebase`
+      // Rust command; in web-dev mode it hits the dev-server endpoint — both
+      // because plain `gitExec` can't control the sequence-editor env var.
+      const data = await gitInteractiveRebase(cwd, base, todoLines);
       if (data.conflict) {
         await detectRebaseState(cwd);
         return { success: true, conflict: true, inProgress: true };

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -981,6 +981,35 @@ export async function gitRebaseAction(
   }
 }
 
+/**
+ * Start an interactive rebase with a caller-supplied todo list.
+ * Returns `{ conflict }` — true when the rebase halted on a merge conflict.
+ * Throws on a hard failure.
+ */
+export async function gitInteractiveRebase(
+  cwd: string,
+  base: string,
+  todoLines: string[]
+): Promise<{ conflict: boolean }> {
+  if (isTauri()) {
+    return tauriInvoke<{ conflict: boolean }>("git_interactive_rebase", {
+      cwd,
+      base,
+      todoLines,
+    });
+  }
+  const res = await devFetch(`${DEV_SERVER}/api/git-interactive-rebase`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ cwd, base, todoLines }),
+  });
+  const data = await res.json().catch(() => ({ error: res.statusText }));
+  if (!res.ok || data.error) {
+    throw new Error(data.error ?? "interactive rebase failed");
+  }
+  return { conflict: !!data.conflict };
+}
+
 // ─── Git show (commit diff) ───────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary
Interactive rebase now runs through a real Rust `git_interactive_rebase` command that drives `git rebase -i` via `GIT_SEQUENCE_EDITOR` with a temporary todo file, instead of going through an HTTP fetch. The base-branch picker also sorts candidates by most recent commit date so the freshest branch is preselected.

## Changes
- Add `git_interactive_rebase` Tauri command that pilots `git rebase -i` using a temporary todo file and `GIT_SEQUENCE_EDITOR`, without blocking on an editor.
- Register the new command and expose a typed wrapper in `backend.ts`.
- Replace the `useInteractiveRebase` HTTP fetch path with the native command, keeping the dev-server endpoint for web-dev mode.
- Sort base-branch candidates by `committerdate:iso-strict`, placing the most recently updated branch at the top of the selector.
- Refresh the base picker UI (taller list, revised icon and items).

## Test plan
- [ ] Run an interactive rebase from the desktop app and confirm the todo actions apply without opening an external editor.
- [ ] Verify the base picker lists branches ordered by most recent commit date.
- [ ] Confirm web-dev mode (`pnpm dev:web`) still drives rebase via the dev-server endpoint.
- [ ] Check that a rebase with conflicts surfaces correctly and can be continued/aborted.

## I made some small visual change in the "Choose a Branch" modal when using the Actions button

First it ask the branch

<img width="654" height="660" alt="image" src="https://github.com/user-attachments/assets/7cc00e9a-f0c0-4e96-9517-ea3b2f9c5687" />

Then we see the interactive rebase view
