### PR TITLE
feat(desktop): carry WIP to target branch on dirty switch

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1854,19 +1854,43 @@ async function confirmDirtyCarry() {
   const pending = pendingDirtySwitch.value;
   if (!pending) return;
   pendingDirtySwitch.value = null;
+  // First attempt: let git carry the WIP across as-is. This succeeds when the
+  // changes don't collide with the files differing between the two branches.
   const ok = pending.isCreate
     ? await createBranch(pending.name)
     : await switchBranch(pending.name);
-  if (!ok) {
-    // switchBranch/createBranch already set repoError to the underlying git
-    // error, prefixed with internal context ("switch branch: " / "create
-    // branch: "). Strip that prefix before surfacing it inside the
-    // user-facing carry-failure message.
-    const detail = (repoError.value ?? "").replace(/^(?:switch|create) branch:\s*/, "");
-    repoError.value = t("branches.dirtySwitchCarryFailed", detail);
+  if (ok) {
+    if (!pending.isCreate) await promptPullIfBehind();
     return;
   }
-  if (!pending.isCreate) await promptPullIfBehind();
+  // Carry refused (git would overwrite local changes). Fall back to
+  // stash → switch → pop, which is exactly what the user asked for by
+  // confirming the carry — bring the WIP along to the target branch.
+  if (!repoFolderPath.value) return;
+  repoError.value = "";
+  isSwitchingBranch.value = true;
+  try {
+    await gitStash(repoFolderPath.value);
+    const switched = pending.isCreate
+      ? await createBranch(pending.name)
+      : await switchBranch(pending.name);
+    if (!switched) {
+      // Even stashing didn't let us switch — restore the WIP where it was and
+      // surface the underlying git error. switchBranch/createBranch prefix it
+      // with internal context ("switch branch: " / "create branch: "); strip
+      // that before showing the user-facing carry-failure message.
+      await gitStashPop(repoFolderPath.value);
+      const detail = (repoError.value ?? "").replace(/^(?:switch|create) branch:\s*/, "");
+      repoError.value = t("branches.dirtySwitchCarryFailed", detail);
+      return;
+    }
+    await gitStashPop(repoFolderPath.value);
+    if (!pending.isCreate) await promptPullIfBehind();
+  } catch (err: any) {
+    repoError.value = `switch (stash): ${err.message}`;
+  } finally {
+    isSwitchingBranch.value = false;
+  }
 }
 
 function confirmDirtyCommitFirst() {

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -230,6 +230,7 @@ const {
   loadBranches,
   createBranch,
   switchBranch,
+  carryChangesToBranch,
   deleteBranch,
   deleteRemoteBranch,
   deleteTag,
@@ -1854,43 +1855,19 @@ async function confirmDirtyCarry() {
   const pending = pendingDirtySwitch.value;
   if (!pending) return;
   pendingDirtySwitch.value = null;
-  // First attempt: let git carry the WIP across as-is. This succeeds when the
-  // changes don't collide with the files differing between the two branches.
-  const ok = pending.isCreate
-    ? await createBranch(pending.name)
-    : await switchBranch(pending.name);
-  if (ok) {
-    if (!pending.isCreate) await promptPullIfBehind();
+  // Carry the WIP across, stashing as a fallback when git refuses a plain
+  // switch (see carryChangesToBranch). Confirming the carry *is* confirming
+  // the stash/pop — that is what the user asked for.
+  const ok = await carryChangesToBranch(pending.name, pending.isCreate);
+  if (!ok) {
+    // carryChangesToBranch leaves repoError set to the underlying git error,
+    // prefixed with internal context ("switch branch: " / "create branch: ").
+    // Strip that prefix before surfacing the user-facing carry-failure message.
+    const detail = (repoError.value ?? "").replace(/^(?:switch|create) branch:\s*/, "");
+    repoError.value = t("branches.dirtySwitchCarryFailed", detail);
     return;
   }
-  // Carry refused (git would overwrite local changes). Fall back to
-  // stash → switch → pop, which is exactly what the user asked for by
-  // confirming the carry — bring the WIP along to the target branch.
-  if (!repoFolderPath.value) return;
-  repoError.value = "";
-  isSwitchingBranch.value = true;
-  try {
-    await gitStash(repoFolderPath.value);
-    const switched = pending.isCreate
-      ? await createBranch(pending.name)
-      : await switchBranch(pending.name);
-    if (!switched) {
-      // Even stashing didn't let us switch — restore the WIP where it was and
-      // surface the underlying git error. switchBranch/createBranch prefix it
-      // with internal context ("switch branch: " / "create branch: "); strip
-      // that before showing the user-facing carry-failure message.
-      await gitStashPop(repoFolderPath.value);
-      const detail = (repoError.value ?? "").replace(/^(?:switch|create) branch:\s*/, "");
-      repoError.value = t("branches.dirtySwitchCarryFailed", detail);
-      return;
-    }
-    await gitStashPop(repoFolderPath.value);
-    if (!pending.isCreate) await promptPullIfBehind();
-  } catch (err: any) {
-    repoError.value = `switch (stash): ${err.message}`;
-  } finally {
-    isSwitchingBranch.value = false;
-  }
+  if (!pending.isCreate) await promptPullIfBehind();
 }
 
 function confirmDirtyCommitFirst() {

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -30,6 +30,8 @@ import {
   gitCherryPick,
   gitCherryPickAbort,
   gitCherryPickContinue,
+  gitStash,
+  gitStashPop,
   gitStashList,
   gitStashApply,
   gitStashDrop,
@@ -1061,6 +1063,36 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     }
   }
 
+  /**
+   * Switch to (or create) a branch, carrying uncommitted WIP across.
+   *
+   * First tries a plain switch/create, which git allows when the WIP doesn't
+   * collide with the files differing between the two branches. If git refuses
+   * (it would overwrite local changes), falls back to stash → switch → pop so
+   * the WIP still follows the user to the target branch.
+   *
+   * On failure leaves `error.value` set to the underlying git error (prefixed
+   * "switch branch: " / "create branch: " / "switch (stash): ") and returns
+   * false; callers map that to their own user-facing message.
+   */
+  async function carryChangesToBranch(name: string, isCreate: boolean): Promise<boolean> {
+    if (!folderPath.value) return false;
+    const direct = isCreate ? await createBranch(name) : await switchBranch(name);
+    if (direct) return true;
+    isSwitchingBranch.value = true;
+    try {
+      await gitStash(folderPath.value);
+      const switched = isCreate ? await createBranch(name) : await switchBranch(name);
+      await gitStashPop(folderPath.value);
+      return switched;
+    } catch (err: any) {
+      error.value = `switch (stash): ${err.message}`;
+      return false;
+    } finally {
+      isSwitchingBranch.value = false;
+    }
+  }
+
   async function deleteBranch(name: string, force = false) {
     if (!folderPath.value) return;
     try {
@@ -1239,6 +1271,7 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     loadWorktrees,
     createBranch,
     switchBranch,
+    carryChangesToBranch,
     deleteBranch,
     deleteRemoteBranch,
     deleteTag,


### PR DESCRIPTION
## Summary

When a user confirms carrying their work-in-progress across a branch switch, Git can refuse if local changes would be overwritten. This change adds a stash-based fallback so the confirmed carry still lands the changes on the target branch, and extracts the logic into a reusable composable.

## Changes

- On a refused carry (local changes would be overwritten), **retry via stash → switch → pop to bring WIP onto the target branch**.
- Add `carryChangesToBranch` helper to `useGitRepo.ts` encapsulating the carry-with-stash-fallback flow.
- Simplify `App.vue`'s `confirmDirtyCarry` to call the composable and map its failure to a user-facing message.

## Test plan

- [ ] Switch branches with uncommitted changes that Git carries cleanly — changes follow to the target branch.
- [ ] Switch branches when local changes would be overwritten — stash fallback carries WIP successfully.
- [ ] Verify a failed carry surfaces a clear user-facing error message.
- [ ] Confirm stash is popped and no orphan stash entry remains after a successful fallback.