### PR TITLE
ci: automate AUR package publishing on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,3 +251,60 @@ jobs:
           path: website/.vitepress/dist
       - name: Deploy to GitHub Pages
         uses: actions/deploy-pages@v4
+
+  # After Linux and Windows releases succeed, publish the package to the AUR (Arch User Repository)
+  publish-aur:
+    name: Publish to AUR
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Download Linux deb package from release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          # Retry download as assets might take a minute to finalize
+          for attempt in 1 2 3; do
+            if gh release download "${{ github.ref_name }}" \
+                --pattern "GitWand_${VERSION}_amd64.deb" \
+                --dir . \
+                --repo "${{ github.repository }}" 2>&1; then
+              break
+            fi
+            echo "::warning::Deb package not yet available on release ${{ github.ref_name }} (attempt $attempt/3) — sleeping 15s"
+            sleep 15
+          done
+          [ -f "GitWand_${VERSION}_amd64.deb" ] || { echo "::error::Deb package missing or empty after retries"; exit 1; }
+
+      - name: Generate PKGBUILD from template
+        run: |
+          set -euo pipefail
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          
+          # Calculate checksums
+          SHA256_DEB=$(sha256sum "GitWand_${VERSION}_amd64.deb" | awk '{print $1}')
+          SHA256_LICENSE=$(sha256sum LICENSE | awk '{print $1}')
+          
+          # Replace placeholders in template
+          sed -e "s/#VERSION#/${VERSION}/g" \
+              -e "s/#SHA256_DEB#/${SHA256_DEB}/g" \
+              -e "s/#SHA256_LICENSE#/${SHA256_LICENSE}/g" \
+              scripts/PKGBUILD.template > PKGBUILD
+
+          echo "=== Generated PKGBUILD ==="
+          cat PKGBUILD
+
+      - name: Publish AUR package
+        uses: KSXGitHub/github-actions-deploy-aur@v3
+        with:
+          pkgname: gitwand-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+

--- a/scripts/PKGBUILD.template
+++ b/scripts/PKGBUILD.template
@@ -1,0 +1,29 @@
+# Maintainer: Laurent Guitton <laurent@devlint.fr>
+# Contributor: GitWand Release Bot <actions@github.com>
+
+pkgname=gitwand-bin
+pkgver=#VERSION#
+pkgrel=1
+pkgdesc="Automatic Git merge conflict resolution desktop client"
+arch=('x86_64')
+url="https://github.com/devlint/GitWand"
+license=('MIT')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'xdotool' 'nss' 'libxtst')
+provides=('gitwand')
+conflicts=('gitwand')
+source_x86_64=(
+  "https://github.com/devlint/GitWand/releases/download/v${pkgver}/GitWand_${pkgver}_amd64.deb"
+  "LICENSE::https://raw.githubusercontent.com/devlint/GitWand/v${pkgver}/LICENSE"
+)
+sha256sums_x86_64=(
+  '#SHA256_DEB#'
+  '#SHA256_LICENSE#'
+)
+
+package() {
+  # Extract the Debian data file
+  bsdtar -xf data.tar.* -C "${pkgdir}"
+  
+  # Install the license file
+  install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}/"
+}

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -12,7 +12,7 @@ GitWand is available as a desktop app, a CLI tool, and a VS Code extension. Inst
 Download the latest release for your platform:
 
 - **macOS** — `.dmg` (Universal: Apple Silicon + Intel)
-- **Linux** — `.AppImage` or `.deb`
+- **Linux** — `.AppImage` or `.deb` (also available in the AUR as `gitwand-bin`)
 - **Windows** — `.msi` or `.exe`
 
 👉 [Download from GitHub Releases](https://github.com/devlint/GitWand/releases)


### PR DESCRIPTION
## Summary
Automate the publishing of the `gitwand-bin` package to the Arch User Repository (AUR) upon a new release. This simplifies distribution for Arch Linux users and ensures the getting-started guide is updated with the new installation method.

## Changes
- Add a workflow step to automate PKGBUILD generation and publishing to the AUR
- Create a PKGBUILD template script to format the package metadata on release
- Update the Linux section of the getting-started guide to highlight AUR availability

Here are the next steps to set up and trigger the publication:

### 1. AUR Account & SSH Key Setup

  1. Register an account on the AUR Website https://aur.archlinux.org/ if you haven't already.
  2. Generate an SSH key pair on your machine for the AUR integration:
    ssh-keygen -f ~/.ssh/aur_key -t ed25519 -C "your-email@example.com"
    
  3. Upload the public key ( aur_key.pub ) to your AUR profile page under SSH Public Key.

### 2. Configure GitHub Secrets

Add the following secrets to your GitHub repository under Settings > Secrets and variables > Actions > New repository secret:

  •  AUR_USERNAME : Your AUR account username.
  •  AUR_EMAIL : The email address associated with your AUR account.
  •  AUR_SSH_PRIVATE_KEY : The content of the private key ( aur_key ) you generated above.

### 3. Release & Publish

  Once the secrets are set up, publishing to the AUR happens automatically when you tag a release:

  1. Bump the version and prepare the release:
    ./scripts/bump-version.sh X.Y.Z

  2. Commit, tag, and push the changes:
    git add -A
    git commit -m "chore: bump version to X.Y.Z"
    git tag vX.Y.Z
    git push origin main --tags


The  publish-aur  job in the  Release  workflow will pick up the tag, build the Debian package ( .deb ), generate the  PKGBUILD  with matching checksums, and push it directly to the AUR repository at  ssh://aur@aur.archlinux.org/gitwand-bin.git .

──────

### Summary of Work

  • Researched the codebase for AUR integration.
  • Identified the AUR deployment pipeline in release.yml and the template in PKGBUILD.template.
  • Outlined the concrete setup steps (AUR account, SSH key, GitHub secrets, and tagging process) needed to publish the package.

## Test plan
- [ ] Verify that the PKGBUILD template successfully interpolates version and checksum values
- [ ] Test the release workflow to confirm it correctly pushes to the target AUR repository
- [ ] Verify the updated getting-started markdown page renders correctly