### PR TITLE
fix(website): prevent hero reflow when switching tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Git's magic wand — automatic conflict resolution and smart merge tools",
   "author": "Laurent Guitton <lb.guitton@gmail.com>",
   "license": "MIT",
-  "packageManager": "pnpm@11.2.2",
+  "packageManager": "pnpm@11.9.0",
   "engines": {
     "node": ">=22.13.0",
     "pnpm": ">=11"

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -3200,9 +3200,8 @@ function cellClass(v: CompareValue | undefined): string {
   grid-area: 1 / 1;
 }
 .hero-pane--hidden {
+  /* visibility:hidden keeps the box in the grid cell (no reflow) while hiding it. */
   visibility: hidden;
-  opacity: 0;
-  pointer-events: none;
 }
 .hero-gui {
   width: 100%;

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -1030,17 +1030,20 @@ function cellClass(v: CompareValue | undefined): string {
             >{{ t.heroTabCli }}</button>
           </div>
 
+          <!-- Both panels share one grid cell so the stage keeps the height of the
+               taller panel — toggling visibility (not display) avoids any reflow. -->
+          <div class="hero-stage">
           <!-- GUI: desktop dashboard screenshot -->
-          <div v-show="heroTab === 'gui'" class="hero-gui" role="tabpanel">
+          <div class="hero-gui" :class="{ 'hero-pane--hidden': heroTab !== 'gui' }" role="tabpanel" :aria-hidden="heroTab !== 'gui'">
             <img
-              src="/screenshots/app-dashboard.png" :alt="t.heroGuiAlt"
-              class="hero-gui__img" width="1200" height="617"
+              src="/screenshots/GitWand_dashboard.png" :alt="t.heroGuiAlt"
+              class="hero-gui__img" width="1842" height="931"
               loading="lazy" decoding="async"
             />
           </div>
 
           <!-- CLI: terminal animation -->
-          <div v-show="heroTab === 'cli'" class="hero-term" role="tabpanel">
+          <div class="hero-term" :class="{ 'hero-pane--hidden': heroTab !== 'cli' }" role="tabpanel" :aria-hidden="heroTab !== 'cli'">
             <div class="hero-term__bar">
               <span class="tl tl-r"></span><span class="tl tl-y"></span><span class="tl tl-g"></span>
               <span class="hero-term__title">~/projects/myapp — gitwand</span>
@@ -1054,6 +1057,7 @@ function cellClass(v: CompareValue | undefined): string {
               >{{ line.text }}</div>
               <span v-if="termRunning" class="hero-term__cursor">▋</span>
             </div>
+          </div>
           </div>
         </div>
       </div>
@@ -3184,6 +3188,21 @@ function cellClass(v: CompareValue | undefined): string {
 .hero-tab--active {
   background: var(--gw-purple);
   color: #fff;
+}
+/* Stack both panels in a single grid cell: the stage sizes to the taller of the
+   two, so toggling the tab never changes the visual's height (no reflow). */
+.hero-stage {
+  display: grid;
+  width: 100%;
+  justify-items: center;
+}
+.hero-stage > * {
+  grid-area: 1 / 1;
+}
+.hero-pane--hidden {
+  visibility: hidden;
+  opacity: 0;
+  pointer-events: none;
 }
 .hero-gui {
   width: 100%;


### PR DESCRIPTION
## Summary
The homepage hero jumped in height when toggling between the GUI and CLI panels because each tab occupied its own sized grid cell. This change stacks both panels in a single grid cell sized to the largest one, eliminating the layout shift, and refreshes the dashboard screenshot.

## Changes
- Stack the GUI and CLI hero panels in a single shared grid cell sized to the largest panel to avoid height jumps
- Update the dashboard screenshot used in the hero section
- Bump pnpm to 11.9.0 in package.json

## Test plan
- [ ] Load the homepage and toggle between the GUI and CLI tabs, confirming the hero height stays constant
- [ ] Verify the updated dashboard screenshot renders correctly
- [ ] Check the hero layout on mobile and desktop breakpoints
- [ ] Run the website build with pnpm 11.9.0 to confirm no regressions