### PR TITLE
feat(desktop): hide empty Changes dock entry by default

### DIFF
--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -932,6 +932,13 @@ watch(viewMode, async (mode) => {
   }
 });
 
+// When the Changes entry hides itself on a clean tree (opt-in), a user sitting
+// on the Changes view would be left staring at an empty pane — fall back to the
+// Git Tree instead.
+watch([() => repoFiles.value.length, () => settings.value.dockHideChangesWhenEmpty], ([count, hideWhenEmpty]) => {
+  if (hideWhenEmpty && count === 0 && viewMode.value === "changes") viewMode.value = "graph";
+});
+
 // Also refresh the dashboard sidebar data when the repo itself changes.
 watch(hasRepo, (has) => {
   if (has && viewMode.value === "dashboard") {

--- a/apps/desktop/src/components/AppDock.vue
+++ b/apps/desktop/src/components/AppDock.vue
@@ -51,6 +51,8 @@ const vertical = computed(() => settings.value.dockVertical);
 const idleOpacity = computed(() => settings.value.dockIdleOpacity ?? 0.45);
 
 function isHidden(id: DockEntryId): boolean {
+  // Changes hides itself while the working tree is clean, when the user opted in.
+  if (id === "changes" && settings.value.dockHideChangesWhenEmpty && !props.changesCount) return true;
   return isDockEntryHidden(id, settings.value);
 }
 
@@ -225,6 +227,12 @@ function removeFromDock(id: DockEntryId) {
 function setAsStartup(id: DockEntryId) {
   if (id === "changes") return; // not a valid startup view
   patch({ startupView: id });
+  closeMenu();
+}
+
+const hideChangesWhenEmpty = computed(() => settings.value.dockHideChangesWhenEmpty);
+function toggleHideChangesWhenEmpty() {
+  patch({ dockHideChangesWhenEmpty: !settings.value.dockHideChangesWhenEmpty });
   closeMenu();
 }
 
@@ -519,6 +527,11 @@ onBeforeUnmount(() => {
           :aria-checked="isStartup(entryTarget)" @click="setAsStartup(entryTarget)">
           {{ t('settings.dock.menu.setStartup') }}
           <span class="dock-menu-check">{{ isStartup(entryTarget) ? '✓' : '' }}</span>
+        </button>
+        <button v-if="entryTarget === 'changes'" class="dock-menu-item" role="menuitemcheckbox"
+          :aria-checked="hideChangesWhenEmpty" @click="toggleHideChangesWhenEmpty">
+          {{ t('settings.dock.menu.hideChangesWhenEmpty') }}
+          <span class="dock-menu-check">{{ hideChangesWhenEmpty ? '✓' : '' }}</span>
         </button>
         <div class="dock-menu-sep" role="separator"></div>
       </template>

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -158,6 +158,7 @@ interface Settings {
   dockHidePrs: boolean;
   dockHideTerminal: boolean;
   dockHideFiles: boolean;
+  dockHideChangesWhenEmpty: boolean;
   dockIconsOnly: boolean;
   dockVertical: boolean;
   dockIdleOpacity: number;
@@ -237,6 +238,7 @@ const defaultSettings: Settings = {
   dockHidePrs: false,
   dockHideTerminal: false,
   dockHideFiles: false,
+  dockHideChangesWhenEmpty: false,
   dockIconsOnly: false,
   dockVertical: false,
   dockIdleOpacity: 0.45,
@@ -1541,6 +1543,17 @@ function deleteReleaseNoteTemplate(id: string) {
               <span>{{ t('settings.dock.gitTreeLocked') }}</span>
             </label>
             <span class="sp-hint">{{ t('settings.dock.lockedHint') }}</span>
+          </div>
+
+          <!-- Hide Changes when the working tree is clean -->
+          <div class="sp-row sp-row--checkbox">
+            <label class="sp-checkbox-label" for="setting-dock-hide-changes-empty">
+              <input id="setting-dock-hide-changes-empty" type="checkbox" class="sp-checkbox"
+                :checked="settings.dockHideChangesWhenEmpty"
+                @change="updateSetting('dockHideChangesWhenEmpty', ($event.target as HTMLInputElement).checked)" />
+              <span>{{ t('settings.dock.hideChangesWhenEmpty.label') }}</span>
+            </label>
+            <span class="sp-hint">{{ t('settings.dock.hideChangesWhenEmpty.help') }}</span>
           </div>
 
           <!-- ── Appearance ── -->

--- a/apps/desktop/src/components/SettingsPanel.vue
+++ b/apps/desktop/src/components/SettingsPanel.vue
@@ -238,7 +238,7 @@ const defaultSettings: Settings = {
   dockHidePrs: false,
   dockHideTerminal: false,
   dockHideFiles: false,
-  dockHideChangesWhenEmpty: false,
+  dockHideChangesWhenEmpty: true,
   dockIconsOnly: false,
   dockVertical: false,
   dockIdleOpacity: 0.45,

--- a/apps/desktop/src/composables/useSettings.ts
+++ b/apps/desktop/src/composables/useSettings.ts
@@ -208,6 +208,8 @@ export interface AppSettings {
   dockHideTerminal: boolean;
   /** Hide the Files (File Explorer) tile from the bottom dock. */
   dockHideFiles: boolean;
+  /** Hide the Changes entry from the dock while the working tree is clean. */
+  dockHideChangesWhenEmpty: boolean;
   /** Show only icons in the bottom dock (hide text labels). */
   dockIconsOnly: boolean;
   /** Lay the dock out vertically (column) with vertically-oriented labels. */
@@ -394,6 +396,7 @@ export const defaultAppSettings: AppSettings = {
   dockHidePrs: false,
   dockHideTerminal: false,
   dockHideFiles: false,
+  dockHideChangesWhenEmpty: false,
   dockIconsOnly: false,
   dockVertical: false,
   dockIdleOpacity: 0.45,

--- a/apps/desktop/src/composables/useSettings.ts
+++ b/apps/desktop/src/composables/useSettings.ts
@@ -396,7 +396,7 @@ export const defaultAppSettings: AppSettings = {
   dockHidePrs: false,
   dockHideTerminal: false,
   dockHideFiles: false,
-  dockHideChangesWhenEmpty: false,
+  dockHideChangesWhenEmpty: true,
   dockIconsOnly: false,
   dockVertical: false,
   dockIdleOpacity: 0.45,

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -1297,6 +1297,10 @@ const en = {
       showFiles: "Show Files",
       gitTreeLocked: "Git Tree & Changes",
       lockedHint: "Always shown — cannot be removed.",
+      hideChangesWhenEmpty: {
+        label: "Hide Changes when clean",
+        help: "Hide the Changes entry while the working tree has no changes.",
+      },
       iconsOnly: {
         label: "Icons only",
         help: "Hide the text labels in the dock and show only icons.",
@@ -1333,6 +1337,7 @@ const en = {
       menu: {
         remove: "Remove from dock",
         setStartup: "Set as startup view",
+        hideChangesWhenEmpty: "Hide when clean",
         lock: "Lock dock",
         unlock: "Unlock dock",
         hideText: "Hide text",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -1272,6 +1272,10 @@ const es: Locale = {
       showFiles: "Mostrar archivos",
       gitTreeLocked: "Árbol Git y Cambios",
       lockedHint: "Siempre visibles — no se pueden quitar.",
+      hideChangesWhenEmpty: {
+        label: "Ocultar Cambios si está limpio",
+        help: "Oculta la entrada Cambios cuando el árbol de trabajo no tiene cambios.",
+      },
       iconsOnly: {
         label: "Solo iconos",
         help: "Oculta las etiquetas del dock y muestra solo los iconos.",
@@ -1308,6 +1312,7 @@ const es: Locale = {
       menu: {
         remove: "Quitar del dock",
         setStartup: "Establecer como vista de inicio",
+        hideChangesWhenEmpty: "Ocultar si está limpio",
         lock: "Bloquear el dock",
         unlock: "Desbloquear el dock",
         hideText: "Ocultar texto",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -1281,6 +1281,10 @@ const fr: Locale = {
       showFiles: "Afficher les fichiers",
       gitTreeLocked: "Arbre Git & Modifications",
       lockedHint: "Toujours affichés — non supprimables.",
+      hideChangesWhenEmpty: {
+        label: "Masquer Modifications si propre",
+        help: "Masque l'entrée Modifications quand l'arbre de travail n'a aucune modification.",
+      },
       iconsOnly: {
         label: "Icônes uniquement",
         help: "Masque les libellés du dock et n'affiche que les icônes.",
@@ -1317,6 +1321,7 @@ const fr: Locale = {
       menu: {
         remove: "Retirer du dock",
         setStartup: "Définir comme vue de démarrage",
+        hideChangesWhenEmpty: "Masquer si propre",
         lock: "Verrouiller le dock",
         unlock: "Déverrouiller le dock",
         hideText: "Masquer le texte",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -1272,6 +1272,10 @@ const ptBR: Locale = {
       showFiles: "Mostrar arquivos",
       gitTreeLocked: "\u00c1rvore Git e Altera\u00e7\u00f5es",
       lockedHint: "Sempre vis\u00edveis \u2014 n\u00e3o podem ser removidos.",
+      hideChangesWhenEmpty: {
+        label: "Ocultar Altera\u00e7\u00f5es quando limpo",
+        help: "Oculta a entrada Altera\u00e7\u00f5es quando a \u00e1rvore de trabalho n\u00e3o tem altera\u00e7\u00f5es.",
+      },
       iconsOnly: {
         label: "Apenas \u00edcones",
         help: "Oculta os r\u00f3tulos do dock e mostra apenas os \u00edcones.",
@@ -1308,6 +1312,7 @@ const ptBR: Locale = {
       menu: {
         remove: "Remover do dock",
         setStartup: "Definir como vista inicial",
+        hideChangesWhenEmpty: "Ocultar quando limpo",
         lock: "Bloquear o dock",
         unlock: "Desbloquear o dock",
         hideText: "Ocultar texto",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -1017,6 +1017,10 @@ const zhCN: Locale = {
       showFiles: "显示文件",
       gitTreeLocked: "Git 树和更改",
       lockedHint: "始终显示 — 无法移除。",
+      hideChangesWhenEmpty: {
+        label: "工作区干净时隐藏「更改」",
+        help: "当工作区没有更改时，隐藏「更改」入口。",
+      },
       iconsOnly: {
         label: "仅图标",
         help: "隐藏停靠栏中的文字标签，仅显示图标。",
@@ -1053,6 +1057,7 @@ const zhCN: Locale = {
       menu: {
         remove: "从停靠栏移除",
         setStartup: "设为启动视图",
+        hideChangesWhenEmpty: "干净时隐藏",
         lock: "锁定停靠栏",
         unlock: "解锁停靠栏",
         hideText: "隐藏文字",


### PR DESCRIPTION
## Summary
Introduces a configuration to hide the **Changes** dock button/view when the repository working tree is clean, decluttering the navigation dock. This behavior is enabled by default and automatically falls back to the Git Tree view if the Changes dock entry becomes hidden while active.

## Why

The Changes entry is only actionable when the working tree is dirty — on a clean repo it's a dead button that navigates to an empty pane. Keeping it permanently docked adds visual noise and invites clicks that lead nowhere. Hiding it while the tree is clean keeps the dock focused on what the user can actually do right now, and surfacing it automatically the moment changes appear means no functionality is lost. The Git Tree fallback avoids stranding a user on a view that's about to vanish out from under them.

## Changes
- Implement the `dockHideChangesWhenEmpty` setting, enabled by default
- Add settings panel option to toggle the visibility behavior of the clean Changes dock
- Filter out the Changes entry from the workspace dock when clean and the setting is enabled
- Fall back to the Git Tree view in the main App wrapper if Changes becomes hidden
- Add localization strings for the new setting in English, Spanish, French, Portuguese, and Chinese

## Test plan
- [ ] Verify that the Changes dock entry is hidden by default when there are no modifications
- [ ] Verify that modifying a file immediately shows the Changes dock entry
- [ ] Verify that toggling the setting off in the Settings Panel keeps the Changes entry visible at all times
- [ ] Verify that committing or discarding the last change while viewing the Changes panel correctly switches focus to the Git Tree view