### PR TITLE
fix(github): refresh repo state and fix fork PR checkout

### DIFF
--- a/apps/desktop/src-tauri/src/commands/github_api.rs
+++ b/apps/desktop/src-tauri/src/commands/github_api.rs
@@ -1021,12 +1021,29 @@ pub(crate) fn rest_pr_ready(cwd: &str, number: i64, token: &str) -> Result<(), S
 }
 
 pub(crate) fn rest_checkout_pr(cwd: &str, number: i64) -> Result<(), String> {
-    // Local git fetch of the PR head ref — token not needed (git uses its own
-    // credential helper). Works for same-repo and fork PRs alike.
+    // Resolve which repo the PR actually lives in. When the local repo is a
+    // fork, the listed PRs belong to the upstream *parent*, so `pull/N/head`
+    // exists on the parent's refs — fetching it from `origin` (the fork) 404s.
+    let (owner, repo) = owner_repo(cwd)?;
+    let origin = format!("{}/{}", owner, repo);
+    let pr_repo = settings_github_token()
+        .and_then(|tok| get_pr_json(cwd, number, &tok).ok())
+        .map(|(repo, _)| repo)
+        .unwrap_or_else(|| origin.clone());
+
+    // Fetch the PR head ref. When the PR lives in `origin` use the configured
+    // remote; otherwise fetch straight from the upstream repo URL (no remote is
+    // configured for it). git's credential helper supplies auth for private
+    // upstreams, same as the origin path — no token in process args.
+    let fetch_target = if pr_repo == origin {
+        "origin".to_string()
+    } else {
+        format!("https://github.com/{}.git", pr_repo)
+    };
     let local = format!("pr-{}", number);
     let refspec = format!("pull/{}/head:{}", number, local);
     let fetch = git_cmd()
-        .args(["fetch", "origin", &refspec])
+        .args(["fetch", &fetch_target, &refspec])
         .current_dir(cwd)
         .output()
         .map_err(|e| format!("git fetch failed: {}", e))?;

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -304,7 +304,14 @@ watch(
 
 // ─── PR panel (shared state via provide/inject) ──────────
 const prCwd = computed(() => repoFolderPath.value ?? "");
-const prPanel = usePrPanel(prCwd);
+const prPanel = usePrPanel(prCwd, {
+  // After a PR checkout switches the branch on disk, refresh repo state +
+  // branch list so the UI follows — mirrors what switchBranch() does.
+  onRepoMutated: async () => {
+    await repoRefresh();
+    await loadBranches();
+  },
+});
 provide(PR_PANEL_KEY, prPanel);
 const issuePanel = useIssuePanel(prCwd);
 provide(ISSUE_PANEL_KEY, issuePanel);

--- a/apps/desktop/src/composables/usePrPanel.ts
+++ b/apps/desktop/src/composables/usePrPanel.ts
@@ -54,7 +54,18 @@ export function isMergeConflict(mergeable: string | null | undefined): boolean {
   return ["CONFLICTING", "CONFLICTS", "DIRTY"].includes((mergeable || "").toUpperCase());
 }
 
-export function usePrPanel(cwd: Ref<string>) {
+/** Optional host hooks so the panel can notify the app of side effects. */
+export interface PrPanelOptions {
+  /**
+   * Called after an action mutates the local working copy (e.g. `checkoutPr`
+   * switches the checked-out branch). The host wires this to its repo-state
+   * refresh so the branch indicator / status / log stay in sync — otherwise the
+   * checkout happens on disk but the UI keeps showing the previous branch.
+   */
+  onRepoMutated?: () => void | Promise<void>;
+}
+
+export function usePrPanel(cwd: Ref<string>, opts: PrPanelOptions = {}) {
 
   // Disk-persisted SWR cache — paints the list/detail instantly on repo-switch
   // or cold app start, then revalidates in the background. See usePrCache.ts.
@@ -736,6 +747,9 @@ export function usePrPanel(cwd: Ref<string>) {
     try {
       await forge.value.checkoutPR(cwd.value, pr.number);
       success.value = t("pr.success.checkoutDone", pr.number);
+      // The branch changed on disk — let the host refresh repo state so the
+      // current-branch indicator / status / log reflect the checkout.
+      await opts.onRepoMutated?.();
     } catch (err: any) { error.value = err.message; }
   }
 


### PR DESCRIPTION
## Summary
Checking out a pull request now correctly resolves the PR's real source repository (fetching from upstream for fork PRs) and refreshes the UI so the displayed branch, status, and log match the actual on-disk state.

## Changes
- Resolve the PR's actual repository and fetch `pull/N/head` from upstream when the PR originates from a fork.
- Add an `onRepoMutated` hook in the PR panel to notify the app after a PR checkout.
- Resync branch, status, and log in `App.vue` when the repo is mutated.

## Test plan
- [ ] Check out a PR from a fork and confirm the branch is fetched and switched correctly.
- [ ] Check out a PR from the same repository and confirm checkout still works.
- [ ] Verify the UI updates the current branch, status, and log immediately after checkout.
- [ ] Confirm no stale branch name is shown after switching PRs.