### PR TITLE
fix(desktop): don't cache failed ghCurrentUser (transient 500 poisoned PR panel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **PR panel stuck after a transient "current user" failure** — `ghCurrentUser()` cached its result promise unconditionally, so a one-off failure (a rate-limit blip or momentary GitHub 5xx surfacing as `Failed to get current user: 500`) poisoned the cached identity for the whole app session — the PR panel stayed broken until restart. Only successful results are cached now; a failure is evicted so the next caller retries. The thrown error also carries the server's response body instead of a bare status code.
+
 ## [2.24.0] - 2026-06-19
 
 ### Added

--- a/apps/desktop/src/utils/__tests__/backend-pr.test.ts
+++ b/apps/desktop/src/utils/__tests__/backend-pr.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Regression tests for `ghCurrentUser` identity caching.
+ *
+ * The session-level cache must memoize a *successful* login (one request shared
+ * across callers) but must NOT memoize a failure — a transient 500 (rate-limit
+ * blip, momentary GitHub 5xx) once poisoned `_currentUserPromise` for the whole
+ * session, so the PR panel stayed broken until the app was restarted.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const devFetch = vi.fn();
+const tauriInvoke = vi.fn();
+let tauri = false;
+
+vi.mock("../backend-core", () => ({
+  isTauri: () => tauri,
+  devFetch: (...args: unknown[]) => devFetch(...args),
+  tauriInvoke: (...args: unknown[]) => tauriInvoke(...args),
+  DEV_SERVER: "http://localhost:3001",
+}));
+
+function mockRes(opts: { ok: boolean; status?: number; body?: string; json?: unknown }) {
+  return {
+    ok: opts.ok,
+    status: opts.status ?? (opts.ok ? 200 : 500),
+    text: async () => opts.body ?? "",
+    json: async () => opts.json,
+  };
+}
+
+describe("ghCurrentUser caching", () => {
+  beforeEach(() => {
+    vi.resetModules(); // reset module-level `_currentUserPromise`
+    devFetch.mockReset();
+    tauriInvoke.mockReset();
+    tauri = false;
+  });
+
+  it("memoizes a successful login — a single request is shared across calls", async () => {
+    devFetch.mockResolvedValue(mockRes({ ok: true, json: "alice" }));
+    const { ghCurrentUser } = await import("../backend-pr");
+    await expect(ghCurrentUser()).resolves.toBe("alice");
+    await expect(ghCurrentUser()).resolves.toBe("alice");
+    expect(devFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT memoize a failure — the next call retries and can succeed", async () => {
+    devFetch
+      .mockResolvedValueOnce(mockRes({ ok: false, status: 500, body: "GitHub API 403: rate limit" }))
+      .mockResolvedValueOnce(mockRes({ ok: true, json: "alice" }));
+    const { ghCurrentUser } = await import("../backend-pr");
+    await expect(ghCurrentUser()).rejects.toThrow();
+    await expect(ghCurrentUser()).resolves.toBe("alice"); // retried, not the cached rejection
+    expect(devFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces the server error body in the thrown message", async () => {
+    devFetch.mockResolvedValue(mockRes({ ok: false, status: 500, body: "GitHub API 403: rate limit" }));
+    const { ghCurrentUser } = await import("../backend-pr");
+    await expect(ghCurrentUser()).rejects.toThrow(/500.*rate limit/);
+  });
+});

--- a/apps/desktop/src/utils/backend-pr.ts
+++ b/apps/desktop/src/utils/backend-pr.ts
@@ -10,21 +10,29 @@ let _currentUserPromise: Promise<string> | null = null;
 
 /**
  * Returns the GitHub login of the currently authenticated user (via `gh` CLI or token).
- * Result is cached for the lifetime of the app session.
+ * A successful result is cached for the lifetime of the app session; a failure is
+ * not cached, so a transient error can be retried by the next caller.
  */
 export function ghCurrentUser(): Promise<string> {
   if (_currentUserPromise) return _currentUserPromise;
-  if (isTauri()) {
-    _currentUserPromise = tauriInvoke<string>("gh_current_user");
-  } else {
-    _currentUserPromise = devFetch(`${DEV_SERVER}/api/gh-current-user`).then(
-      async (res) => {
-        if (!res.ok) throw new Error(`Failed to get current user: ${res.status}`);
+  const p = isTauri()
+    ? tauriInvoke<string>("gh_current_user")
+    : devFetch(`${DEV_SERVER}/api/gh-current-user`).then(async (res) => {
+        if (!res.ok) {
+          // Surface the server's error body (e.g. "GitHub API 403: rate limit")
+          // — the bare status code alone is undiagnosable.
+          const body = await res.text().catch(() => "");
+          throw new Error(`Failed to get current user: ${res.status}${body ? ` — ${body}` : ""}`);
+        }
         return res.json() as Promise<string>;
-      }
-    );
-  }
-  return _currentUserPromise;
+      });
+  _currentUserPromise = p;
+  // Cache only on success: evict on rejection so a transient failure (rate-limit
+  // blip, momentary 5xx) doesn't poison the identity for the whole app session.
+  p.catch(() => {
+    if (_currentUserPromise === p) _currentUserPromise = null;
+  });
+  return p;
 }
 
 /** GitHub fork relationship for the repo at `cwd`. */


### PR DESCRIPTION
## Summary

`[usePrPanel] ghCurrentUser failed: Failed to get current user: 500` — the PR panel could stay broken for a whole app session after a single transient failure.

**Root cause:** `ghCurrentUser()` in `backend-pr.ts` memoized its result promise *unconditionally*. A one-off failure (a rate-limit blip or momentary GitHub 5xx, surfaced by the dev-server as HTTP 500) was cached in `_currentUserPromise` and replayed on every subsequent call — so even after GitHub/the token recovered, the identity stayed broken until the app was restarted. The bug affects both the dev (`/api/gh-current-user`) and Tauri (`gh_current_user`) paths.

A second, smaller issue made it undiagnosable: the dev path threw `Failed to get current user: ${res.status}` without reading the response body, discarding the actual cause (e.g. `GitHub API 403: rate limit`).

## Changes
- Cache **only successful** results; evict `_currentUserPromise` on rejection so the next caller retries.
- Include the server's error body in the thrown message instead of a bare status code.
- Add `backend-pr` unit tests covering: success is memoized (single request), failure is **not** memoized (retry succeeds), and the error body is surfaced.

## Test plan
- [x] `pnpm test` — 28 files / 268 tests green (incl. 3 new)
- [x] `vue-tsc --noEmit` clean
- [ ] In a running app: force a `/user` failure, confirm the panel recovers on the next revalidation instead of staying stuck until restart