### PR TITLE
chore(deps): bump pnpm to 11.9.0 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Git's magic wand — automatic conflict resolution and smart merge tools",
   "author": "Laurent Guitton <lb.guitton@gmail.com>",
   "license": "MIT",
-  "packageManager": "pnpm@11.2.2",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=22.13.0",
     "pnpm": ">=11"


### PR DESCRIPTION
## Summary
Updates the `packageManager` field in the root `package.json` to pin pnpm 11.9.0, keeping the Corepack pin in sync with the toolchain update.

## Changes
- Bump pnpm to 11.9.0 via the `packageManager` field in root `package.json`

## Test plan
- [ ] `corepack enable` resolves pnpm 11.9.0
- [ ] `pnpm install` succeeds at the repo root
- [ ] CI build passes on the updated toolchain