### PR TITLE
feat(ai-presets): drop duplicate default preset and fix stale checkmark

### DIFF
--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -2518,22 +2518,23 @@ function formatActivityDate(dateStr: string): string {
   right: 100%;
   bottom: 0;
   margin-right: var(--space-1);
-  min-width: 130px;
-  max-height: 300px;
+  min-width: 120px;
+  max-height: 280px;
   overflow-y: auto;
   background: var(--color-bg);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   box-shadow: var(--shadow-popover);
   list-style: none;
-  padding: var(--space-2) 0;
+  padding: var(--space-1) 0;
   z-index: 101;
 }
 
 .commit-ai-submenu li {
+  position: relative;
   display: flex;
   align-items: center;
-  padding: 6px 12px 6px 30px;
+  padding: 4px 10px 4px 26px;
   font-size: var(--font-size-sm);
   color: var(--color-text);
   cursor: pointer;
@@ -2546,11 +2547,14 @@ function formatActivityDate(dateStr: string): string {
 
 .commit-ai-submenu li.is-active {
   font-weight: 600;
-  padding-left: 12px;
 }
 
+/* Check sits in the fixed 30px gutter so toggling it never reflows the label. */
 .commit-ai-check {
-  margin-right: 6px;
+  position: absolute;
+  left: 8px;
+  top: 50%;
+  transform: translateY(-50%);
   flex-shrink: 0;
 }
 
@@ -2576,7 +2580,6 @@ function formatActivityDate(dateStr: string): string {
 
 /* Preset submenu — slightly wider to show preset names */
 .commit-ai-preset-submenu {
-  min-width: 180px;
 }
 
 /* Preset label inline in the menu entry */

--- a/apps/desktop/src/composables/__tests__/v2.13-ai-presets.test.ts
+++ b/apps/desktop/src/composables/__tests__/v2.13-ai-presets.test.ts
@@ -72,7 +72,7 @@ describe("useAiPromptPresets (module-level functions)", () => {
     removePreset(builtinId);
     const stillExists = BUILTIN_PRESETS.find((p) => p.id === builtinId);
     expect(stillExists).toBeDefined();
-    expect(BUILTIN_PRESETS.length).toBe(4);
+    expect(BUILTIN_PRESETS.length).toBe(3);
   });
 
   // 6. setActivePreset(cwd, id) + getActivePresetId(cwd) returns the id
@@ -106,8 +106,8 @@ describe("useAiPromptPresets (module-level functions)", () => {
     expect(getActivePresetId(CWD_B)).toBeNull();
   });
 
-  // 9. allPresetsWithBuiltins() includes all 4 builtins + user presets
-  it("allPresetsWithBuiltins() includes all 4 builtins + user presets", async () => {
+  // 9. allPresetsWithBuiltins() includes all 3 builtins + user presets
+  it("allPresetsWithBuiltins() includes all 3 builtins + user presets", async () => {
     const { addPreset, allPresetsWithBuiltins, BUILTIN_PRESETS } = await import("../useAiPromptPresets");
     addPreset({ name: "Custom A", systemPrompt: "prompt A" });
     addPreset({ name: "Custom B", systemPrompt: "prompt B" });

--- a/apps/desktop/src/composables/useAiPromptPresets.ts
+++ b/apps/desktop/src/composables/useAiPromptPresets.ts
@@ -12,28 +12,14 @@
  */
 
 import { computed } from "vue";
-import { loadSettings, saveSettings, type AiPromptPreset } from "./useSettings";
+import { loadSettings, saveSettings, settingsRevision, type AiPromptPreset } from "./useSettings";
 
 // ─── Built-in presets ─────────────────────────────────────────────────────────
 
+// Note: there is intentionally no "__builtin_default" preset. The default
+// Conventional Commits prompt is already reachable via the "Default" menu entry
+// (activate(null) → buildSystemPrompt), so adding it here would duplicate it.
 export const BUILTIN_PRESETS: ReadonlyArray<AiPromptPreset> = [
-  {
-    id: "__builtin_default",
-    name: "Default",
-    description: "Conventional Commits, imperative mood, ${lang}.",
-    systemPrompt: `You are a senior software engineer writing a Git commit message.
-
-Rules:
-1. Follow the Conventional Commits spec: "<type>(<optional scope>): <subject>".
-   Valid types: feat, fix, refactor, perf, docs, test, chore, build, ci, style.
-2. Subject line MUST be 72 characters or less, imperative mood, no trailing period.
-3. After the subject, leave a blank line, then optionally add a short body (1-3 lines)
-   explaining *why* the change was made. Skip the body for trivial changes.
-4. Write in \${lang}.
-5. Do not include trailers (Co-Authored-By, Signed-off-by, Reviewed-by…) — the user controls those via the GitWand trailer checkboxes.
-6. Never wrap your answer in code fences or add explanations — output ONLY the
-   raw commit message, ready to be passed to \`git commit -m\`.`,
-  },
   {
     id: "__builtin_concise",
     name: "Concise",
@@ -161,16 +147,28 @@ export function setActivePreset(cwd: string, presetId: string | null): void {
 // ─── composable ──────────────────────────────────────────────────────────────
 
 export function useAiPromptPresets(getCwd?: () => string) {
-  const userPresets = computed(() => allPresets());
-  const allWithBuiltins = computed(() => allPresetsWithBuiltins());
+  // `void settingsRevision.value` registers a reactive dependency on the
+  // settings-changed counter. The reads below pull straight from localStorage
+  // (via loadSettings), so without this they would never recompute after a
+  // saveSettings() — the active-preset checkmark would stay stale until reload.
+  const userPresets = computed(() => {
+    void settingsRevision.value;
+    return allPresets();
+  });
+  const allWithBuiltins = computed(() => {
+    void settingsRevision.value;
+    return allPresetsWithBuiltins();
+  });
 
-  const activePresetId = computed<string | null>(() =>
-    getCwd ? getActivePresetId(getCwd()) : null,
-  );
+  const activePresetId = computed<string | null>(() => {
+    void settingsRevision.value;
+    return getCwd ? getActivePresetId(getCwd()) : null;
+  });
 
-  const activePreset = computed<AiPromptPreset | null>(() =>
-    getCwd ? getActivePreset(getCwd()) : null,
-  );
+  const activePreset = computed<AiPromptPreset | null>(() => {
+    void settingsRevision.value;
+    return getCwd ? getActivePreset(getCwd()) : null;
+  });
 
   function activate(presetId: string | null) {
     if (!getCwd) return;


### PR DESCRIPTION
## Summary
The built-in `__builtin_default` preset duplicated the Default menu entry, which already routes to the Conventional Commits prompt via `activate(null)`. This removes the redundant preset and fixes two UI glitches: the active-preset checkmark going stale until reload, and the submenu check reflowing its label when toggled.

## Changes
- Remove the `__builtin_default` built-in preset to avoid duplicating the Default menu entry
- Track `settingsRevision` in `useAiPromptPresets` so the active-preset checkmark refreshes after save instead of staying stale until reload
- Pin the submenu check in a fixed gutter so toggling it no longer reflows the preset label
- Update `v2.13-ai-presets` tests to match the dropped built-in preset

## Test plan
- [ ] Open the AI preset submenu and confirm only one Default entry appears
- [ ] Select a preset, save, and verify the checkmark moves without a reload
- [ ] Toggle the active preset and confirm the label does not shift horizontally
- [ ] Run `pnpm test` and confirm the AI preset suite passes

## Visual

### How it was before (The select didn't works)

<img width="732" height="373" alt="image" src="https://github.com/user-attachments/assets/fdc87139-5a81-4fca-88b2-4951492634ea" />

### How it is now (I test all variations)

<img width="342" height="260" alt="image" src="https://github.com/user-attachments/assets/28f793c3-a739-4ca9-9dcb-5b9a363c2859" />
