### PR TITLE
feat(desktop): serialize per-repo git commands with an RW lock

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -1654,6 +1654,7 @@ dependencies = [
  "dirs 5.0.1",
  "git2",
  "keyring",
+ "parking_lot",
  "portable-pty",
  "rayon",
  "serde",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -51,6 +51,11 @@ base64 = "0.22"
 # Used for data-parallel iteration in workspace_*_all (P3.2). Each repo's
 # git/gh subprocess runs on its own rayon thread instead of in series.
 rayon = "1"
+# Per-repo read/write serialization of git subprocesses (git/repo_lock.rs).
+# `arc_lock` gives owned `Arc`-based guards so a command can hold the lock
+# across its blocking `.output()` with a single-line RAII guard. Already in
+# the tree transitively via tauri, so the direct dep adds ~zero binary cost.
+parking_lot = { version = "0.12", features = ["arc_lock"] }
 portable-pty = "0.9"
 
 # libgit2 bindings for in-process git operations (P3.3). Used in the

--- a/apps/desktop/src-tauri/src/commands/azure.rs
+++ b/apps/desktop/src-tauri/src/commands/azure.rs
@@ -648,6 +648,11 @@ fn rest_list_prs(cwd: &str, state: &str, limit: i64, offset: i64) -> Result<Vec<
     // (merged/closed) leave the stats at 0.
     if !prs.is_empty() {
         if offset == 0 && should_fetch_origin(cwd) {
+            // Write guard: this background PR-list fetch mutates remote-tracking
+            // refs and can collide on `.git/index.lock` with the single-repo
+            // view of the same repo. Held only for the fetch; the read-only
+            // `diff_numstat` calls below don't touch the index.
+            let _repo = crate::git::repo_lock::write(cwd);
             let _ = git_cmd().args(["fetch", "origin"]).current_dir(cwd).output();
         }
         prs.par_iter_mut().for_each(|pr| {

--- a/apps/desktop/src-tauri/src/commands/azure.rs
+++ b/apps/desktop/src-tauri/src/commands/azure.rs
@@ -747,6 +747,12 @@ fn diff_numstat(cwd: &str, source: &str, target: &str) -> (i64, i64, i64) {
 /// Diff is produced locally: fetch both PR branches from origin and diff the
 /// merge base. Azure DevOps has no single unified-patch endpoint.
 fn fetch_pr_branches(cwd: &str, source: &str, target: &str) -> Result<(), String> {
+    // Write guard: fetching the PR branches updates remote-tracking refs and can
+    // race the single-repo view of the same repo on `index.lock`. None of the
+    // three callers (`rest_pr_detail`/`rest_pr_diff`/`rest_pr_files`) hold a repo
+    // lock, so acquiring here can't re-lock (the RwLock is non-reentrant). Held
+    // only for the fetch; the diffs the callers run afterwards are read-only.
+    let _repo = crate::git::repo_lock::write(cwd);
     let out = git_cmd()
         .args(["fetch", "origin", source, target])
         .current_dir(cwd)
@@ -1023,6 +1029,11 @@ fn rest_pr_ready(cwd: &str, number: i64) -> Result<(), String> {
 fn rest_checkout_pr(cwd: &str, number: i64) -> Result<(), String> {
     let (_r, pr) = get_pr_json(cwd, number)?;
     let source = short_ref(&js(&pr, "sourceRefName"));
+    // Write guard: fetch + checkout mutate refs and the worktree, colliding on
+    // `.git/index.lock` with a single-repo view of the same repo. Acquired after
+    // the network `get_pr_json` above so the lock isn't held during the REST
+    // round-trip; held across both git ops (non-reentrant — acquire once).
+    let _repo = crate::git::repo_lock::write(cwd);
     let fetch = git_cmd()
         .args(["fetch", "origin", &source])
         .current_dir(cwd)

--- a/apps/desktop/src-tauri/src/commands/bitbucket.rs
+++ b/apps/desktop/src-tauri/src/commands/bitbucket.rs
@@ -627,6 +627,11 @@ pub(crate) async fn bb_checkout_pr(cwd: String, pr_id: i64) -> Result<(), String
         return Err(format!("Could not determine source branch for PR #{}", pr_id));
     }
 
+    // Write guard: fetch + switch mutate refs and the worktree, colliding on
+    // `.git/index.lock` with a single-repo view of the same repo. Held across
+    // both git ops (the RwLock is non-reentrant — acquire exactly once).
+    let _repo = crate::git::repo_lock::write(&cwd);
+
     // Fetch the branch.
     let fetch = hidden_cmd("git")
         .args(["fetch", "origin", &branch])

--- a/apps/desktop/src-tauri/src/commands/gh.rs
+++ b/apps/desktop/src-tauri/src/commands/gh.rs
@@ -547,6 +547,12 @@ pub(crate) async fn gh_branches(cwd: String) -> Result<Vec<String>, String> {
 }
 
 fn gh_checkout_pr_inner(cwd: String, number: i64) -> Result<(), String> {
+    // Write guard: both paths below fetch a PR ref and check it out — index +
+    // refs + worktree mutations that would collide on `.git/index.lock` with a
+    // single-repo view of the same repo. Held for the whole op; the inner
+    // `github_api::rest_checkout_pr` must NOT re-lock (the RwLock is
+    // non-reentrant), so the guard lives only here.
+    let _repo = repo_lock::write(&cwd);
     if github_api::settings_github_token().is_some() {
         return github_api::rest_checkout_pr(&cwd, number);
     }

--- a/apps/desktop/src-tauri/src/commands/gh.rs
+++ b/apps/desktop/src-tauri/src/commands/gh.rs
@@ -87,6 +87,10 @@ fn gh_list_prs_inner(
     // Enrich +/- stats via local git diff — mirrors rest_list_prs behaviour.
     // Fetch remote branches once so numstat can resolve origin/branch refs.
     if !prs.is_empty() && off == 0 {
+        // Write guard: refreshing remote-tracking refs mutates `.git` and can
+        // race the single-repo view of the same repo on `index.lock`. Held only
+        // around the fetch — the numstat diffs below are read-only.
+        let _repo = repo_lock::write(&cwd);
         let _ = hidden_cmd("git").args(["fetch", "origin"]).current_dir(&cwd).output();
     }
     for pr in &mut prs {

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -1650,6 +1650,11 @@ pub(crate) async fn git_submodule_check_updates(cwd: String) -> Result<Vec<Submo
 /// tracked branch tip. Returns `None` when the comparison can't be made
 /// (offline, no remote, detached with no tracking branch, etc.).
 fn submodule_behind(sub_dir: &std::path::Path, configured_branch: Option<&str>) -> Option<u32> {
+    // Per-submodule write guard: a submodule is a separate working tree with its
+    // own `.git/index.lock`. Two concurrent `git_submodule_updates` polls would
+    // otherwise race the same submodule's fetch. Keyed on the submodule path, so
+    // distinct submodules still fetch in parallel under the caller's rayon loop.
+    let _repo = repo_lock::write(&sub_dir.to_string_lossy());
     // Resolve the upstream ref to compare against.
     let upstream: String = match configured_branch {
         Some(b) => {

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -10,6 +10,7 @@ use rayon::prelude::*;
 
 #[tauri::command]
 pub(crate) async fn git_stage(cwd: String, paths: Vec<String>) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let mut cmd = git_cmd();
     cmd.arg("add").arg("--").current_dir(&cwd);
     for p in &paths {
@@ -25,6 +26,7 @@ pub(crate) async fn git_stage(cwd: String, paths: Vec<String>) -> Result<(), Str
 
 #[tauri::command]
 pub(crate) async fn git_unstage(cwd: String, paths: Vec<String>) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let mut cmd = git_cmd();
     cmd.arg("reset").arg("HEAD").arg("--").current_dir(&cwd);
     for p in &paths {
@@ -40,6 +42,7 @@ pub(crate) async fn git_unstage(cwd: String, paths: Vec<String>) -> Result<(), S
 
 #[tauri::command]
 pub(crate) async fn git_stage_patch(cwd: String, patch: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let mut cmd = git_cmd();
     cmd.args(["apply", "--cached", "--unidiff-zero", "-"])
         .current_dir(&cwd)
@@ -59,6 +62,7 @@ pub(crate) async fn git_stage_patch(cwd: String, patch: String) -> Result<(), St
 
 #[tauri::command]
 pub(crate) async fn git_unstage_patch(cwd: String, patch: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let mut cmd = git_cmd();
     cmd.args(["apply", "--cached", "--reverse", "--unidiff-zero", "-"])
         .current_dir(&cwd)
@@ -85,6 +89,7 @@ pub(crate) async fn git_commit(
     identity_name: Option<String>,
     identity_email: Option<String>,
 ) -> Result<String, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let mut cmd = git_cmd();
     // Inject identity overrides before the `commit` sub-command so git sees them.
@@ -119,6 +124,7 @@ pub(crate) async fn git_commit(
 
 #[tauri::command]
 pub(crate) async fn git_amend_commit(cwd: String, message: String) -> Result<String, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["commit", "--amend", "-m", &message])
@@ -347,6 +353,10 @@ pub(crate) async fn git_split_commit(
 
 #[tauri::command]
 pub(crate) async fn git_push(cwd: String, set_upstream: Option<bool>, force: Option<bool>) -> Result<GitPushPullResult, String> {
+    // Shared guard: push is network-bound and touches only refs, not the
+    // index/worktree, so it need not exclude reads — but it must not overlap a
+    // writer (checkout/pull/rebase) mutating the refs it is about to publish.
+    let _repo = repo_lock::read(&cwd);
     let mut args: Vec<&str> = vec!["push"];
     if set_upstream.unwrap_or(false) {
         args.extend(["--set-upstream", "origin", "HEAD"]);
@@ -383,6 +393,7 @@ pub(crate) async fn git_push(cwd: String, set_upstream: Option<bool>, force: Opt
 
 #[tauri::command]
 pub(crate) async fn git_fetch(cwd: String) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["fetch", "--prune"])
@@ -407,6 +418,7 @@ pub(crate) async fn git_fetch(cwd: String) -> Result<GitPushPullResult, String> 
 
 #[tauri::command]
 pub(crate) async fn git_merge(cwd: String, branch: String) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["merge", &branch])
@@ -435,6 +447,7 @@ pub(crate) async fn git_merge(cwd: String, branch: String) -> Result<GitPushPull
 
 #[tauri::command]
 pub(crate) async fn git_merge_abort(cwd: String) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["merge", "--abort"])
@@ -458,6 +471,7 @@ pub(crate) async fn git_merge_abort(cwd: String) -> Result<GitPushPullResult, St
 
 #[tauri::command]
 pub(crate) async fn git_merge_continue(cwd: String) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["-c", "core.editor=true", "merge", "--continue"])
@@ -490,6 +504,7 @@ pub(crate) async fn git_pull(cwd: String, rebase: bool) -> Result<GitPushPullRes
     // git config, which means a user with `pull.rebase=true` would silently
     // get a rebase even when they picked "merge" in GitWand (and vice-versa).
     let strategy = if rebase { "--rebase" } else { "--no-rebase" };
+    let _repo = repo_lock::write(&cwd);
     let output = git_cmd()
         .args(["pull", strategy])
         .current_dir(&cwd)
@@ -519,6 +534,7 @@ pub(crate) async fn git_rebase_action(cwd: String, action: String) -> Result<(),
         "continue" | "abort" | "skip" => action.as_str(),
         _ => return Err(format!("Unknown rebase action '{}'", action)),
     };
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["rebase", &format!("--{}", arg)])
@@ -564,6 +580,7 @@ pub(crate) async fn git_interactive_rebase(
 ) -> Result<InteractiveRebaseResult, String> {
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    let _repo = repo_lock::write(&cwd);
     let nanos = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_nanos())
@@ -628,6 +645,7 @@ pub(crate) async fn git_interactive_rebase(
 
 #[tauri::command]
 pub(crate) async fn git_discard(cwd: String, paths: Vec<String>, untracked: bool) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     if untracked {
         let mut cmd = git_cmd();
         cmd.arg("clean").arg("-f").arg("--").current_dir(&cwd);
@@ -704,6 +722,7 @@ fn declared_submodule_paths(cwd: &str) -> std::collections::HashSet<String> {
 
 #[tauri::command]
 pub(crate) async fn git_branches(cwd: String) -> Result<Vec<GitBranch>, String> {
+    let _repo = repo_lock::read(&cwd);
     let main_name = get_main_branch_name(&cwd);
     let output = git_cmd()
         .args([
@@ -820,6 +839,7 @@ fn get_main_branch_name(cwd: &str) -> String {
 
 #[tauri::command]
 pub(crate) async fn git_create_branch(cwd: String, name: String, checkout: bool, start_point: Option<String>) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     if checkout {
         let mut args = vec!["checkout", "-b", &name];
         if let Some(ref sp) = start_point { args.push(sp); }
@@ -854,6 +874,7 @@ pub(crate) async fn git_create_branch(cwd: String, name: String, checkout: bool,
 
 #[tauri::command]
 pub(crate) async fn git_switch_branch(cwd: String, name: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["checkout", &name])
@@ -870,6 +891,7 @@ pub(crate) async fn git_switch_branch(cwd: String, name: String) -> Result<(), S
 
 #[tauri::command]
 pub(crate) async fn git_delete_branch(cwd: String, name: String, force: bool) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let flag = if force { "-D" } else { "-d" };
     let _t0 = Instant::now();
     let output = git_cmd()
@@ -919,6 +941,7 @@ pub(crate) async fn git_rename_branch(cwd: String, old_name: String, new_name: S
 
 #[tauri::command]
 pub(crate) async fn git_stash(cwd: String, message: Option<String>) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let mut args: Vec<&str> = vec!["stash", "push", "--include-untracked"];
     let trimmed = message.as_deref().map(str::trim).filter(|s| !s.is_empty());
     if let Some(m) = trimmed {
@@ -941,6 +964,7 @@ pub(crate) async fn git_stash(cwd: String, message: Option<String>) -> Result<()
 
 #[tauri::command]
 pub(crate) async fn git_stash_pop(cwd: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["stash", "pop"])
@@ -957,6 +981,7 @@ pub(crate) async fn git_stash_pop(cwd: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) async fn git_stash_list(cwd: String) -> Result<Vec<StashEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
     let output = git_cmd()
         .args(["stash", "list", "--format=%H%x00%gd%x00%gs%x00%ai"])
         .current_dir(&cwd)
@@ -1011,6 +1036,7 @@ pub(crate) async fn git_stash_list(cwd: String) -> Result<Vec<StashEntry>, Strin
 
 #[tauri::command]
 pub(crate) async fn git_stash_apply(cwd: String, index: usize) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let stash_ref = format!("stash@{{{}}}", index);
     let _t0 = Instant::now();
     let output = git_cmd()
@@ -1030,6 +1056,7 @@ pub(crate) async fn git_stash_apply(cwd: String, index: usize) -> Result<(), Str
 
 #[tauri::command]
 pub(crate) async fn git_stash_drop(cwd: String, index: usize) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let stash_ref = format!("stash@{{{}}}", index);
     let output = git_cmd()
         .args(["stash", "drop", &stash_ref])
@@ -1047,6 +1074,7 @@ pub(crate) async fn git_stash_drop(cwd: String, index: usize) -> Result<(), Stri
 
 #[tauri::command]
 pub(crate) async fn git_stash_clear(cwd: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let output = git_cmd()
         .args(["stash", "clear"])
         .current_dir(&cwd)
@@ -1063,6 +1091,7 @@ pub(crate) async fn git_stash_clear(cwd: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) async fn git_stash_show(cwd: String, index: usize) -> Result<String, String> {
+    let _repo = repo_lock::read(&cwd);
     let stash_ref = format!("stash@{{{}}}", index);
     let output = git_cmd()
         .args(["stash", "show", "-p", &stash_ref])
@@ -1082,6 +1111,7 @@ pub(crate) async fn git_stash_show(cwd: String, index: usize) -> Result<String, 
 
 #[tauri::command]
 pub(crate) async fn git_cherry_pick(cwd: String, hashes: Vec<String>) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let git = git_binary();
     let mut args = vec!["cherry-pick".to_string()];
     args.extend(hashes);
@@ -1125,6 +1155,7 @@ pub(crate) async fn git_cherry_pick_abort(cwd: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) async fn git_cherry_pick_continue(cwd: String) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["cherry-pick", "--continue"])
@@ -1148,6 +1179,7 @@ pub(crate) async fn git_cherry_pick_continue(cwd: String) -> Result<GitPushPullR
 
 #[tauri::command]
 pub(crate) async fn git_checkout_commit(cwd: String, sha: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["checkout", &sha])
@@ -1166,6 +1198,7 @@ pub(crate) async fn git_checkout_commit(cwd: String, sha: String) -> Result<(), 
 
 #[tauri::command]
 pub(crate) async fn git_reset_to_commit(cwd: String, sha: String, mode: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let flag = match mode.as_str() {
         "soft" => "--soft",
         "hard" => "--hard",
@@ -1190,6 +1223,7 @@ pub(crate) async fn git_reset_to_commit(cwd: String, sha: String, mode: String) 
 
 #[tauri::command]
 pub(crate) async fn git_revert_commit(cwd: String, sha: String, mainline: Option<u32>) -> Result<GitPushPullResult, String> {
+    let _repo = repo_lock::write(&cwd);
     let mut args = vec!["revert".to_string(), "--no-edit".to_string()];
     if let Some(m) = mainline {
         args.push("-m".to_string());
@@ -1433,6 +1467,7 @@ pub(crate) async fn git_conflict_check(cwd: String, target_branch: String) -> Re
 
 #[tauri::command]
 pub(crate) async fn git_submodule_list(cwd: String) -> Result<Vec<SubmoduleEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
     let gitmodules = std::path::Path::new(&cwd).join(".gitmodules");
     if !gitmodules.exists() {
         return Ok(Vec::new());
@@ -1534,6 +1569,7 @@ pub(crate) async fn git_submodule_list(cwd: String) -> Result<Vec<SubmoduleEntry
 /// Submodules that are offline / unreachable are skipped silently.
 #[tauri::command]
 pub(crate) async fn git_submodule_check_updates(cwd: String) -> Result<Vec<SubmoduleUpdate>, String> {
+    let _repo = repo_lock::read(&cwd);
     let gitmodules = std::path::Path::new(&cwd).join(".gitmodules");
     if !gitmodules.exists() {
         return Ok(Vec::new());
@@ -1662,6 +1698,7 @@ fn submodule_behind(sub_dir: &std::path::Path, configured_branch: Option<&str>) 
 
 #[tauri::command]
 pub(crate) async fn git_submodule_init(cwd: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let output = git_cmd()
         .args(["submodule", "init"])
         .current_dir(&cwd)
@@ -1678,6 +1715,7 @@ pub(crate) async fn git_submodule_init(cwd: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) async fn git_submodule_update(cwd: String, init: bool, recursive: bool) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let mut cmd = git_cmd();
     cmd.arg("submodule").arg("update");
     if init {
@@ -1708,6 +1746,7 @@ pub(crate) async fn git_submodule_update(cwd: String, init: bool, recursive: boo
 pub(crate) async fn git_submodule_update_one(cwd: String, path: String) -> Result<(), String> {
     // Validate the submodule path stays inside the repo before passing it on.
     safe_repo_path(&cwd, &path)?;
+    let _repo = repo_lock::write(&cwd);
 
     let output = git_cmd()
         .args(["submodule", "update", "--remote", "--rebase", "--init", "--", &path])
@@ -1725,6 +1764,7 @@ pub(crate) async fn git_submodule_update_one(cwd: String, path: String) -> Resul
 
 #[tauri::command]
 pub(crate) async fn git_submodule_add(cwd: String, url: String, path: String) -> Result<(), String> {
+    let _repo = repo_lock::write(&cwd);
     let output = git_cmd()
         .args(["submodule", "add", &url, &path])
         .current_dir(&cwd)
@@ -1746,6 +1786,9 @@ pub(crate) async fn git_submodule_branches(
     cwd: String,
     submodule_path: String,
 ) -> Result<Vec<SubmoduleBranch>, String> {
+    // Lock on the superproject cwd (same key submodule mutations use) so this
+    // read can't race a concurrent `submodule update` rebuilding sub_dir.
+    let _repo = repo_lock::read(&cwd);
     let sub_dir = std::path::Path::new(&cwd).join(&submodule_path);
     if !sub_dir.exists() {
         return Ok(Vec::new());
@@ -1790,6 +1833,7 @@ pub(crate) async fn git_submodule_branches(
 pub(crate) async fn git_commit_submodule_changes(
     cwd: String,
 ) -> Result<HashMap<String, Vec<CommitSubmoduleChange>>, String> {
+    let _repo = repo_lock::read(&cwd);
     let gitmodules = std::path::Path::new(&cwd).join(".gitmodules");
     if !gitmodules.exists() {
         return Ok(HashMap::new());
@@ -2864,6 +2908,7 @@ pub(crate) async fn set_git_config(git_path: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) async fn get_conflicted_files(cwd: String) -> Result<Vec<String>, String> {
+    let _repo = repo_lock::read(&cwd);
     let output = git_cmd()
         .args(["diff", "--name-only", "--diff-filter=U"])
         .current_dir(&cwd)

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -1936,9 +1936,21 @@ pub(crate) async fn git_commit_submodule_changes(
 
 #[tauri::command]
 pub(crate) async fn git_worktree_list(cwd: String) -> Result<Vec<WorktreeEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
+    list_worktrees(&cwd)
+}
+
+/// Plain (non-command) worktree enumeration shared by `git_worktree_list` and
+/// its in-process callers (`git_worktree_status_all`, `agent_session_list`).
+///
+/// Deliberately takes no repo lock: the caller owns whatever guard it needs.
+/// Factoring this out keeps the "command bodies never call one another"
+/// invariant true (see `git/repo_lock.rs`) so the non-reentrant `RwLock` can
+/// never be re-acquired on the same repo from a single command.
+fn list_worktrees(cwd: &str) -> Result<Vec<WorktreeEntry>, String> {
     let output = git_cmd()
         .args(["worktree", "list", "--porcelain"])
-        .current_dir(&cwd)
+        .current_dir(cwd)
         .output()
         .map_err(|e| format!("Failed to list worktrees: {}", e))?;
 
@@ -2117,7 +2129,7 @@ pub(crate) async fn git_worktree_prune(cwd: String) -> Result<(), String> {
 
 #[tauri::command]
 pub(crate) async fn git_worktree_status_all(cwd: String) -> Result<Vec<WorkspaceRepoStatus>, String> {
-    let worktrees = git_worktree_list(cwd).await?;
+    let worktrees = list_worktrees(&cwd)?;
 
     let statuses = worktrees.into_par_iter().map(|wt| {
         let path = wt.path.clone();
@@ -2595,7 +2607,7 @@ fn detect_agent_tool(worktree_path: &str) -> Option<String> {
 pub(crate) async fn agent_session_list(cwd: String) -> Result<Vec<AgentSession>, String> {
     if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
     let path = PathBuf::from(&cwd);
-    let worktrees = git_worktree_list(path.to_string_lossy().to_string()).await?;
+    let worktrees = list_worktrees(&path.to_string_lossy())?;
 
     let mut cwds_cache: HashMap<String, HashSet<String>> = HashMap::new();
 

--- a/apps/desktop/src-tauri/src/commands/read.rs
+++ b/apps/desktop/src-tauri/src/commands/read.rs
@@ -48,6 +48,13 @@ pub(crate) async fn git_status(
     cwd: String,
     pathspec: Option<String>,
 ) -> Result<GitStatus, String> {
+    // Shared guard: block only while a writer mutates this repo (checkout /
+    // fetch / submodule update), so a background status refresh can't observe a
+    // half-rebuilt working tree — the source of the `os error 2` on git status
+    // seen during a submodule-heavy sync. See git::repo_lock. Covers both the
+    // libgit2 fast path and the `git_status_cli` fallback below (a plain
+    // helper, not a command — it does not re-lock).
+    let _repo = repo_lock::read(&cwd);
     // When a pathspec is provided, skip the libgit2 fast path and use the CLI
     // directly — libgit2's status API does not accept a pathspec filter the
     // same way `git status -- <path>` does.
@@ -701,6 +708,7 @@ fn compute_main_commit_count(cwd: &str, branch: &str) -> i32 {
 
 #[tauri::command]
 pub(crate) async fn git_diff(cwd: String, path: String, staged: bool) -> Result<GitDiff, String> {
+    let _repo = repo_lock::read(&cwd);
     let mut cmd = git_cmd();
     if staged {
         cmd.arg("diff").arg("--cached");
@@ -791,6 +799,7 @@ pub(crate) async fn git_log(
     pathspec: Option<String>,
     since: Option<String>,
 ) -> Result<Vec<GitLogEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
     let limit = count.unwrap_or(100);
     let skip  = offset.unwrap_or(0).max(0);
     // Default: current branch only (like `git log`). Pass `all: true` to include all refs.
@@ -1063,6 +1072,7 @@ pub(crate) async fn git_repo_state(cwd: String) -> Result<RepoOperationState, St
 
 #[tauri::command]
 pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, String> {
+    let _repo = repo_lock::read(&cwd);
     let output = git_cmd()
         .args(["show", "-m", "--first-parent", "--format=", &hash])
         .current_dir(&cwd)
@@ -1219,6 +1229,7 @@ pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, 
 
 #[tauri::command]
 pub(crate) async fn git_file_log(cwd: String, path: String, count: Option<u32>) -> Result<Vec<FileLogEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
     let n = count.unwrap_or(50).to_string();
     let fmt = "%H\n%h\n%an\n%aI\n%s\n%b\n---END---";
     let output = git_cmd()
@@ -1236,6 +1247,7 @@ pub(crate) async fn git_file_log(cwd: String, path: String, count: Option<u32>) 
 /// mode: "S" (literal string) | "G" (regex)
 #[tauri::command]
 pub(crate) async fn git_file_log_pickaxe(cwd: String, path: String, search: String, mode: String) -> Result<Vec<FileLogEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
     let flag = if mode == "G" { "-G" } else { "-S" };
     let fmt = "%H\n%h\n%an\n%aI\n%s\n%b\n---END---";
     let output = git_cmd()
@@ -1253,6 +1265,7 @@ pub(crate) async fn git_file_log_pickaxe(cwd: String, path: String, search: Stri
 /// Uses git log -L <start>,<end>:<path> (no --follow; incompatible with -L).
 #[tauri::command]
 pub(crate) async fn git_file_log_range(cwd: String, path: String, start_line: u32, end_line: u32) -> Result<Vec<FileLogEntry>, String> {
+    let _repo = repo_lock::read(&cwd);
     let range = format!("{},{}:{}", start_line, end_line, path);
     let fmt = "%H\n%h\n%an\n%aI\n%s\n%b\n---END---";
     let output = git_cmd()
@@ -1270,6 +1283,7 @@ pub(crate) async fn git_file_log_range(cwd: String, path: String, start_line: u3
 /// algorithm: "histogram" | "patience" | "minimal" | "myers" (default "histogram").
 #[tauri::command]
 pub(crate) async fn git_blame(cwd: String, path: String, algorithm: Option<String>) -> Result<Vec<BlameLine>, String> {
+    let _repo = repo_lock::read(&cwd);
     let algo = algorithm.as_deref().unwrap_or("histogram");
     let diff_algo_flag = format!("--diff-algorithm={}", algo);
     let output = git_cmd()
@@ -1741,6 +1755,7 @@ fn merge_file_preview(
 pub(crate) async fn git_branch_merged(cwd: String) -> Result<Vec<String>, String> {
     use crate::git::cmd::git_cmd;
 
+    let _repo = repo_lock::read(&cwd);
     // Resolve default branch (main / master / trunk / …)
     let default_out = git_cmd()
         .args(["symbolic-ref", "--short", "refs/remotes/origin/HEAD"])

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -92,6 +92,10 @@ pub(crate) async fn workspace_status_all(repos: Vec<WorkspaceRepo>) -> Vec<Works
 #[tauri::command]
 pub(crate) async fn workspace_fetch_all(repos: Vec<WorkspaceRepo>) -> Vec<WorkspaceRepoStatus> {
     repos.par_iter().for_each(|repo| {
+        // Per-repo write guard: fetch mutates refs and can collide on
+        // `.git/index.lock` with a single-repo view of the same repo. Distinct
+        // repos map to distinct locks, so cross-repo rayon parallelism is kept.
+        let _repo = repo_lock::write(&repo.path);
         let _ = git_cmd()
             .args(["fetch", "--all", "--prune"])
             .current_dir(&repo.path)
@@ -107,6 +111,10 @@ pub(crate) async fn workspace_fetch_all(repos: Vec<WorkspaceRepo>) -> Vec<Worksp
 #[tauri::command]
 pub(crate) async fn workspace_pull_all(repos: Vec<WorkspaceRepo>) -> Vec<WorkspaceRepoStatus> {
     repos.par_iter().for_each(|repo| {
+        // Per-repo write guard: pull updates the index/worktree and would race a
+        // single-repo view of the same repo on `.git/index.lock`. Different
+        // repos hold different locks, so the rayon parallelism is preserved.
+        let _repo = repo_lock::write(&repo.path);
         let _ = git_cmd()
             .args(["pull", "--ff-only"])
             .current_dir(&repo.path)

--- a/apps/desktop/src-tauri/src/git/mod.rs
+++ b/apps/desktop/src-tauri/src/git/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod cmd;
 pub(crate) mod libgit2;
 pub(crate) mod parse;
+pub(crate) mod repo_lock;
 
 pub(crate) use cmd::*;
 pub(crate) use libgit2::*;

--- a/apps/desktop/src-tauri/src/git/repo_lock.rs
+++ b/apps/desktop/src-tauri/src/git/repo_lock.rs
@@ -1,0 +1,127 @@
+//! Per-repository serialization of git subprocesses.
+//!
+//! # Why
+//!
+//! A git working tree is guarded by a single `.git/index.lock`. Two git
+//! processes that both want to touch the index/refs/worktree of the *same*
+//! repo cannot run concurrently: the second dies with
+//!
+//! ```text
+//! fatal: Unable to create '.../.git/index.lock': File exists.
+//! ```
+//!
+//! GitWand fires several commands at once — e.g. a background refresh runs
+//! `git status` / `git stash list` / `git log` while the user triggers a sync
+//! (`git fetch` + `git checkout`). Two failure modes were observed in the wild
+//! (submodule-heavy repo, "click origin/main to sync"):
+//!
+//! - the mutating op collides on `index.lock` (the message above);
+//! - a *read* spawned with `current_dir(cwd)` fails with
+//!   `No such file or directory (os error 2)` because a concurrent checkout /
+//!   submodule update was recreating a working-tree directory out from under
+//!   it at spawn time.
+//!
+//! # How
+//!
+//! One `RwLock` per repo, keyed by `cwd`. Reads take the shared guard (many
+//! concurrent readers of one repo are fine); anything that mutates the index,
+//! refs, or working tree takes the exclusive guard. Different repos map to
+//! different locks, so cross-repo parallelism (the `workspace_*_all` rayon hot
+//! paths) is unaffected — the lock only serializes operations that would
+//! genuinely contend on the same `index.lock`.
+//!
+//! Keying is by the raw `cwd` string (no `rev-parse` spawn on the hot path).
+//! For the contended case — a repo's own status/log/stash racing its
+//! checkout/fetch — every caller passes the same `cwd`, so they share a lock.
+//!
+//! # Discipline
+//!
+//! Acquire the guard at the top of a `#[tauri::command]` body and hold it for
+//! the whole command. Never acquire a second repo guard while holding one
+//! (the `RwLock` is non-reentrant — re-locking the same repo would deadlock).
+//! GitWand's command bodies each spawn their git subprocess directly and do
+//! not call one another, so this holds by construction.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+use parking_lot::{ArcRwLockReadGuard, ArcRwLockWriteGuard, RawRwLock, RwLock};
+
+/// Shared guard: multiple readers of a repo proceed together, all blocked
+/// while a writer holds the lock.
+pub(crate) type RepoReadGuard = ArcRwLockReadGuard<RawRwLock, ()>;
+/// Exclusive guard: blocks every other reader and writer on the same repo.
+pub(crate) type RepoWriteGuard = ArcRwLockWriteGuard<RawRwLock, ()>;
+
+/// Registry of per-repo locks. `Mutex` only guards the map itself (cheap,
+/// never held across a git call); the returned `Arc<RwLock<()>>` is what the
+/// git subprocess is serialized on.
+static LOCKS: OnceLock<Mutex<HashMap<String, Arc<RwLock<()>>>>> = OnceLock::new();
+
+/// Fetch (or create) the lock for `cwd`. Entries are tiny and bounded by the
+/// number of distinct repo paths the session has touched, so the map is left
+/// to grow rather than reference-counted for eviction.
+fn lock_for(cwd: &str) -> Arc<RwLock<()>> {
+    let map = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut guard = map.lock().unwrap();
+    guard
+        .entry(cwd.to_string())
+        .or_insert_with(|| Arc::new(RwLock::new(())))
+        .clone()
+}
+
+/// Acquire the shared (read) guard for `cwd`. Use for commands that only
+/// *inspect* the repo (status, log, diff, stash list, …). The returned guard
+/// is `#[must_use]` (via the underlying `ArcRwLockReadGuard`): bind it to a
+/// named local (`let _repo = …`) so it lives for the whole command body.
+pub(crate) fn read(cwd: &str) -> RepoReadGuard {
+    lock_for(cwd).read_arc()
+}
+
+/// Acquire the exclusive (write) guard for `cwd`. Use for any command that
+/// mutates the index, refs, or working tree (fetch, pull, merge, checkout,
+/// stash push/pop, submodule update, discard, …).
+pub(crate) fn write(cwd: &str) -> RepoWriteGuard {
+    lock_for(cwd).write_arc()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_cwd_shares_one_lock() {
+        let a = lock_for("/tmp/repo-a");
+        let b = lock_for("/tmp/repo-a");
+        assert!(Arc::ptr_eq(&a, &b), "same cwd must resolve to the same lock");
+    }
+
+    #[test]
+    fn distinct_cwd_distinct_locks() {
+        let a = lock_for("/tmp/repo-one");
+        let b = lock_for("/tmp/repo-two");
+        assert!(!Arc::ptr_eq(&a, &b), "different repos must not contend");
+    }
+
+    #[test]
+    fn readers_share_writer_excludes() {
+        // Two read guards on the same repo coexist.
+        let _r1 = read("/tmp/repo-rw");
+        let _r2 = read("/tmp/repo-rw");
+        // A writer cannot be taken while a reader is held.
+        assert!(
+            lock_for("/tmp/repo-rw").try_write_arc().is_none(),
+            "writer must be excluded while a reader holds the lock"
+        );
+    }
+
+    #[test]
+    fn distinct_repos_do_not_block() {
+        let _w = write("/tmp/repo-x");
+        // A writer on another repo is unaffected.
+        assert!(
+            lock_for("/tmp/repo-y").try_write_arc().is_some(),
+            "a writer on one repo must not block another repo"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/git/repo_lock.rs
+++ b/apps/desktop/src-tauri/src/git/repo_lock.rs
@@ -39,8 +39,12 @@
 //! Acquire the guard at the top of a `#[tauri::command]` body and hold it for
 //! the whole command. Never acquire a second repo guard while holding one
 //! (the `RwLock` is non-reentrant — re-locking the same repo would deadlock).
-//! GitWand's command bodies each spawn their git subprocess directly and do
-//! not call one another, so this holds by construction.
+//! To keep that safe by construction, command bodies must never call another
+//! `#[tauri::command]`: when one command needs another's logic, that logic is
+//! factored into a plain (non-command, unlocked) helper both share, and the
+//! caller owns the single guard. See `list_worktrees` in `commands/ops.rs`
+//! (shared by `git_worktree_list`, `git_worktree_status_all`, and
+//! `agent_session_list`) for the pattern.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, OnceLock};


### PR DESCRIPTION
## Summary
Git subprocesses that run concurrently against the same repository can corrupt the index or refs. This change introduces a per-repository read-write lock so that mutating git operations are serialized while reads and pushes can still proceed in parallel.

## Changes
- Add `git/repo_lock.rs` implementing a per-repository RW lock backed by `parking_lot`.
- Acquire the writer lock around mutating git commands in `commands/ops.rs`.
- Acquire the shared reader lock around read operations and push in `commands/read.rs`.
- Register the new `repo_lock` module in `git/mod.rs`.
- Add the `parking_lot` dependency in `Cargo.toml`/`Cargo.lock`.

## Test plan
- [ ] Run concurrent mutating git operations on one repo and verify the index/refs stay intact.
- [ ] Confirm reads and pushes can run in parallel without deadlocking.
- [ ] `cargo build` and existing desktop tests pass.
- [ ] Manually exercise commit/merge/push flows in the desktop app.