### PR TITLE
fix(desktop): strip NUL bytes from AI CLI prompts before spawn

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -191,6 +191,12 @@ pub(crate) async fn claude_cli_prompt(
 
     let fmt = output_format.unwrap_or_else(|| "text".to_string());
 
+    // The prompt is passed as a CLI argument, and spawning a process with an
+    // interior NUL byte fails with "nul byte found in provided data". Binary
+    // or malformed content can leak a `\0` into the prompt via diffs or file
+    // snapshots, so strip NULs defensively before building the command.
+    let full_prompt = full_prompt.replace('\0', "");
+
     let mut cmd = hidden_cmd(&binary);
     cmd.args(["-p", &full_prompt, "--output-format", &fmt]);
     // v2.17 — explicit per-provider model selection. When empty, the CLI
@@ -294,6 +300,10 @@ pub(crate) async fn codex_cli_prompt(
         }
         _ => prompt,
     };
+
+    // Strip NUL bytes — the prompt is passed as a CLI argument and an interior
+    // `\0` makes the spawn fail with "nul byte found in provided data".
+    let full_prompt = full_prompt.replace('\0', "");
 
     let mut cmd = hidden_cmd(&binary);
     cmd.arg("exec");
@@ -432,6 +442,10 @@ pub(crate) async fn opencode_cli_prompt(
         }
         _ => prompt,
     };
+
+    // Strip NUL bytes — the prompt is passed as a CLI argument and an interior
+    // `\0` makes the spawn fail with "nul byte found in provided data".
+    let full_prompt = full_prompt.replace('\0', "");
 
     let mut cmd = hidden_cmd(&binary);
     cmd.arg("run");
@@ -602,6 +616,10 @@ pub(crate) fn copilot_cli_prompt(
         }
         _ => prompt,
     };
+
+    // Strip NUL bytes — the prompt is passed as a CLI argument and an interior
+    // `\0` makes the spawn fail with "nul byte found in provided data".
+    let full_prompt = full_prompt.replace('\0', "");
 
     let mut cmd = hidden_cmd(&binary);
     // `--no-color` keeps stdout free of ANSI escapes. Flags precede the


### PR DESCRIPTION
## Summary
Spawning a CLI process with an interior NUL byte fails with "nul byte found in provided data". Binary or malformed content can leak NUL bytes into prompts through diffs or file snapshots, so this strips them defensively before spawning any AI CLI provider.

## Changes
- Strip NUL bytes from prompts before process spawn across all four CLI providers (claude, codex, opencode, copilot).
- Guard against binary or malformed content leaking NUL bytes via diffs or file snapshots.

## Test plan
- [ ] Build the desktop Tauri app and confirm it compiles.
- [ ] Send a prompt containing an embedded NUL byte and verify the CLI spawns without the "nul byte found" error.
- [ ] Verify normal prompts without NUL bytes still work for each provider (claude, codex, opencode, copilot).