### PR TITLE
feat(telemetry): anonymous launch ping via Umami

### DIFF
--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -72,7 +72,7 @@ keyring = "2"
 # Lightweight blocking HTTP client for the anonymous launch-count ping.
 # No async/tokio dependency — runs in a detached thread. Only used in
 # release builds (cfg(not(debug_assertions))).
-ureq = { version = "2", default-features = false, features = ["tls"] }
+ureq = { version = "2", default-features = false, features = ["tls", "json"] }
 
 # Anonymous install ID generation (v4 random UUID, stored on first launch).
 uuid = { version = "1", features = ["v4"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -69,6 +69,17 @@ git2 = { version = "0.20.4", default-features = false, features = ["vendored-lib
 # Windows Credential Manager on Windows.
 keyring = "2"
 
+# Lightweight blocking HTTP client for the anonymous launch-count ping.
+# No async/tokio dependency — runs in a detached thread. Only used in
+# release builds (cfg(not(debug_assertions))).
+ureq = { version = "2", default-features = false, features = ["tls"] }
+
+# Anonymous install ID generation (v4 random UUID, stored on first launch).
+uuid = { version = "1", features = ["v4"] }
+
+# Cross-platform system locale detection (macOS / Linux / Windows).
+sys-locale = "0.3"
+
 # ─── Release profile (P2.4) ──────────────────────────────────
 #
 # Profile tuné pour la build de production (vs defaults Cargo conservateurs).

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -233,6 +233,32 @@ pub fn git_commit_submodule_changes_parity(
 // ─── Tauri entry point ─────────────────────────────────────
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+#[cfg(not(debug_assertions))]
+/// Returns the anonymous install ID, creating it on first launch.
+///
+/// Stored at `{data_local_dir}/gitwand/install_id` as a plain UUID v4.
+/// Random, not derived from hardware — not personal data under GDPR.
+fn get_or_create_install_id() -> String {
+    let path = dirs::data_local_dir()
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join("gitwand")
+        .join("install_id");
+
+    if let Ok(id) = std::fs::read_to_string(&path) {
+        let id = id.trim().to_string();
+        if !id.is_empty() {
+            return id;
+        }
+    }
+
+    let id = uuid::Uuid::new_v4().to_string();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, &id);
+    id
+}
+
 pub fn run() {
     // macOS GUI apps launched from Finder/Dock get a minimal launchd env
     // (no SSH_AUTH_SOCK, GH_TOKEN, XDG_*, or anything from ~/.zshrc).
@@ -267,6 +293,33 @@ pub fn run() {
                     let _ = handle.emit("global-shortcut-activate", ());
                 }
             })?;
+
+            // Anonymous launch telemetry via Umami — fire-and-forget POST.
+            // No personal data: UUID is random (not hardware-derived), IP is
+            // anonymised server-side by Umami. Skipped in debug builds.
+            #[cfg(not(debug_assertions))]
+            std::thread::spawn(|| {
+                let install_id = get_or_create_install_id();
+                let language = sys_locale::get_locale().unwrap_or_else(|| "en".to_string());
+                let version = env!("CARGO_PKG_VERSION");
+                let _ = ureq::post("https://cloud.umami.is/api/send")
+                    .set("Content-Type", "application/json")
+                    .send_json(serde_json::json!({
+                        "payload": {
+                            "website": "171a9307-29ca-4524-8772-6187daacd9ca",
+                            "hostname": "app.gitwand.devlint.fr",
+                            "url": "/launch",
+                            "language": language,
+                            "name": "launch",
+                            "data": {
+                                "version": version,
+                                "install_id": install_id
+                            }
+                        },
+                        "type": "event"
+                    }));
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![


### PR DESCRIPTION
## Summary

- Sends a fire-and-forget POST to Umami on each **release-build** launch (skipped in debug)
- Tracks: anonymous install ID, app version, system language, country (auto-detected by Umami server-side)
- Install ID is a random UUID v4 stored at `{data_local_dir}/gitwand/install_id` — not hardware-derived, not personal data under GDPR

## New dependencies

| Crate | Version | Purpose |
|---|---|---|
| `ureq` | 2 | Lightweight blocking HTTP (no tokio) |
| `uuid` | 1 | UUID v4 generation |
| `sys-locale` | 0.3 | Cross-platform system locale |

## Test plan

- [ ] Verify `{data_local_dir}/gitwand/install_id` is created on first release build launch
- [ ] Verify the same UUID is reused on subsequent launches
- [ ] Verify no ping fires in `cargo run` / dev builds
- [ ] Confirm event appears in Umami dashboard with `version`, `install_id`, `language` fields