### PR TITLE
feat(desktop): add fullscreen image viewer for markdown images

### DIFF
--- a/apps/desktop/src/components/DashboardView.vue
+++ b/apps/desktop/src/components/DashboardView.vue
@@ -1656,8 +1656,10 @@ watch(topContributors, () => nextTick(updateContribArrows), { immediate: true })
   color: var(--color-success);
 }
 
-.readme-formatted :deep(.md-img) {
+.readme-formatted :deep(.md-img),
+.readme-formatted :deep(img) {
   max-width: 100%;
+  height: auto !important;
   border-radius: var(--radius-md);
   margin: var(--space-3) 0;
 }

--- a/apps/desktop/src/components/PrCommentThread.vue
+++ b/apps/desktop/src/components/PrCommentThread.vue
@@ -392,6 +392,13 @@ function timeAgo(dateStr: string): string {
   background: var(--color-bg-secondary);
 }
 
+.pct-body :deep(img),
+.pct-body :deep(.md-img) {
+  max-width: 100%;
+  height: auto !important;
+  border-radius: var(--radius-sm);
+}
+
 /* Suggestion apply button */
 .pct-suggestion-actions {
   margin-top: 6px;

--- a/apps/desktop/src/components/PrDetailView.vue
+++ b/apps/desktop/src/components/PrDetailView.vue
@@ -11,7 +11,7 @@
  * - Stat cards refined with icons + gradient hover
  * - Polished tabs with animation + count badges
  */
-import { computed, inject, nextTick, ref } from "vue";
+import { computed, inject, nextTick, ref, onMounted, onUnmounted, watch } from "vue";
 import { PR_PANEL_KEY, isMergeConflict, type PrPanelState } from "../composables/usePrPanel";
 import { renderMarkdown, onMarkdownLinkClick } from "../composables/useSafeHtml";
 import { useAvatar } from "../composables/useAvatar";
@@ -173,6 +173,70 @@ const timeline = computed<TimelineItem[]>(() => {
 
 /** PR description rendered once (see `sortedComments` for the rationale). */
 const descriptionHtml = computed(() => renderMarkdown(p.prDetail.value?.body));
+
+const fullscreenImageUrl = ref<string | null>(null);
+
+function handleDescriptionClick(e: MouseEvent) {
+  const target = e.target as HTMLElement | null;
+  const img = target?.closest("img");
+  if (img) {
+    const src = img.getAttribute("src");
+    if (src) {
+      fullscreenImageUrl.value = src;
+      return;
+    }
+  }
+  onMarkdownLinkClick(e);
+}
+
+const lastMousePos = { x: 0, y: 0 };
+function trackMouse(e: MouseEvent) {
+  lastMousePos.x = e.clientX;
+  lastMousePos.y = e.clientY;
+}
+
+function handleKeydown(e: KeyboardEvent) {
+  if (e.key === "Escape" && fullscreenImageUrl.value) {
+    fullscreenImageUrl.value = null;
+  }
+}
+
+onMounted(() => {
+  window.addEventListener("keydown", handleKeydown);
+  window.addEventListener("mousemove", trackMouse);
+});
+
+onUnmounted(() => {
+  window.removeEventListener("keydown", handleKeydown);
+  window.removeEventListener("mousemove", trackMouse);
+  document.body.style.cursor = "";
+});
+
+watch(fullscreenImageUrl, (newUrl) => {
+  if (newUrl) {
+    document.body.style.cursor = "zoom-out";
+    nextTick(() => {
+      const dummyEvent = new MouseEvent("mousemove", {
+        bubbles: true,
+        cancelable: true,
+        clientX: lastMousePos.x,
+        clientY: lastMousePos.y,
+      });
+      document.dispatchEvent(dummyEvent);
+    });
+  }
+});
+
+function handleAfterLeave() {
+  document.body.style.cursor = "";
+  const dummyEvent = new MouseEvent("mousemove", {
+    bubbles: true,
+    cancelable: true,
+    clientX: lastMousePos.x,
+    clientY: lastMousePos.y,
+  });
+  document.dispatchEvent(dummyEvent);
+}
 
 /** Anchor at the bottom of the comments list — target for the Comments tile. */
 const commentsEnd = ref<HTMLElement | null>(null);
@@ -605,7 +669,7 @@ function commentTimeAgo(dateStr: string): string {
               <div
                 v-if="descriptionTab === 'formatted'"
                 class="pdv-body-formatted"
-                @click="onMarkdownLinkClick"
+                @click="handleDescriptionClick"
                 v-html="descriptionHtml"
               />
               <pre v-else class="pdv-body-raw"><code>{{ p.prDetail.value.body }}</code></pre>
@@ -821,6 +885,28 @@ function commentTimeAgo(dateStr: string): string {
       @submit="p.handleSubmitReview"
       @close="p.showReviewModal.value = false"
     />
+
+    <!-- Fullscreen Image Viewer Modal -->
+    <Transition name="pdv-fade" @after-leave="handleAfterLeave">
+      <div
+        v-if="fullscreenImageUrl"
+        class="pdv-image-overlay"
+        @click="fullscreenImageUrl = null"
+      >
+        <button
+          type="button"
+          class="pdv-image-overlay-close"
+          @click="fullscreenImageUrl = null"
+          aria-label="Close fullscreen view"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
+        </button>
+        <img
+          :src="fullscreenImageUrl"
+          class="pdv-image-overlay-content"
+        />
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -1835,7 +1921,14 @@ function commentTimeAgo(dateStr: string): string {
 .pdv-body-formatted :deep(img),
 .pdv-body-formatted :deep(.md-img) {
   max-width: 100%;
+  height: auto !important;
   border-radius: var(--radius-sm);
+  cursor: zoom-in;
+  transition: opacity 0.2s ease;
+}
+.pdv-body-formatted :deep(img:hover),
+.pdv-body-formatted :deep(.md-img:hover) {
+  opacity: 0.95;
 }
 
 .pdv-body-raw {
@@ -2151,5 +2244,77 @@ function commentTimeAgo(dateStr: string): string {
   .pdv-spinner {
     animation: none;
   }
+}
+
+/* Image overlay transition */
+.pdv-fade-enter-active,
+.pdv-fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+.pdv-fade-enter-active .pdv-image-overlay-content,
+.pdv-fade-leave-active .pdv-image-overlay-content {
+  transition: transform 0.2s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.pdv-fade-enter-from,
+.pdv-fade-leave-to {
+  opacity: 0;
+}
+.pdv-fade-enter-from .pdv-image-overlay-content,
+.pdv-fade-leave-to .pdv-image-overlay-content {
+  transform: scale(0.96);
+}
+
+/* Image overlay styling */
+.pdv-image-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.85);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  cursor: zoom-out;
+}
+
+.pdv-image-overlay-content {
+  width: 90vw;
+  height: 90vh;
+  object-fit: contain;
+  border-radius: var(--radius-md);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+  cursor: zoom-out;
+  user-select: none;
+}
+
+.pdv-image-overlay-close {
+  position: absolute;
+  top: var(--space-6);
+  right: var(--space-6);
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.15s;
+}
+
+.pdv-image-overlay-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+  transform: scale(1.05);
+}
+
+.pdv-image-overlay-close svg {
+  width: 20px;
+  height: 20px;
 }
 </style>

--- a/apps/desktop/src/composables/__tests__/useSafeHtml.test.ts
+++ b/apps/desktop/src/composables/__tests__/useSafeHtml.test.ts
@@ -112,32 +112,29 @@ describe("renderMarkdown — markdown → sanitized HTML", () => {
     expect(out).toContain('<pre class="md-code-block">');
   });
 
-  it("does NOT parse raw HTML embedded in markdown (html: false)", () => {
-    // With html: false, markdown-it escapes raw HTML to entities rather
-    // than emitting real tags. The &lt;script&gt; text that remains is
-    // rendered as inert text, not executable code. Belt-and-suspenders:
-    // even if markdown-it did emit it, DOMPurify would strip the script.
+  it("strips raw HTML <script> tags embedded in markdown", () => {
+    // markdown-it (html: true) parses the raw HTML tag, and DOMPurify strips it.
     const out = renderMarkdown("normal\n\n<script>alert(1)</script>\n\nmore");
-    // No real <script> tag — only the escaped entity form.
-    expect(out).not.toMatch(/<script[\s>]/i);
-    expect(out).toContain("&lt;script&gt;");
+    expect(out).not.toContain("<script");
+    expect(out).not.toContain("alert(1)");
     expect(out).toContain("normal");
     expect(out).toContain("more");
   });
 
   it("strips XSS payloads smuggled via inline HTML in markdown", () => {
     const out = renderMarkdown('click <img src=x onerror="alert(1)"> here');
-    // markdown-it (html: false) escapes the raw HTML to entities, so
-    // what lands in the DOM is a text node — `&lt;img...&gt;` — and
-    // the browser does NOT re-parse it as markup. The substring
-    // `onerror="..."` may appear in that escaped text, which is inert.
-    // What we must guarantee: no real <img> tag and no real attribute.
-    expect(out).not.toMatch(/<img[\s>]/i);
-    // No real element with an onerror attribute (i.e. onerror inside
-    // an opening tag, not inside escaped text).
-    expect(out).not.toMatch(/<[^>]*\sonerror\s*=[^>]*>/i);
-    expect(out).toContain("&lt;img");
+    // markdown-it (html: true) parses the raw HTML tag. DOMPurify allows the img tag,
+    // but strips the onerror handler.
+    expect(out).toContain('<img src="x">');
+    expect(out.toLowerCase()).not.toContain("onerror");
+    expect(out).not.toContain("alert(1)");
   });
+
+  it("renders raw HTML img tags with width and height in markdown", () => {
+    const out = renderMarkdown('hello <img width="2521" height="203" alt="image" src="https://github.com/user-attachments/assets/5284ccc2-4567-40f0-88b7-1faec2289bbe" /> world');
+    expect(out).toContain('<img width="2521" height="203" alt="image" src="https://github.com/user-attachments/assets/5284ccc2-4567-40f0-88b7-1faec2289bbe">');
+  });
+
 
   it("neutralises javascript: links in markdown", () => {
     // markdown-it's default link validator rejects javascript: URIs, so

--- a/apps/desktop/src/composables/useSafeHtml.ts
+++ b/apps/desktop/src/composables/useSafeHtml.ts
@@ -75,6 +75,8 @@ const ALLOWED_ATTR = [
   "target", "rel",
   // For diff / code rendering:
   "data-line", "data-lang",
+  // For image / display attributes:
+  "width", "height",
 ];
 
 /**
@@ -146,12 +148,12 @@ export function safeHtml(raw: string | null | undefined): string {
 // ─── Markdown ──────────────────────────────────────────────────────
 
 /**
- * `markdown-it` instance shared across the app. `html: false` means raw
- * `<script>` tags inside markdown are left as text, not parsed as HTML.
- * DOMPurify takes care of anything markdown-it still passes through.
+ * `markdown-it` instance shared across the app. `html: true` allows raw
+ * HTML tags (like `<img>` or `<details>`) inside markdown.
+ * DOMPurify downstream takes care of sanitizing the raw HTML output.
  */
 const md = new MarkdownIt({
-  html: false, // do not let source markdown embed arbitrary HTML
+  html: true, // let source markdown embed raw HTML (DOMPurify will sanitize)
   linkify: true,
   breaks: true,
   typographer: false,


### PR DESCRIPTION
## Summary
Adds a fullscreen image viewer triggered by clicking images in PR descriptions, improving how users inspect visual content. Image scaling and styling are now consistent across all markdown-rendered surfaces (PR descriptions, comments, and dashboard READMEs), and markdown parsing handles raw HTML `<img>` tags more robustly.

## Changes
- Add a fullscreen image viewer that opens when clicking markdown images in PR descriptions.
- Apply consistent image scaling and styling across PR descriptions, comments, and dashboard READMEs.
- Support raw HTML `<img>` tags in markdown parsing, including `width` and `height` attributes.
- Preserve XSS protection while allowing the new image attributes in sanitized HTML.
- Update `useSafeHtml` composable and its tests to cover the new parsing behavior.

## Test plan
- [ ] Click an image in a PR description and confirm the fullscreen viewer opens and closes correctly.
- [ ] Verify images render with consistent scaling in PR comments and dashboard READMEs.
- [ ] Confirm raw `<img>` tags with `width`/`height` attributes render as expected.
- [ ] Ensure malicious/script content is still stripped by the sanitizer.
- [ ] Run the `useSafeHtml` unit tests and confirm they pass.