### PR TITLE
style(pr-create): keep close button visible while scrolling

### DIFF
--- a/apps/desktop/src/components/PrCreateView.vue
+++ b/apps/desktop/src/components/PrCreateView.vue
@@ -784,7 +784,7 @@ function removeReviewer(name: string) {
   margin-left: auto;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  background: transparent;
+  background: var(--color-bg-secondary);
   color: var(--color-text-muted);
   cursor: pointer;
   flex-shrink: 0;
@@ -792,6 +792,7 @@ function removeReviewer(name: string) {
   position: sticky;
   top: 20px;
   right: 20px;
+  z-index: 6;
 }
 .pcv-close:hover {
   background: var(--color-bg-tertiary);


### PR DESCRIPTION
## Summary
The sticky close button in the PR creation view could blend into or be obscured by the content while scrolling. This change adds a background and a stacking context so the button stays clearly visible at all times.

## Changes
- Add a background to the sticky close button in `PrCreateView.vue`
- Raise the close button's `z-index` so it renders above scrolling content

## Test plan
- [ ] Open the PR creation view and scroll through long content
- [ ] Confirm the close button stays visible above the content
- [ ] Verify the close button remains clickable while scrolling