### PR TITLE
feat(settings): hide terminal and file explorer on nav by default

### DIFF
--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -268,13 +268,13 @@ const defaultSettings: Settings = {
   terminalShell: "",
   terminalMode: "bottom",
   terminalPrevMode: "bottom",
-  terminalHideOnNav: false,
+  terminalHideOnNav: true,
   terminalContextMenu: true,
   terminalCopyOnSelect: false,
   terminalPasteOnRightClick: false,
   filesMode: "floating",
   filesPrevMode: "floating",
-  filesHideOnNav: false,
+  filesHideOnNav: true,
 };
 
 function loadSettings(): Settings {

--- a/apps/desktop/src/composables/useSettings.ts
+++ b/apps/desktop/src/composables/useSettings.ts
@@ -347,7 +347,7 @@ export interface AppSettings {
   filesMode: FilesMode;
   /** Layout to restore when leaving fullscreen. Never "fullscreen" itself. */
   filesPrevMode: Exclude<FilesMode, "fullscreen">;
-  /** Hide the File Explorer when switching views from the dock. Default: false. */
+  /** Hide the File Explorer when switching views from the dock. Default: true. */
   filesHideOnNav: boolean;
 }
 
@@ -425,13 +425,13 @@ export const defaultAppSettings: AppSettings = {
   terminalShell:                     "",
   terminalMode:                      "bottom",
   terminalPrevMode:                  "bottom",
-  terminalHideOnNav:                 false,
+  terminalHideOnNav:                 true,
   terminalContextMenu:               true,
   terminalCopyOnSelect:              false,
   terminalPasteOnRightClick:         false,
   filesMode:                         "floating",
   filesPrevMode:                     "floating",
-  filesHideOnNav:                    false,
+  filesHideOnNav:                    true,
 };
 
 const SETTINGS_KEY = "gitwand-settings";


### PR DESCRIPTION
## Summary
Changes the default behavior so the terminal and file explorer are hidden when switching views, reducing visual clutter and matching more expected behavior.

## Changes
- Update the default settings so the terminal is hidden on view navigation
- Update the default settings so the file explorer is hidden on view navigation
- Keep the `AppSettings` interface and `SettingsPanel` defaults in sync

## Test plan
- [ ] Open a repo and switch views; confirm terminal and file explorer are hidden by default
- [ ] Toggle the settings back on and verify the panels stay visible on navigation
- [ ] Confirm existing user settings are preserved on upgrade
- [ ] Run `pnpm --filter @gitwand/desktop test`