### PR TITLE
fix(CommitGraph): reattach ResizeObserver via ref watch

### DIFF
--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -1022,15 +1022,31 @@ watch(() => props.commits.length, () => {
 });
 
 let _ro: ResizeObserver | null = null;
-onMounted(() => {
-  if (scrollContainer.value) {
-    clientHeight.value = scrollContainer.value.clientHeight;
-    _ro = new ResizeObserver(() => {
-      if (scrollContainer.value) clientHeight.value = scrollContainer.value.clientHeight;
-    });
-    _ro.observe(scrollContainer.value);
-  }
-});
+
+function measureViewport() {
+  if (scrollContainer.value) clientHeight.value = scrollContainer.value.clientHeight;
+}
+
+// The whole component (including `.cg-scroll`) is behind `v-if="displayCommits.length > 0"`,
+// so the scroll container only enters the DOM once commits are loaded. If the graph view
+// mounts before commits arrive, `scrollContainer` is null and a mount-only observer would
+// never attach — clientHeight would stay 0, fall back to 600, and the rows below that never
+// render nor recalculate on resize. Watch the ref instead so the observer (re)attaches every
+// time the element appears (initial load, repo switch, filter-mode toggle).
+watch(
+  scrollContainer,
+  (el) => {
+    _ro?.disconnect();
+    _ro = null;
+    if (el) {
+      measureViewport();
+      _ro = new ResizeObserver(() => measureViewport());
+      _ro.observe(el);
+    }
+  },
+  { immediate: true, flush: "post" },
+);
+
 onUnmounted(() => {
   _ro?.disconnect();
   _ro = null;


### PR DESCRIPTION
## Summary
The commit graph's scroll container lives behind a `v-if` and is absent from the DOM on mount until commits load, so the ResizeObserver attached at mount time never observed the element. This change watches the ref instead of the mount lifecycle, guaranteeing the observer (re)attaches every time the element appears.

## Changes
- Watch the scroll container ref rather than the component `onMounted` hook to attach the ResizeObserver.
- Ensure the observer is (re)attached each time the container enters the DOM after commits load.
- Clean up the previous observer before reattaching to avoid duplicate observations.

## Test plan
- [ ] Open a repository and confirm the commit graph viewport sizes correctly on first load.
- [ ] Switch away and back to the commit graph and verify the viewport still resizes.
- [ ] Resize the window and confirm the graph reflows without stale dimensions.
- [ ] Verify no observer leaks by toggling the graph visibility repeatedly.