### PR TITLE
feat(desktop): integrate Antigravity CLI as local AI provider

### DIFF
--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -4154,6 +4154,82 @@ async function handleRequest(req, res) {
       }
     }
 
+    // GET /api/antigravity-cli-detect
+    if (url.pathname === "/api/antigravity-cli-detect" && req.method === "GET") {
+      try {
+        const AGY = resolveBin("agy");
+        const exists = (() => {
+          try { return existsSync(AGY); } catch { return false; }
+        })();
+        let resolved = exists ? AGY : "";
+        if (!resolved) {
+          try {
+            const r = spawnSync(process.platform === "win32" ? "where" : "which", ["agy"], { encoding: "utf-8" });
+            if (r.status === 0 && r.stdout.trim()) {
+              resolved = r.stdout.split(/\r?\n/)[0].trim();
+            }
+          } catch { /* ignore */ }
+        }
+
+        if (!resolved) {
+          return jsonResponse(req, res, {
+            found: false,
+            path: "",
+            version: "",
+            logged_in: false,
+            status: "not_found",
+            detail: "Binaire `agy` introuvable. Installez-le avec `curl -fsSL https://antigravity.google/cli/install.sh | bash`.",
+          });
+        }
+
+        let version = "";
+        try {
+          const r = spawnSync(resolved, ["--version"], { encoding: "utf-8" });
+          if (r.status === 0) version = r.stdout.trim();
+        } catch { /* ignore */ }
+
+        return jsonResponse(req, res, {
+          found: true,
+          path: resolved,
+          version,
+          logged_in: false,
+          status: "detected",
+          detail: "",
+        });
+      } catch (err) {
+        return jsonResponse(req, res, { error: err.stderr?.toString() || err.message }, 500);
+      }
+    }
+
+    // POST /api/antigravity-cli-prompt  { prompt, systemPrompt?, cwd?, model? }
+    if (url.pathname === "/api/antigravity-cli-prompt" && req.method === "POST") {
+      try {
+        const body = await readBody(req);
+        const AGY = resolveBin("agy");
+        const fullPrompt = body.systemPrompt && body.systemPrompt.trim()
+          ? `# System\n${body.systemPrompt.trim()}\n\n# User\n${(body.prompt || "").trim()}`
+          : (body.prompt || "");
+        const agyArgs = [];
+        if (body.model && String(body.model).trim()) {
+          agyArgs.push("--model", String(body.model).trim());
+        }
+        agyArgs.push("-p", fullPrompt);
+        const r = spawnSync(AGY, agyArgs, {
+          cwd: body.cwd || undefined,
+          encoding: "utf-8",
+          timeout: 5 * 60 * 1000,
+          maxBuffer: 20 * 1024 * 1024,
+        });
+        if (r.status !== 0) {
+          const detail = (r.stderr || r.stdout || "").trim() || "Antigravity CLI a échoué sans message";
+          return jsonResponse(req, res, { error: detail }, 500);
+        }
+        return res.writeHead(200, { ...corsHeaders(req), "Content-Type": "text/plain" }).end(r.stdout);
+      } catch (err) {
+        return jsonResponse(req, res, { error: err.stderr?.toString() || err.message }, 500);
+      }
+    }
+
     // POST /api/claude-cli-login  (opens a terminal with `claude login`)
     if (url.pathname === "/api/claude-cli-login" && req.method === "POST") {
       try {

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -385,6 +385,100 @@ pub(crate) fn resolve_antigravity_binary() -> Option<String> {
     None
 }
 
+/// Detect Antigravity CLI presence and version. Same privacy stance as the
+/// Claude / Codex / opencode / Copilot detectors: no prompt is sent to verify
+/// auth — that is confirmed implicitly on the first real `antigravity_cli_prompt`.
+#[tauri::command]
+pub(crate) fn detect_antigravity_cli() -> Result<AntigravityCliInfo, String> {
+    let binary = match resolve_antigravity_binary() {
+        Some(b) => b,
+        None => {
+            return Ok(AntigravityCliInfo {
+                found: false,
+                path: String::new(),
+                version: String::new(),
+                logged_in: false,
+                status: "not_found".to_string(),
+                detail: "Binaire `agy` introuvable. Installez-le avec `curl -fsSL https://antigravity.google/cli/install.sh | bash`."
+                    .to_string(),
+            });
+        }
+    };
+
+    let version = hidden_cmd(&binary)
+        .arg("--version")
+        .output()
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default();
+
+    Ok(AntigravityCliInfo {
+        found: true,
+        path: binary,
+        version,
+        logged_in: false,
+        status: "detected".to_string(),
+        detail: String::new(),
+    })
+}
+
+/// Run a one-shot prompt through the local Antigravity CLI (`agy -p`).
+///
+/// Antigravity exposes no separate system channel, so the system prompt is
+/// prepended as a Markdown section — same portable shape as the Claude /
+/// Codex / opencode / Copilot flows. Auth is managed by Antigravity itself.
+#[tauri::command]
+pub(crate) fn antigravity_cli_prompt(
+    prompt: String,
+    system_prompt: Option<String>,
+    cwd: Option<String>,
+    model: Option<String>,
+) -> Result<String, String> {
+    let binary = resolve_antigravity_binary()
+        .ok_or_else(|| "Binaire `agy` introuvable".to_string())?;
+
+    let full_prompt = match system_prompt {
+        Some(sys) if !sys.trim().is_empty() => {
+            format!("# System\n{}\n\n# User\n{}", sys.trim(), prompt.trim())
+        }
+        _ => prompt,
+    };
+
+    // Strip NUL bytes — the prompt is passed as a CLI argument and an interior
+    // `\0` makes the spawn fail with "nul byte found in provided data".
+    let full_prompt = full_prompt.replace('\0', "");
+
+    let mut cmd = hidden_cmd(&binary);
+    // Flags precede the positional prompt passed via `-p`.
+    if let Some(m) = model.as_ref() {
+        if !m.trim().is_empty() {
+            cmd.args(["--model", m.trim()]);
+        }
+    }
+    cmd.args(["-p", full_prompt.as_str()]);
+    if let Some(dir) = cwd {
+        if !dir.trim().is_empty() {
+            cmd.current_dir(dir);
+        }
+    }
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run antigravity CLI: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let detail = if stderr.is_empty() { stdout } else { stderr };
+        return Err(if detail.is_empty() {
+            "Antigravity CLI a échoué sans message".to_string()
+        } else {
+            detail
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
 // ─── opencode CLI provider (v2.17) ───────────────────────────────────────
 
 // Models are advertised in `provider/model` form (e.g. `anthropic/claude-…`),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -94,10 +94,12 @@ use tauri_plugin_global_shortcut::GlobalShortcutExt;
 // `pub(crate) use crate::types::*;`.
 
 // `strip_claude_auth_env` + `resolve_claude_binary` + `resolve_codex_binary`
-// + `resolve_opencode_binary` + `resolve_copilot_binary` + 10 AI CLI commands
+// + `resolve_opencode_binary` + `resolve_copilot_binary`
+// + `resolve_antigravity_binary` + 12 AI CLI commands
 // (detect_claude_cli, claude_cli_prompt, detect_codex_cli, codex_cli_prompt,
 // claude_cli_login, detect_opencode_cli, opencode_cli_prompt,
-// opencode_list_models, detect_copilot_cli, copilot_cli_prompt)
+// opencode_list_models, detect_copilot_cli, copilot_cli_prompt,
+// detect_antigravity_cli, antigravity_cli_prompt)
 // migrated to `src/commands/ai.rs` (§3.4f).
 // Handler entries below route to `commands::ai::*`.
 
@@ -494,6 +496,8 @@ pub fn run() {
             commands::ai::opencode_list_models,
             commands::ai::detect_copilot_cli,
             commands::ai::copilot_cli_prompt,
+            commands::ai::detect_antigravity_cli,
+            commands::ai::antigravity_cli_prompt,
             commands::network::check_remote_reachable,
             commands::gitlab::detect_glab,
             commands::gitlab::gl_list_mrs,

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -662,6 +662,18 @@ pub struct CopilotCliInfo {
     pub detail: String,
 }
 
+// ─── Antigravity CLI ───────────────────────────────────────────────
+
+#[derive(Serialize)]
+pub struct AntigravityCliInfo {
+    pub found: bool,
+    pub path: String,
+    pub version: String,
+    pub logged_in: bool,
+    pub status: String,
+    pub detail: String,
+}
+
 // ─── Git hooks ─────────────────────────────────────────────────────
 
 #[derive(Serialize)]

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -22,6 +22,8 @@ import {
   type OpencodeCliInfo,
   detectCopilotCli,
   type CopilotCliInfo,
+  detectAntigravityCli,
+  type AntigravityCliInfo,
   readGitwandrc,
   writeGitwandrc,
   checkForUpdates,
@@ -531,6 +533,8 @@ function onAIProviderChange(val: AIProvider) {
     loadCliModels(val);
   } else if (val === "copilot-cli") {
     runCopilotCliDetect();
+  } else if (val === "antigravity-cli") {
+    runAntigravityCliDetect();
     loadCliModels(val);
   } else if (val === "claude") {
     if (!settings.value.aiApiEndpoint || settings.value.aiApiEndpoint === "https://api.openai.com/v1") {
@@ -720,6 +724,28 @@ async function runCopilotCliDetect() {
   }
 }
 
+// ─── Antigravity CLI detection ──────────────────────────
+const antigravityCliInfo = ref<AntigravityCliInfo | null>(null);
+const antigravityCliDetecting = ref(false);
+
+async function runAntigravityCliDetect() {
+  antigravityCliDetecting.value = true;
+  try {
+    antigravityCliInfo.value = await detectAntigravityCli();
+  } catch (e) {
+    antigravityCliInfo.value = {
+      found: false,
+      path: "",
+      version: "",
+      logged_in: false,
+      status: "error",
+      detail: (e as Error).message,
+    };
+  } finally {
+    antigravityCliDetecting.value = false;
+  }
+}
+
 // ─── Per-provider model picker for CLI agents (v2.17) ───
 const cliModelOptions = ref<string[]>([]);
 const cliModelsLoading = ref(false);
@@ -795,6 +821,7 @@ type LlmFallbackProvider =
   | "codex-cli"
   | "opencode-cli"
   | "copilot-cli"
+  | "antigravity-cli"
   | "openai-compat"
   | "ollama"
   | "mcp";
@@ -962,6 +989,7 @@ onMounted(() => {
   runCodexCliDetect();
   runOpencodeCliDetect();
   runCopilotCliDetect();
+  runAntigravityCliDetect();
   // Preload the model list when a CLI agent is already the active provider.
   loadCliModels();
 });
@@ -1983,6 +2011,10 @@ function deleteReleaseNoteTemplate(id: string) {
                   {{ t('settings.aiProviderCopilotCli') }}{{ copilotCliInfo && !copilotCliInfo.found ?
                     t('settings.aiProviderCopilotCliNotFound') : '' }}
                 </option>
+                <option value="antigravity-cli">
+                  {{ t('settings.aiProviderAntigravityCli') }}{{ antigravityCliInfo && !antigravityCliInfo.found ?
+                    t('settings.aiProviderAntigravityCliNotFound') : '' }}
+                </option>
                 <option value="openai-compat">{{ t('settings.aiProviderOpenAiCompat') }}</option>
                 <option value="ollama" :disabled="!ollamaAvailable">
                   {{ t('settings.aiProviderOllama') }}{{ ollamaAvailable ? '' : t('settings.aiProviderOllamaNotFound')
@@ -2352,6 +2384,51 @@ function deleteReleaseNoteTemplate(id: string) {
               </div>
             </template>
 
+            <!-- Antigravity CLI provider — same shape as the Copilot block -->
+            <template v-if="settings.aiProvider === 'antigravity-cli'">
+              <div class="sp-row">
+                <div class="sp-label">{{ t('settings.aiCliStatus') }}</div>
+                <div class="sp-cli-status">
+                  <template v-if="antigravityCliDetecting">
+                    <span class="sp-hint">{{ t('settings.aiCliDetecting') }}</span>
+                  </template>
+                  <template v-else-if="!antigravityCliInfo || !antigravityCliInfo.found">
+                    <div class="sp-connect-error-block">
+                      <div class="sp-connect-error">
+                        {{ t('settings.aiCliNotFound') }} <code>agy</code> {{ t('settings.aiCliNotFoundSuffix') }}
+                      </div>
+                      <span class="sp-hint">
+                        {{ t('settings.aiCliInstallHint') }}
+                        <code>curl -fsSL https://antigravity.google/cli/install.sh | bash</code>
+                        {{ t('settings.aiCliInstallHintSuffix') }}
+                      </span>
+                      <button class="sp-text-btn" @click="runAntigravityCliDetect">{{ t('settings.aiCliRedetect') }}</button>
+                    </div>
+                  </template>
+                  <template v-else>
+                    <!-- Detected. Auth is managed by Antigravity itself and
+                         verified implicitly on first use; we don't ping. -->
+                    <div class="sp-connected-badge">
+                      <span class="sp-connected-dot sp-connected-dot--neutral"></span>
+                      <span>{{ t('settings.aiCliDetected', antigravityCliInfo.version || 'antigravity') }}</span>
+                      <button class="sp-disconnect-btn sp-disconnect-btn--neutral" @click="runAntigravityCliDetect">{{ t('settings.aiCliRedetect')
+                      }}</button>
+                    </div>
+                    <span class="sp-hint">{{ t('settings.aiAntigravityCliDetectedHint') }}</span>
+                  </template>
+                </div>
+              </div>
+
+              <div v-if="antigravityCliInfo?.found" class="sp-info-box">
+                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3">
+                  <circle cx="8" cy="8" r="7" />
+                  <path d="M8 7v4" stroke-linecap="round" />
+                  <circle cx="8" cy="5" r="0.7" fill="currentColor" stroke="none" />
+                </svg>
+                <p>{{ t('settings.aiAntigravityCliInfoBox') }}</p>
+              </div>
+            </template>
+
             <!-- OpenAI-compatible provider -->
             <template v-if="settings.aiProvider === 'openai-compat'">
               <div class="sp-row">
@@ -2591,6 +2668,7 @@ function deleteReleaseNoteTemplate(id: string) {
                   <option value="codex-cli">{{ t('settings.aiProviderCodexCli') }}</option>
                   <option value="opencode-cli">{{ t('settings.aiProviderOpencodeCli') }}</option>
                   <option value="copilot-cli">{{ t('settings.aiProviderCopilotCli') }}</option>
+                  <option value="antigravity-cli">{{ t('settings.aiProviderAntigravityCli') }}</option>
                   <option value="openai-compat">{{ t('settings.aiProviderOpenAiCompat') }}</option>
                   <option value="ollama">{{ t('settings.aiProviderOllama') }}</option>
                   <option value="mcp">MCP (Claude Code / Cursor)</option>

--- a/apps/desktop/src/composables/useAIProvider.ts
+++ b/apps/desktop/src/composables/useAIProvider.ts
@@ -5,6 +5,7 @@ import {
   codexCliPrompt,
   opencodeCliPrompt,
   copilotCliPrompt,
+  antigravityCliPrompt,
   listOpencodeModels,
   detectClaudeCli,
 } from "../utils/backend";
@@ -25,6 +26,9 @@ import { t } from "./useI18n";
  * - `copilot-cli`    : piggyback on the user's locally-installed GitHub
  *                     Copilot CLI (`copilot -p`) — uses their Copilot
  *                     subscription stored on the machine, no API key needed
+ * - `antigravity-cli`: piggyback on the user's locally-installed Antigravity
+ *                     CLI (`agy -p`) — uses the auth stored on the machine,
+ *                     no API key needed
  * - `openai-compat`  : any OpenAI-compatible endpoint
  * - `ollama`         : local Ollama instance
  * - `mcp`            : route the LLM call through a connected MCP agent
@@ -40,6 +44,7 @@ export type AIProvider =
   | "codex-cli"
   | "opencode-cli"
   | "copilot-cli"
+  | "antigravity-cli"
   | "openai-compat"
   | "ollama"
   | "mcp";
@@ -49,13 +54,15 @@ export type CliAgentProvider =
   | "claude-code-cli"
   | "codex-cli"
   | "opencode-cli"
-  | "copilot-cli";
+  | "copilot-cli"
+  | "antigravity-cli";
 
 export const CLI_AGENT_PROVIDERS: CliAgentProvider[] = [
   "claude-code-cli",
   "codex-cli",
   "opencode-cli",
   "copilot-cli",
+  "antigravity-cli",
 ];
 
 export interface AISettings {
@@ -298,6 +305,19 @@ async function callCopilotCli(
   return result ?? "";
 }
 
+/**
+ * Call the local Antigravity CLI (`agy -p`). Uses the auth stored on the
+ * machine — no API key required.
+ */
+async function callAntigravityCli(
+  systemPrompt: string,
+  userPrompt: string,
+  model?: string,
+): Promise<string> {
+  const result = await antigravityCliPrompt(userPrompt, systemPrompt, undefined, model);
+  return result ?? "";
+}
+
 // ─── Per-provider model selection (v2.17) ───────────────
 //
 // The three CLI agents each expose a second model picker. opencode can
@@ -322,7 +342,8 @@ export function modelForProvider(
     provider === "claude-code-cli" ||
     provider === "codex-cli" ||
     provider === "opencode-cli" ||
-    provider === "copilot-cli"
+    provider === "copilot-cli" ||
+    provider === "antigravity-cli"
   ) {
     const m = s.aiModelByProvider?.[provider];
     return m && m.trim() ? m.trim() : undefined;
@@ -435,6 +456,7 @@ export function useAIProvider() {
       if (s.aiProvider === "codex-cli") return true;
       if (s.aiProvider === "opencode-cli") return true;
       if (s.aiProvider === "copilot-cli") return true;
+      if (s.aiProvider === "antigravity-cli") return true;
       // misconfigured explicit provider — fall through to CLI auto-detect
     }
     // Auto-fallback: use Claude Code CLI if installed and logged in,
@@ -482,6 +504,9 @@ export function useAIProvider() {
           break;
         case "copilot-cli":
           rawResponse = await callCopilotCli(systemPrompt, userPrompt, model);
+          break;
+        case "antigravity-cli":
+          rawResponse = await callAntigravityCli(systemPrompt, userPrompt, model);
           break;
         case "openai-compat":
           rawResponse = await callOpenAICompat(s, systemPrompt, userPrompt);
@@ -534,6 +559,8 @@ export function useAIProvider() {
         return callOpencodeCli(systemPrompt, userPrompt, model);
       case "copilot-cli":
         return callCopilotCli(systemPrompt, userPrompt, model);
+      case "antigravity-cli":
+        return callAntigravityCli(systemPrompt, userPrompt, model);
       case "openai-compat":
         return callOpenAICompat(s, systemPrompt, userPrompt);
       case "ollama":

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -1104,6 +1104,10 @@ const en = {
     aiProviderCopilotCliNotFound: " — not detected",
     aiCopilotCliDetectedHint: "Auth is managed by GitHub Copilot CLI. Verified on first use.",
     aiCopilotCliInfoBox: "GitWand runs `copilot -p` locally. No API key required: it uses the GitHub Copilot authentication stored on your machine. Pick a model below or keep the default.",
+    aiProviderAntigravityCli: "Antigravity CLI (Antigravity subscription)",
+    aiProviderAntigravityCliNotFound: " — not detected",
+    aiAntigravityCliDetectedHint: "Auth is managed by Antigravity CLI. Verified on first use.",
+    aiAntigravityCliInfoBox: "GitWand runs `agy -p` locally. No API key required: it uses the Antigravity authentication stored on your machine. Pick a model below or keep the default.",
     // Per-provider model picker for CLI agents (v2.17)
     aiModelCliDefault: "Default (CLI's own setting)",
     aiModelCliPlaceholder: "e.g. gpt-5-codex",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -1081,6 +1081,10 @@ const es: Locale = {
     aiProviderCopilotCliNotFound: " — no detectado",
     aiCopilotCliDetectedHint: "La autenticación la gestiona GitHub Copilot CLI. Se verifica en el primer uso.",
     aiCopilotCliInfoBox: "GitWand ejecuta `copilot -p` localmente. No se requiere clave API: usa la autenticación de GitHub Copilot almacenada en tu equipo. Elige un modelo abajo o deja el predeterminado.",
+    aiProviderAntigravityCli: "Antigravity CLI (suscripción Antigravity)",
+    aiProviderAntigravityCliNotFound: " — no detectado",
+    aiAntigravityCliDetectedHint: "La autenticación la gestiona Antigravity CLI. Se verifica en el primer uso.",
+    aiAntigravityCliInfoBox: "GitWand ejecuta `agy -p` localmente. No se requiere clave API: usa la autenticación de Antigravity almacenada en tu equipo. Elige un modelo abajo o deja el predeterminado.",
     // Selector de modelo por proveedor para agentes CLI (v2.17)
     aiModelCliDefault: "Predeterminado (ajuste del CLI)",
     aiModelCliPlaceholder: "p. ej. gpt-5-codex",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -1090,6 +1090,10 @@ const fr: Locale = {
     aiProviderCopilotCliNotFound: " — non détecté",
     aiCopilotCliDetectedHint: "L'authentification est gérée par GitHub Copilot CLI. Vérifiée à la première utilisation.",
     aiCopilotCliInfoBox: "GitWand exécute `copilot -p` localement. Aucune clé API requise : il utilise l'authentification GitHub Copilot stockée sur votre machine. Choisissez un modèle ci-dessous ou laissez par défaut.",
+    aiProviderAntigravityCli: "Antigravity CLI (abonnement Antigravity)",
+    aiProviderAntigravityCliNotFound: " — non détecté",
+    aiAntigravityCliDetectedHint: "L'authentification est gérée par Antigravity CLI. Vérifiée à la première utilisation.",
+    aiAntigravityCliInfoBox: "GitWand exécute `agy -p` localement. Aucune clé API requise : il utilise l'authentification Antigravity stockée sur votre machine. Choisissez un modèle ci-dessous ou laissez par défaut.",
     // Sélecteur de modèle par fournisseur pour les agents CLI (v2.17)
     aiModelCliDefault: "Par défaut (réglage du CLI)",
     aiModelCliPlaceholder: "ex. gpt-5-codex",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -1082,6 +1082,10 @@ const ptBR: Locale = {
     aiProviderCopilotCliNotFound: " — não detectado",
     aiCopilotCliDetectedHint: "A autenticação é gerenciada pelo GitHub Copilot CLI. Verificada no primeiro uso.",
     aiCopilotCliInfoBox: "O GitWand executa `copilot -p` localmente. Nenhuma chave de API necessária: usa a autenticação do GitHub Copilot armazenada na sua máquina. Escolha um modelo abaixo ou mantenha o padrão.",
+    aiProviderAntigravityCli: "Antigravity CLI (assinatura Antigravity)",
+    aiProviderAntigravityCliNotFound: " — não detectado",
+    aiAntigravityCliDetectedHint: "A autenticação é gerenciada pelo Antigravity CLI. Verificada no primeiro uso.",
+    aiAntigravityCliInfoBox: "O GitWand executa `agy -p` localmente. Nenhuma chave de API necessária: usa a autenticação do Antigravity armazenada na sua máquina. Escolha um modelo abaixo ou mantenha o padrão.",
     // Seletor de modelo por provedor para agentes CLI (v2.17)
     aiModelCliDefault: "Padrão (configuração do CLI)",
     aiModelCliPlaceholder: "ex. gpt-5-codex",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -1133,6 +1133,10 @@ const zhCN: Locale = {
     aiProviderCopilotCliNotFound: " — 未检测到",
     aiCopilotCliDetectedHint: "身份验证由 GitHub Copilot CLI 管理，首次使用时验证。",
     aiCopilotCliInfoBox: "GitWand 在本地执行 `copilot -p`。无需 API 密钥：它使用存储在你机器上的 GitHub Copilot 身份验证。在下方选择模型或保留默认。",
+    aiProviderAntigravityCli: "Antigravity CLI（Antigravity 订阅）",
+    aiProviderAntigravityCliNotFound: " — 未检测到",
+    aiAntigravityCliDetectedHint: "身份验证由 Antigravity CLI 管理。首次使用时验证。",
+    aiAntigravityCliInfoBox: "GitWand 在本地执行 `agy -p`。无需 API 密钥：它使用存储在你机器上的 Antigravity 身份验证。在下方选择模型或保留默认。",
     // CLI 代理的按提供商模型选择器 (v2.17)
     aiModelCliDefault: "默认（CLI 自身设置）",
     aiModelCliPlaceholder: "例如 gpt-5-codex",

--- a/apps/desktop/src/utils/backend-ai.ts
+++ b/apps/desktop/src/utils/backend-ai.ts
@@ -331,6 +331,76 @@ export async function copilotCliPrompt(
   return await res.text();
 }
 
+// ─── Antigravity CLI provider ──────────────────────────────
+// Mirrors the Claude / Codex / opencode / Copilot CLI shape. Antigravity runs
+// one-shot prompts via `agy -p "<prompt>" [--model <m>]`. Auth is managed by
+// Antigravity itself — GitWand just shells out.
+
+export interface AntigravityCliInfo {
+  found: boolean;
+  path: string;
+  version: string;
+  logged_in: boolean;
+  status: "ok" | "not_found" | "not_logged_in" | "error" | "detected" | string;
+  detail: string;
+}
+
+/**
+ * Detect whether the Antigravity CLI is installed. Safe to call on app boot.
+ */
+export async function detectAntigravityCli(): Promise<AntigravityCliInfo> {
+  if (isTauri()) {
+    return tauriInvoke<AntigravityCliInfo>("detect_antigravity_cli");
+  }
+  try {
+    const res = await devFetch(`${DEV_SERVER}/api/antigravity-cli-detect`);
+    if (res.ok) return (await res.json()) as AntigravityCliInfo;
+  } catch {
+    // Dev server unavailable
+  }
+  return {
+    found: false,
+    path: "",
+    version: "",
+    logged_in: false,
+    status: "not_found",
+    detail: "",
+  };
+}
+
+/**
+ * Run a prompt through the local Antigravity CLI (`agy -p`).
+ */
+export async function antigravityCliPrompt(
+  prompt: string,
+  systemPrompt?: string,
+  cwd?: string,
+  model?: string,
+): Promise<string> {
+  if (isTauri()) {
+    return tauriInvoke<string>("antigravity_cli_prompt", {
+      prompt,
+      systemPrompt,
+      cwd,
+      model,
+    }, IPC_TIMEOUT.NONE);
+  }
+  const res = await devFetch(`${DEV_SERVER}/api/antigravity-cli-prompt`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ prompt, systemPrompt, cwd, model }),
+  });
+  if (!res.ok) {
+    let msg = `antigravity CLI error ${res.status}`;
+    try {
+      const body = await res.json();
+      if (body?.error) msg = body.error;
+    } catch { /* ignore */ }
+    throw new Error(msg);
+  }
+  return await res.text();
+}
+
 /**
  * Open the native terminal with `claude login` so the user can complete
  * the OAuth-style setup. Not a PTY integration — just a one-shot bootstrap.


### PR DESCRIPTION
## Summary
Integrate the Antigravity CLI (`agy`) as a local AI provider option. This adds local AI provider support to the Tauri backend and dev server, exposing the choice to users in the settings panel to allow running local AI commands.

## Changes
- Implement backend detection and execution utilities for Antigravity CLI in Rust/Tauri
- Update the mock dev server to simulate the Antigravity CLI provider
- Add UI option in the settings panel and integrate provider detection
- Include localized strings for the new provider across all supported languages

## Test plan
- [ ] Verify Antigravity CLI backend provider detection works correctly on startup
- [ ] Verify settings panel shows the Antigravity CLI option when available
- [ ] Test prompt execution routing to the local provider
- [ ] Ensure translations load properly in settings across all supported languages