### PR TITLE
feat(sidebar): merge unstaged and untracked into one Changes section

### DIFF
--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -153,7 +153,7 @@ function toggleSection(sectionKey: string) {
 }
 
 function expandSectionForFile(path: string) {
-  for (const sectionKey of ['conflicted', 'staged', 'unstaged', 'untracked']) {
+  for (const sectionKey of SECTION_KEYS) {
     if (sections.value[sectionKey].some(f => f.path === path)) {
       if (collapsedSections.value[sectionKey]) {
         collapsedSections.value[sectionKey] = false;
@@ -270,7 +270,7 @@ function unstagePaths(paths: string[]) {
 /** Un-collapse every ancestor folder of `path` so the file becomes visible. */
 function expandFoldersForFile(path: string) {
   let sectionKey: string | null = null;
-  for (const sk of ["conflicted", "staged", "unstaged", "untracked"]) {
+  for (const sk of SECTION_KEYS) {
     if (sections.value[sk].some((f) => f.path === path)) {
       sectionKey = sk;
       break;
@@ -295,7 +295,7 @@ function expandFoldersForFile(path: string) {
 /** Flattened tree rows per section, recomputed when files or collapse state change. */
 const treeRowsBySection = computed<Record<string, TreeRow[]>>(() => {
   const result: Record<string, TreeRow[]> = {};
-  for (const sectionKey of ["conflicted", "staged", "unstaged", "untracked"]) {
+  for (const sectionKey of SECTION_KEYS) {
     const root = buildFileTree(sections.value[sectionKey]);
     result[sectionKey] = flattenTree(
       root,
@@ -663,24 +663,29 @@ async function onAiAction(action: "regenerate" | "shorten" | "detail" | "changeL
   }
 }
 
+// Working-tree changes (modified/deleted/added-untracked) share one section
+// header. Files keep their real `section` ('unstaged' | 'untracked') for the
+// per-file stage/discard semantics — only the display grouping is merged here.
 const sections = computed(() => {
   const map: Record<string, RepoFileEntry[]> = {
     conflicted: [],
     staged: [],
-    unstaged: [],
-    untracked: [],
+    changes: [],
   };
   for (const f of props.files) {
-    map[f.section].push(f);
+    const key = f.section === "unstaged" || f.section === "untracked" ? "changes" : f.section;
+    map[key].push(f);
   }
   return map;
 });
 
+/** Display section keys, in render order. */
+const SECTION_KEYS = ["conflicted", "staged", "changes"] as const;
+
 const sectionMeta = computed((): Record<string, { label: string; color: string; icon: string }> => ({
   conflicted: { label: t('sidebar.sectionConflicts'), color: "var(--color-danger)", icon: "!" },
   staged: { label: t('sidebar.sectionStaged'), color: "var(--color-success)", icon: "+" },
-  unstaged: { label: t('sidebar.sectionModified'), color: "var(--color-warning)", icon: "~" },
-  untracked: { label: t('sidebar.sectionUntracked'), color: "var(--color-text-muted)", icon: "?" },
+  changes: { label: t('sidebar.sectionChanges'), color: "var(--color-warning)", icon: "~" },
 }));
 
 function statusBadge(status: string): string {
@@ -1126,7 +1131,7 @@ function formatActivityDate(dateStr: string): string {
 
     <!-- File sections -->
     <div class="sections" v-if="showPane('files', 'changes')">
-      <template v-for="sectionKey in ['conflicted', 'staged', 'unstaged', 'untracked']" :key="sectionKey">
+      <template v-for="sectionKey in SECTION_KEYS" :key="sectionKey">
         <div
           v-if="sections[sectionKey].length > 0"
           class="section"
@@ -1149,7 +1154,7 @@ function formatActivityDate(dateStr: string): string {
             <!-- Stage all / Unstage all + Discard all -->
             <div v-if="sectionKey !== 'conflicted'" class="action-group" @click.stop>
               <button
-                v-if="sectionKey === 'unstaged' || sectionKey === 'untracked'"
+                v-if="sectionKey === 'changes'"
                 class="action-group-btn"
                 @click.stop="emit('stagePaths', sections[sectionKey].map(f => f.path))"
                 :title="t('sidebar.stageAll')"
@@ -1299,7 +1304,7 @@ function formatActivityDate(dateStr: string): string {
                       :title="t('sidebar.unstageAll')"
                     >-</button>
                     <button
-                      v-if="sectionKey === 'unstaged' || sectionKey === 'untracked'"
+                      v-if="sectionKey === 'changes'"
                       class="action-group-btn"
                       @click.stop="emit('stagePaths', filesUnderFolder(sectionKey, row.path))"
                       :title="t('sidebar.stageAll')"

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -189,6 +189,7 @@ const en = {
     sectionStaged: "Staged",
     sectionModified: "Modified",
     sectionUntracked: "Untracked",
+    sectionChanges: "Changes",
     // Actions
     stageAll: "Stage all",
     unstageAll: "Unstage all",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -185,6 +185,7 @@ const es: Locale = {
     sectionStaged: "Preparados",
     sectionModified: "Modificados",
     sectionUntracked: "Sin seguimiento",
+    sectionChanges: "Cambios",
     stageAll: "Preparar todo",
     unstageAll: "Quitar todo de preparados",
     discardAll: "Descartar todo",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -181,6 +181,7 @@ const fr: Locale = {
     sectionStaged: "Indexés",
     sectionModified: "Modifi\u00e9s",
     sectionUntracked: "Non suivis",
+    sectionChanges: "Modifications",
     // Actions
     stageAll: "Tout indexer",
     unstageAll: "Tout désindexer",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -186,6 +186,7 @@ const ptBR: Locale = {
     sectionStaged: "Em stage",
     sectionModified: "Modificados",
     sectionUntracked: "Não rastreados",
+    sectionChanges: "Alterações",
     stageAll: "Stage em tudo",
     unstageAll: "Tirar tudo do stage",
     discardAll: "Descartar tudo",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -189,6 +189,7 @@ const zhCN: Locale = {
     sectionStaged: "已暂存",
     sectionModified: "已修改",
     sectionUntracked: "未跟踪",
+    sectionChanges: "更改",
     stageAll: "全部暂存",
     unstageAll: "全部取消暂存",
     discardAll: "全部丢弃",


### PR DESCRIPTION
## Summary
The sidebar previously split working-tree files into separate "Unstaged" and "Untracked" sections. This change merges them into a single unified "Changes" section for a simpler, more conventional working-tree view.

## Changes
- Combine the unstaged and untracked file groups into one "Changes" section in `RepoSidebar.vue`
- Add the new `Changes` section label key across all locales (en, es, fr, pt-BR, zh-CN)

## Test plan
- [ ] Open a repo with both modified and untracked files; confirm all appear under a single "Changes" section
- [ ] Verify the section label renders correctly in each supported locale
- [ ] Confirm staging/unstaging from the merged section still works as expected

## How it looks

### Before the change

<img width="427" height="238" alt="before" src="https://github.com/user-attachments/assets/5651c8d1-27e4-4e9b-a8bb-c3b4c89c9194" />

### After the change (With some few other files)

<img width="427" height="480" alt="now" src="https://github.com/user-attachments/assets/f2555e27-683e-4f81-b7af-621a20fe1562" />