### PR TITLE
fix(desktop): migrate launch telemetry from Umami to Aptabase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Anonymous launch telemetry moved from Umami to Aptabase** — Umami Cloud silently dropped every launch ping (it filters non-browser User-Agents, replying HTTP 200 with a `{"beep":"boop"}` decoy and recording nothing). GitWand now sends the same anonymous, release-only "launch" event through Aptabase (App-Key authenticated, no UA/bot filtering). The GDPR-safe random `install_id` is unchanged; app version and locale are captured automatically by the Aptabase plugin. Dropped the direct `ureq` and `sys-locale` Rust dependencies.
+
 ### Fixed
 
 - **PR base-branch picker only showed `main` on Azure DevOps** — the "into" branch dropdown was built solely from local git refs, which on an Azure clone often hold just `origin/main`, so server-side branches never appeared. The forge is now queried for its branches (`ForgeProvider.listBranches`) and those heads are merged into the picker, falling back to local refs when unavailable. Implemented across all forges for parity: Azure (`az_branches`, refs API), GitHub (`gh_branches`, REST/`gh` CLI), GitLab (`gl_branches`, `glab` CLI), and Bitbucket (`bb_branches`, refs API).

--- a/apps/desktop/src-tauri/CLAUDE.md
+++ b/apps/desktop/src-tauri/CLAUDE.md
@@ -139,7 +139,7 @@ Build manuel : `cargo build --example parity-probe` → `target/debug/examples/p
 ## Dépendances Rust notables
 
 - `tauri 2.x` avec plugins séparés : `dialog`, `shell`, `global-shortcut`, `updater`, `process`
-- Pas de dépendances HTTP/async — Tauri gère la fenêtre, git est synchrone
+- Une seule dépendance HTTP/async : `reqwest` + `tokio`, tirés transitivement par `tauri-plugin-aptabase` (télémétrie de lancement anonyme, release-only). Le reste du backend reste synchrone.
 - `serde` / `serde_json` pour la sérialisation des types vers le frontend
 - `dirs 5` pour la résolution des chemins système
 - `base64 0.22` pour l'encodage des contenus binaires

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -595,6 +595,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,7 +695,7 @@ dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -958,7 +964,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1165,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1315,12 +1321,21 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -1333,6 +1348,12 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1350,12 +1371,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1438,6 +1475,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1659,9 +1697,9 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sys-locale",
  "tauri",
  "tauri-build",
+ "tauri-plugin-aptabase",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
@@ -1669,7 +1707,6 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
- "ureq",
  "uuid",
 ]
 
@@ -1805,6 +1842,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1946,6 +2002,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1972,6 +2029,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,9 +2062,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.4",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2656,7 +2731,24 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2709,7 +2801,19 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.13.0",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
  "libc",
 ]
 
@@ -3065,10 +3169,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3087,13 +3228,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix 0.31.3",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3663,6 +3820,46 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3790,7 +3987,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3799,7 +3996,6 @@ version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -3847,7 +4043,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3872,6 +4068,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4128,6 +4330,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4344,7 +4558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4506,6 +4720,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4616,7 +4851,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4713,6 +4948,26 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-aptabase"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "075ebe083b5f311bdfbf436f8383d316dfb12267be5fd977b57d7701bdb99987"
+dependencies = [
+ "futures",
+ "log",
+ "os_info",
+ "rand 0.9.4",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sys-locale",
+ "tauri",
+ "tauri-plugin",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -4853,7 +5108,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -4992,7 +5247,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5126,6 +5381,16 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.6.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -5366,7 +5631,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5406,7 +5671,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5467,23 +5732,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "once_cell",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "url",
- "webpki-roots 0.26.11",
-]
 
 [[package]]
 name = "url"
@@ -5826,24 +6074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.8",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5907,7 +6137,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6032,6 +6262,17 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -964,7 +964,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1171,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2731,7 +2731,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3250,7 +3250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3987,7 +3987,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4043,7 +4043,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4558,7 +4558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4953,8 +4953,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-aptabase"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075ebe083b5f311bdfbf436f8383d316dfb12267be5fd977b57d7701bdb99987"
+source = "git+https://github.com/devlint/tauri-plugin-aptabase?rev=a868ab1db74b6ae6616389022680881a2c352e1c#a868ab1db74b6ae6616389022680881a2c352e1c"
 dependencies = [
  "futures",
  "log",
@@ -5247,7 +5246,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5631,7 +5630,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5671,7 +5670,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6137,7 +6136,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -76,16 +76,17 @@ git2 = { version = "0.20.4", default-features = false, features = ["vendored-lib
 # Windows Credential Manager on Windows.
 keyring = "2"
 
-# Lightweight blocking HTTP client for the anonymous launch-count ping.
-# No async/tokio dependency — runs in a detached thread. Only used in
-# release builds (cfg(not(debug_assertions))).
-ureq = { version = "2", default-features = false, features = ["tls", "json"] }
+# Anonymous launch telemetry via Aptabase (privacy-first analytics for
+# desktop/Tauri apps). Replaced the previous Umami ping: Umami Cloud
+# filters non-browser User-Agents and silently dropped every event
+# (HTTP 200 + `{"beep":"boop"}` decoy, nothing recorded). Aptabase
+# authenticates by App Key, so there is no UA/bot filtering. Only used in
+# release builds (cfg(not(debug_assertions))). Pulls in reqwest + tokio
+# transitively — see Task 5 measurement note in the migration plan.
+tauri-plugin-aptabase = "1.0.0"
 
 # Anonymous install ID generation (v4 random UUID, stored on first launch).
 uuid = { version = "1", features = ["v4"] }
-
-# Cross-platform system locale detection (macOS / Linux / Windows).
-sys-locale = "0.3"
 
 # ─── Release profile (P2.4) ──────────────────────────────────
 #

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -115,3 +115,17 @@ opt-level = 3
 inherits = "release"
 debug = true
 strip = false
+
+# ─── Patch: tauri-plugin-aptabase tokio runtime panic ────────
+#
+# Upstream 1.0.0 spawns via raw `tokio::spawn` in `src/client.rs` instead of
+# `tauri::async_runtime::spawn`, which panics at startup in release builds
+# ("there is no reactor running, must be called from the context of a
+# Tokio 1.x runtime") — see aptabase/tauri-plugin-aptabase#16 and #22. The
+# fix is queued upstream in PR #30 (unmerged as of this writing). Rather than
+# depend on a random third-party fork carrying that unreviewed PR, we
+# cherry-picked the exact one-line fix onto a fork under our own GitHub
+# account (`devlint/tauri-plugin-aptabase`, branch `fix/tokio-runtime-panic`)
+# with no other changes and no dependency bumps.
+[patch.crates-io]
+tauri-plugin-aptabase = { git = "https://github.com/devlint/tauri-plugin-aptabase", rev = "a868ab1db74b6ae6616389022680881a2c352e1c" }

--- a/apps/desktop/src-tauri/src/commands/network.rs
+++ b/apps/desktop/src-tauri/src/commands/network.rs
@@ -22,6 +22,9 @@
 //! The probe runs synchronously in the Tauri command thread; `TcpStream::
 //! connect_timeout` bounds the wait so a dropped wifi connection cannot
 //! freeze the UI.
+//!
+//! (This module still adds no direct HTTP dependency; an HTTP client only
+//! exists transitively via the Aptabase telemetry plugin.)
 
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::time::Duration;

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -13,6 +13,8 @@ pub(crate) use crate::git::*;
 
 use tauri::{Emitter, Manager};
 use tauri_plugin_global_shortcut::GlobalShortcutExt;
+#[cfg(not(debug_assertions))]
+use tauri_plugin_aptabase::EventTracker;
 
 /// GitWand Desktop — Tauri backend
 ///
@@ -234,7 +236,12 @@ pub fn git_commit_submodule_changes_parity(
 
 // ─── Tauri entry point ─────────────────────────────────────
 
-#[cfg_attr(mobile, tauri::mobile_entry_point)]
+/// Aptabase App Key for anonymous launch telemetry. This is a public client
+/// identifier (format `A-EU-*` / `A-US-*`), not a secret — same trust model
+/// as the previous public Umami website ID. Only used in release builds.
+#[cfg(not(debug_assertions))]
+const APTABASE_APP_KEY: &str = "A-EU-3954664786";
+
 #[cfg(not(debug_assertions))]
 /// Returns the anonymous install ID, creating it on first launch.
 ///
@@ -261,6 +268,7 @@ fn get_or_create_install_id() -> String {
     id
 }
 
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // macOS GUI apps launched from Finder/Dock get a minimal launchd env
     // (no SSH_AUTH_SOCK, GH_TOKEN, XDG_*, or anything from ~/.zshrc).
@@ -271,14 +279,21 @@ pub fn run() {
     // No-op on Linux/Windows. See shell_env.rs for the full rationale.
     shell_env::init_login_shell_env();
 
-    tauri::Builder::default()
+    let builder = tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_clipboard_manager::init());
+
+    // Anonymous launch telemetry (release builds only). Registered
+    // conditionally because APTABASE_APP_KEY is compiled out in debug.
+    #[cfg(not(debug_assertions))]
+    let builder = builder.plugin(tauri_plugin_aptabase::Builder::new(APTABASE_APP_KEY).build());
+
+    builder
         .setup(|app| {
             // Register Cmd+Shift+G (macOS) / Ctrl+Shift+G (Linux/Windows)
             // to bring GitWand to the foreground from anywhere.
@@ -297,31 +312,24 @@ pub fn run() {
                 }
             })?;
 
-            // Anonymous launch telemetry via Umami — fire-and-forget POST.
-            // No personal data: UUID is random (not hardware-derived), IP is
-            // anonymised server-side by Umami. Skipped in debug builds.
+            // Anonymous launch telemetry via Aptabase — fire-and-forget.
+            // Replaced Umami: Umami Cloud filters non-browser User-Agents and
+            // silently dropped every event (HTTP 200 + `{"beep":"boop"}` decoy,
+            // nothing recorded), and spoofing a browser UA to bypass it was
+            // rejected as fragile / against Umami's ToS. Aptabase authenticates
+            // by App Key, so there is no UA/bot filtering. No personal data:
+            // install_id is a random UUID (not hardware-derived). The plugin
+            // auto-captures OS, app version and locale, so only install_id is
+            // sent as a custom property. track_event runs in the background.
+            // Skipped in debug builds.
             #[cfg(not(debug_assertions))]
-            std::thread::spawn(|| {
+            {
                 let install_id = get_or_create_install_id();
-                let language = sys_locale::get_locale().unwrap_or_else(|| "en".to_string());
-                let version = env!("CARGO_PKG_VERSION");
-                let _ = ureq::post("https://cloud.umami.is/api/send")
-                    .set("Content-Type", "application/json")
-                    .send_json(serde_json::json!({
-                        "payload": {
-                            "website": "171a9307-29ca-4524-8772-6187daacd9ca",
-                            "hostname": "app.gitwand.devlint.fr",
-                            "url": "/launch",
-                            "language": language,
-                            "name": "launch",
-                            "data": {
-                                "version": version,
-                                "install_id": install_id
-                            }
-                        },
-                        "type": "event"
-                    }));
-            });
+                let _ = app.track_event(
+                    "launch",
+                    Some(serde_json::json!({ "install_id": install_id })),
+                );
+            }
 
             Ok(())
         })

--- a/docs/superpowers/specs/2026-07-06-telemetry-umami-to-aptabase-plan.md
+++ b/docs/superpowers/specs/2026-07-06-telemetry-umami-to-aptabase-plan.md
@@ -1,0 +1,496 @@
+# Telemetry Provider Migration (Umami → Aptabase) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the broken Umami launch-telemetry ping with an equivalent anonymous launch event sent through the official `tauri-plugin-aptabase`, preserving the existing GDPR-compliant `install_id` mechanism.
+
+**Architecture:** The anonymous "launch" ping today lives entirely in the Rust backend (`apps/desktop/src-tauri/src/lib.rs`), fired from a detached thread inside `.setup()` and gated on `#[cfg(not(debug_assertions))]`. We keep the exact same semantics — one anonymous ping per launch, release-only, fire-and-forget — but swap the transport: register `tauri_plugin_aptabase` on the Tauri builder and call `app.track_event("launch", …)` via the plugin's `EventTracker` trait instead of a raw `ureq` POST. The `install_id` file logic (random UUID v4 at `{data_local_dir}/gitwand/install_id`) is unchanged and passed as a custom event property; app version and system locale are dropped from our payload because the Aptabase plugin captures them automatically.
+
+**Tech Stack:** Rust, Tauri 2, `tauri-plugin-aptabase` 1.0.0 (crate `tauri-plugin-aptabase`, official repo `github.com/aptabase/tauri-plugin-aptabase`, MIT, edition 2021, MSRV 1.70).
+
+## Global Constraints
+
+- **Versions are never hand-edited.** Do NOT touch `Cargo.toml` `version`, `package.json` versions, or `tauri.conf.json` version. Adding a `[dependencies]` line is allowed; changing the package `version` field is not.
+- **`[[example]]` not `[[bin]]`** for secondary binaries — not relevant here (Aptabase is a normal plugin dep), but do not introduce any `[[bin]]`.
+- **No shell string interpolation, `safe_repo_path()` untouched** — this task adds no filesystem-on-user-path or git-subprocess code, so those rules are automatically satisfied; do not regress them.
+- **Never log secrets** — the Aptabase App Key is a public identifier (see "Open decisions"), not a secret; the anonymous `install_id` is not personal data. No secret handling changes.
+- **Telemetry stays release-only:** every new telemetry line must remain under `#[cfg(not(debug_assertions))]`. Debug builds must send nothing.
+- **No opt-out toggle** — do NOT add anything to `useSettings.ts` / `SettingsPanel.vue`. This is a backend transport swap, not a new feature.
+- **Do NOT touch** `website/changelog.md`, `roadmap.md`, or any version file — those are handled by the `/release` flow at tag time. Only the root `CHANGELOG.md` `[Unreleased]` section is edited here.
+- **New Cargo dep must be justified with measured impact** (`apps/desktop/CLAUDE.md` build rule) — this plan includes an explicit compile-time + binary-size measurement step because `tauri-plugin-aptabase` pulls in `reqwest` and `tokio` transitively.
+
+---
+
+## Research Findings (verified, do not re-derive)
+
+These were verified during planning against the live crate registry and the plugin repo. The executor can trust them.
+
+1. **Crate:** `tauri-plugin-aptabase = "1.0.0"` is the current release (published 2025-03-27, MIT, edition 2021, `rust_version = 1.70`). Repo: `https://github.com/aptabase/tauri-plugin-aptabase`. It is Tauri v2 compatible (depends on `tauri ^2.2.5`).
+2. **Registration API:** `tauri_plugin_aptabase::Builder::new("<APP_KEY>").build()` returns a plugin to pass to `.plugin(...)`. (`tauri_plugin_aptabase::init("<key>".into())` is an equivalent shorthand; use the `Builder` form to match the other plugins' style in `lib.rs`.)
+3. **Tracking API:** import the trait `tauri_plugin_aptabase::EventTracker`; then `App`, `AppHandle`, and `Window` gain `track_event(&self, name: &str, props: Option<serde_json::Value>)`. Custom property values may only be strings or numbers. Tracking is non-blocking / runs in background — no manual thread needed. There is also `flush_events_blocking()` on the handle (used in Exit handlers); we do not need it for a launch ping.
+4. **Auto-captured properties:** the plugin automatically enriches every event with OS, **app version**, and **locale**, plus other system properties. Therefore our payload no longer needs to send `version` or `language` — only `install_id` as a custom property.
+5. **App Key format & visibility:** keys look like `A-EU-xxxxxxxxxx` (EU) or `A-US-xxxxxxxxxx` (US). The README/llms.txt document embedding the key inline as a compile-time string constant (or via `dotenv!`), i.e. it is treated as a public client identifier, exactly like the old Umami website ID. See "Open decisions" for where the executor gets the actual key.
+6. **Transitive deps added:** `reqwest ^0.12`, `tokio ^1.43`, `os_info`, `time`, `rand`, `futures`, `log`, plus `serde`/`serde_json`/`sys-locale` (already in tree). `reqwest` + `tokio` are the material additions — hence the measurement step (Task 5). The plugin crate itself is tiny (~10 KB, 449 LOC).
+7. **`ureq` is used in exactly one place** — the Umami POST at `apps/desktop/src-tauri/src/lib.rs:308`. The only other match, `apps/desktop/src-tauri/src/commands/network.rs:8`, is a **comment** ("we deliberately do NOT add an HTTP client … no `reqwest`, `ureq`"). So `ureq` can be fully removed from `Cargo.toml` after this migration. NOTE: that comment in `network.rs` becomes slightly stale (an HTTP client now exists transitively via the plugin), but `network.rs` itself still adds no direct HTTP dep — leave the comment as-is; optionally the executor may append a one-line clarification (see Task 4, optional sub-step).
+8. **`uuid` (v4)** is used only by `get_or_create_install_id` (`lib.rs:256`); the `bitbucket.rs:1112` match is a JSON field-name string, not the crate. `uuid` stays — we keep our own persistent install ID.
+9. **`sys-locale`** is used only by the telemetry block (`lib.rs:306`). After migration the plugin captures locale automatically, so `sys-locale` as a **direct** dep is removable. (It remains in the tree transitively via the plugin, which is fine.)
+10. **ACL permission:** `aptabase:allow-track-event` is only required for the **JavaScript** guest binding (`@aptabase/tauri`), which calls the Rust backend over IPC. We track from Rust only, so it is NOT required. Do not add the npm package and do not add the ACL entry unless a future frontend-tracking need arises. (Documented in Task 2 as explicitly skipped.)
+11. **Latent bug (context):** `#[cfg_attr(mobile, tauri::mobile_entry_point)]` at `lib.rs:237` is attached to `get_or_create_install_id()` instead of `pub fn run()` (mis-moved in commit `0e02f83`). Harmless on desktop, would break a future mobile build. Task 3 fixes it as a trivial, zero-risk move since we are already rewriting these exact lines.
+
+## Current Code Map (verified line references)
+
+- `apps/desktop/src-tauri/src/lib.rs:237` — `#[cfg_attr(mobile, tauri::mobile_entry_point)]` (misplaced, above `get_or_create_install_id`).
+- `apps/desktop/src-tauri/src/lib.rs:238-262` — `#[cfg(not(debug_assertions))] fn get_or_create_install_id() -> String`.
+- `apps/desktop/src-tauri/src/lib.rs:264` — `pub fn run()`.
+- `apps/desktop/src-tauri/src/lib.rs:274-281` — `tauri::Builder::default().plugin(...)` chain.
+- `apps/desktop/src-tauri/src/lib.rs:282` — `.setup(|app| {`.
+- `apps/desktop/src-tauri/src/lib.rs:300-324` — Umami comment + `std::thread::spawn` + `ureq::post(...)` block.
+- `apps/desktop/src-tauri/Cargo.toml:79-88` — comment + `ureq`, `uuid`, `sys-locale` deps.
+- `apps/desktop/src-tauri/src/main.rs` — minimal, calls `gitwand_desktop_lib::run()`; NOT modified.
+- `apps/desktop/src-tauri/src/CLAUDE.md` — subdir doc; NOT part of build, optional doc-accuracy note (Task 6).
+- `CHANGELOG.md` (repo root) — `[Unreleased]` section at line 8.
+
+## File Structure
+
+- **Modify:** `apps/desktop/src-tauri/Cargo.toml` — add `tauri-plugin-aptabase`, remove `ureq` and `sys-locale` direct deps (keep `uuid`).
+- **Modify:** `apps/desktop/src-tauri/src/lib.rs` — register the plugin, replace the telemetry block, fix the `mobile_entry_point` attribute placement.
+- **Modify:** `CHANGELOG.md` (repo root) — one `[Unreleased]` entry.
+- **Modify (optional, doc only):** `apps/desktop/src-tauri/CLAUDE.md` — line ~142 ("Pas de dépendances HTTP/async") becomes stale.
+
+No new files. No frontend files. No capabilities/ACL changes.
+
+---
+
+### Task 1: Add the Aptabase dependency and remove dead HTTP/locale deps in Cargo.toml
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/Cargo.toml:79-88`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: makes `tauri_plugin_aptabase::{Builder, EventTracker}` available to `lib.rs` (Task 2/3); removes `ureq::` and `sys_locale::` availability (Task 3 must not reference them).
+
+- [ ] **Step 1: Edit the dependency block**
+
+Replace the block currently at `apps/desktop/src-tauri/Cargo.toml:79-88`:
+
+```toml
+# Lightweight blocking HTTP client for the anonymous launch-count ping.
+# No async/tokio dependency — runs in a detached thread. Only used in
+# release builds (cfg(not(debug_assertions))).
+ureq = { version = "2", default-features = false, features = ["tls", "json"] }
+
+# Anonymous install ID generation (v4 random UUID, stored on first launch).
+uuid = { version = "1", features = ["v4"] }
+
+# Cross-platform system locale detection (macOS / Linux / Windows).
+sys-locale = "0.3"
+```
+
+with:
+
+```toml
+# Anonymous launch telemetry via Aptabase (privacy-first analytics for
+# desktop/Tauri apps). Replaced the previous Umami ping: Umami Cloud
+# filters non-browser User-Agents and silently dropped every event
+# (HTTP 200 + `{"beep":"boop"}` decoy, nothing recorded). Aptabase
+# authenticates by App Key, so there is no UA/bot filtering. Only used in
+# release builds (cfg(not(debug_assertions))). Pulls in reqwest + tokio
+# transitively — see Task 5 measurement note in the migration plan.
+tauri-plugin-aptabase = "1.0.0"
+
+# Anonymous install ID generation (v4 random UUID, stored on first launch).
+uuid = { version = "1", features = ["v4"] }
+```
+
+Note: `ureq` and the `sys-locale` **direct** dep are removed. `sys-locale` still resolves transitively via `tauri-plugin-aptabase` — that is expected and requires no action.
+
+- [ ] **Step 2: Verify the manifest parses and resolves**
+
+Run: `cd apps/desktop/src-tauri && cargo metadata --no-deps --format-version 1 >/dev/null && cargo tree -i ureq 2>&1 | head -5`
+Expected: `cargo metadata` succeeds (exit 0). `cargo tree -i ureq` prints `error: package ID specification 'ureq' did not match any packages` (or "nothing depends on it") — confirming `ureq` is gone from the tree.
+
+- [ ] **Step 3: Confirm the version field was not touched**
+
+Run: `cd apps/desktop/src-tauri && git diff Cargo.toml | grep -E '^[-+]version'`
+Expected: NO output (the `version = "3.2.0"` line at `Cargo.toml:3` was not modified).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/desktop/src-tauri/Cargo.toml
+git commit -m "chore(desktop): swap ureq/sys-locale for tauri-plugin-aptabase dep"
+```
+
+---
+
+### Task 2: Register the Aptabase plugin on the Tauri builder
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/lib.rs:274-281` (the `.plugin(...)` chain)
+
+**Interfaces:**
+- Consumes: `tauri-plugin-aptabase` from Task 1.
+- Produces: an initialized Aptabase plugin instance on the running app, so `app.track_event(...)` in Task 3 has a live client. Introduces the module-level constant `APTABASE_APP_KEY`.
+
+- [ ] **Step 1: Add the App Key constant near the entry-point section**
+
+Insert this constant immediately above the `#[cfg_attr(mobile, ...)]`/`get_or_create_install_id` block (i.e. just after the `// ─── Tauri entry point ───` divider around `lib.rs:235`):
+
+```rust
+/// Aptabase App Key for anonymous launch telemetry. This is a public client
+/// identifier (format `A-EU-*` / `A-US-*`), not a secret — same trust model
+/// as the previous public Umami website ID. Only used in release builds.
+#[cfg(not(debug_assertions))]
+const APTABASE_APP_KEY: &str = "A-EU-REPLACE_WITH_REAL_KEY";
+```
+
+> The executor MUST replace `A-EU-REPLACE_WITH_REAL_KEY` with the real key from the Aptabase dashboard before release. See "Open decisions". A build with the placeholder compiles and runs fine (events just go to an invalid app id), so this does not block earlier verification steps.
+
+- [ ] **Step 2: Register the plugin in the builder chain (release only)**
+
+In the `.plugin(...)` chain at `lib.rs:274-281`, add the Aptabase plugin after the existing plugins. Because the constant is `#[cfg(not(debug_assertions))]`, the registration line must be gated the same way. Change the tail of the chain from:
+
+```rust
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
+        .setup(|app| {
+```
+
+to:
+
+```rust
+        .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_clipboard_manager::init());
+
+    // Anonymous launch telemetry (release builds only). Registered
+    // conditionally because APTABASE_APP_KEY is compiled out in debug.
+    #[cfg(not(debug_assertions))]
+    let builder = builder.plugin(tauri_plugin_aptabase::Builder::new(APTABASE_APP_KEY).build());
+
+    builder
+        .setup(|app| {
+```
+
+To make that compile, the chain head at `lib.rs:274` must bind to a `let builder`. Change:
+
+```rust
+    tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+```
+
+to:
+
+```rust
+    let builder = tauri::Builder::default()
+        .plugin(tauri_plugin_dialog::init())
+```
+
+(Rationale: `tauri::Builder` methods consume and return `self`, so conditionally chaining requires rebinding `builder` under `#[cfg]`. This is the standard Tauri pattern for release-only plugins.)
+
+- [ ] **Step 3: Confirm we did NOT add the JS binding or ACL entry**
+
+Run: `cd apps/desktop && grep -R "aptabase" package.json src-tauri/capabilities/ 2>/dev/null; echo "exit:$?"`
+Expected: no `aptabase` matches (grep exits non-zero / prints nothing). We track from Rust only; `@aptabase/tauri` and `aptabase:allow-track-event` are intentionally omitted.
+
+- [ ] **Step 4: Type-check the crate (will still reference old telemetry block — expect the OLD block's errors only if any; plugin registration itself must be sound)**
+
+Run: `cd apps/desktop/src-tauri && cargo check --release 2>&1 | tail -20`
+Expected: compiles. (At this point the old `ureq`/`sys_locale` telemetry block at `lib.rs:300-324` still exists and now FAILS to compile because Task 1 removed `ureq`/`sys-locale`. That is expected — Task 2 and Task 3 land together in the same working session; do not commit Task 2 alone in a broken state.) If splitting commits is desired, the executor should perform Task 2 and Task 3 edits before running any `cargo check` and before committing. Treat Task 2 + Task 3 as a single compile/commit unit.
+
+> Handoff note: Tasks 2 and 3 form one atomic compile unit (removing `ureq` in Task 1 breaks the old block until Task 3 replaces it). Do the Task 3 edits, then run checks, then commit once (commit lives in Task 3).
+
+---
+
+### Task 3: Replace the telemetry block and fix the mobile_entry_point attribute
+
+**Files:**
+- Modify: `apps/desktop/src-tauri/src/lib.rs:237` (attribute placement)
+- Modify: `apps/desktop/src-tauri/src/lib.rs:300-324` (telemetry block inside `.setup()`)
+- Modify: `apps/desktop/src-tauri/src/lib.rs:264` (add attribute to `run()`)
+
+**Interfaces:**
+- Consumes: registered Aptabase plugin (Task 2), `get_or_create_install_id()` (unchanged), `tauri_plugin_aptabase::EventTracker` trait (Task 1 dep).
+- Produces: a single anonymous "launch" event per release launch carrying `{ "install_id": <uuid> }`.
+
+- [ ] **Step 1: Add the `EventTracker` trait import**
+
+At the top of `lib.rs`, with the other `use` statements, add (gated so debug builds don't warn about an unused import):
+
+```rust
+#[cfg(not(debug_assertions))]
+use tauri_plugin_aptabase::EventTracker;
+```
+
+- [ ] **Step 2: Move the `mobile_entry_point` attribute off `get_or_create_install_id`**
+
+At `lib.rs:237-243`, the block currently reads:
+
+```rust
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+#[cfg(not(debug_assertions))]
+/// Returns the anonymous install ID, creating it on first launch.
+///
+/// Stored at `{data_local_dir}/gitwand/install_id` as a plain UUID v4.
+/// Random, not derived from hardware — not personal data under GDPR.
+fn get_or_create_install_id() -> String {
+```
+
+Remove the misplaced attribute line so it becomes:
+
+```rust
+#[cfg(not(debug_assertions))]
+/// Returns the anonymous install ID, creating it on first launch.
+///
+/// Stored at `{data_local_dir}/gitwand/install_id` as a plain UUID v4.
+/// Random, not derived from hardware — not personal data under GDPR.
+fn get_or_create_install_id() -> String {
+```
+
+- [ ] **Step 3: Attach `mobile_entry_point` to `run()` where it belongs**
+
+At `lib.rs:264`, change:
+
+```rust
+pub fn run() {
+```
+
+to:
+
+```rust
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+```
+
+- [ ] **Step 4: Replace the Umami telemetry block inside `.setup()`**
+
+At `lib.rs:300-324`, replace the entire Umami comment + `std::thread::spawn` block:
+
+```rust
+            // Anonymous launch telemetry via Umami — fire-and-forget POST.
+            // No personal data: UUID is random (not hardware-derived), IP is
+            // anonymised server-side by Umami. Skipped in debug builds.
+            #[cfg(not(debug_assertions))]
+            std::thread::spawn(|| {
+                let install_id = get_or_create_install_id();
+                let language = sys_locale::get_locale().unwrap_or_else(|| "en".to_string());
+                let version = env!("CARGO_PKG_VERSION");
+                let _ = ureq::post("https://cloud.umami.is/api/send")
+                    .set("Content-Type", "application/json")
+                    .send_json(serde_json::json!({
+                        "payload": {
+                            "website": "171a9307-29ca-4524-8772-6187daacd9ca",
+                            "hostname": "app.gitwand.devlint.fr",
+                            "url": "/launch",
+                            "language": language,
+                            "name": "launch",
+                            "data": {
+                                "version": version,
+                                "install_id": install_id
+                            }
+                        },
+                        "type": "event"
+                    }));
+            });
+```
+
+with:
+
+```rust
+            // Anonymous launch telemetry via Aptabase — fire-and-forget.
+            // Replaced Umami: Umami Cloud filters non-browser User-Agents and
+            // silently dropped every event (HTTP 200 + `{"beep":"boop"}` decoy,
+            // nothing recorded), and spoofing a browser UA to bypass it was
+            // rejected as fragile / against Umami's ToS. Aptabase authenticates
+            // by App Key, so there is no UA/bot filtering. No personal data:
+            // install_id is a random UUID (not hardware-derived). The plugin
+            // auto-captures OS, app version and locale, so only install_id is
+            // sent as a custom property. track_event runs in the background.
+            // Skipped in debug builds.
+            #[cfg(not(debug_assertions))]
+            {
+                let install_id = get_or_create_install_id();
+                app.track_event(
+                    "launch",
+                    Some(serde_json::json!({ "install_id": install_id })),
+                );
+            }
+```
+
+Notes for the executor:
+- `app` is the `&mut App` bound by `.setup(|app| { ... })`; `track_event` comes from the `EventTracker` trait imported in Step 1.
+- Do NOT wrap this in `std::thread::spawn` — the plugin already dispatches non-blockingly. The old thread was needed only because `ureq` is synchronous.
+- Property value is a string (`install_id`), which satisfies Aptabase's "strings and numbers only" rule.
+
+- [ ] **Step 5: Build the whole crate in release mode**
+
+Run: `cd apps/desktop/src-tauri && cargo check --release 2>&1 | tail -25`
+Expected: compiles with no errors and no `unused import` / `unused variable` warnings for the telemetry path. If a warning about `get_or_create_install_id` being unused appears, it means the `#[cfg(not(debug_assertions))]` gating diverged — recheck that both the function and its single caller share the same cfg.
+
+- [ ] **Step 6: Sanity-check debug build compiles telemetry OUT**
+
+Run: `cd apps/desktop/src-tauri && cargo check 2>&1 | tail -25`
+Expected: compiles cleanly with no warnings. In debug, `APTABASE_APP_KEY`, `get_or_create_install_id`, the plugin registration, the `EventTracker` import, and the `track_event` call are ALL compiled out. If the compiler complains about an unused `builder` binding or an unused import in debug, the cfg gating from Task 2/Step-1-here is wrong — fix until debug is warning-free.
+
+- [ ] **Step 7: Grep to confirm all Umami/ureq/sys_locale traces are gone from source**
+
+Run: `cd apps/desktop/src-tauri && grep -RnE "umami|cloud\.umami|ureq::|sys_locale::|app\.gitwand\.devlint\.fr|171a9307" src/`
+Expected: no matches (exit non-zero). The only remaining `ureq` reference anywhere is the descriptive comment in `src/commands/network.rs:8`, which is acceptable (see Task 4).
+
+- [ ] **Step 8: Commit (covers Task 2 + Task 3)**
+
+```bash
+git add apps/desktop/src-tauri/src/lib.rs
+git commit -m "feat(desktop): send anonymous launch telemetry via Aptabase instead of Umami"
+```
+
+---
+
+### Task 4: Confirm the `network.rs` comment and no stray references
+
+**Files:**
+- Inspect only: `apps/desktop/src-tauri/src/commands/network.rs:1-24`
+- Optional modify: `apps/desktop/src-tauri/src/commands/network.rs:6-9`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing (verification/optional-doc task).
+
+- [ ] **Step 1: Re-read the comment context**
+
+Run: `cd apps/desktop/src-tauri && sed -n '6,9p' src/commands/network.rs`
+Expected: shows the comment `//! We deliberately do NOT add an HTTP client dependency (no reqwest, // ureq, etc.)`.
+
+- [ ] **Step 2 (OPTIONAL, low value — skip unless the reviewer asks):** append a one-line clarification so the comment isn't misleading now that the Aptabase plugin brings `reqwest`/`tokio` into the tree. If done, change the comment at `network.rs:7-9` to add:
+
+```rust
+//! (This module still adds no direct HTTP dependency; an HTTP client only
+//! exists transitively via the Aptabase telemetry plugin.)
+```
+
+If skipped, no action. Do NOT change any code in this file.
+
+- [ ] **Step 3: If Step 2 was done, commit**
+
+```bash
+git add apps/desktop/src-tauri/src/commands/network.rs
+git commit -m "docs(desktop): clarify network.rs no-HTTP-dep note post-Aptabase"
+```
+
+---
+
+### Task 5: Measure the dependency's build/binary impact (perf invariant)
+
+`apps/desktop/CLAUDE.md` requires measuring compile-time and binary-size impact for any new Cargo dep. `tauri-plugin-aptabase` pulls in `reqwest` + `tokio`, so this is non-trivial and must be recorded in the PR description.
+
+**Files:**
+- No files modified. Produces numbers for the PR description.
+
+**Interfaces:**
+- Consumes: the built crate from Task 3.
+- Produces: before/after `cargo build --release` wall-time and `target/release` binary size, to paste into the PR.
+
+- [ ] **Step 1: Full release build, timed**
+
+Run: `cd apps/desktop/src-tauri && cargo build --release 2>&1 | tail -3 && echo "--- built ---"`
+Expected: `Finished release [optimized] target(s) in <N>s`. Record `<N>`.
+
+- [ ] **Step 2: Record the release binary size**
+
+Run: `cd apps/desktop/src-tauri && du -h target/release/gitwand-desktop 2>/dev/null || du -h target/release/gitwand_desktop* 2>/dev/null | head`
+Expected: a size figure (the lib/app binary). Record it.
+
+- [ ] **Step 3: Note the transitive additions for the PR**
+
+No command. In the PR description, state: "Adds `tauri-plugin-aptabase` (+ transitive `reqwest 0.12`, `tokio 1.x`, `os_info`, `time`, `rand`). Removed direct `ureq` and `sys-locale`. Net binary delta: `<from Step 2 vs a baseline build of main>`; release build time delta: `<Step 1 vs baseline>`." If a baseline (main branch) build number isn't already known, run the same two commands on a clean `main` checkout/worktree to get the before figures. This is reporting only — no code change, no commit.
+
+---
+
+### Task 6: Update the root CHANGELOG and (optional) subdir doc note
+
+**Files:**
+- Modify: `CHANGELOG.md` (repo root), `[Unreleased]` section (currently starts at line 8, has a `### Fixed` subsection).
+- Optional modify: `apps/desktop/src-tauri/CLAUDE.md:142`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: release-history entry. (Do NOT touch `website/changelog.md`, `roadmap.md`, or version files.)
+
+- [ ] **Step 1: Add a `### Changed` entry under `[Unreleased]`**
+
+In `CHANGELOG.md`, under `## [Unreleased]`, add a `### Changed` subsection (place it before the existing `### Fixed` per Keep a Changelog ordering: Added, Changed, Deprecated, Removed, Fixed, Security):
+
+```markdown
+### Changed
+
+- **Anonymous launch telemetry moved from Umami to Aptabase** — Umami Cloud silently dropped every launch ping (it filters non-browser User-Agents, replying HTTP 200 with a `{"beep":"boop"}` decoy and recording nothing). GitWand now sends the same anonymous, release-only "launch" event through Aptabase (App-Key authenticated, no UA/bot filtering). The GDPR-safe random `install_id` is unchanged; app version and locale are captured automatically by the Aptabase plugin. Dropped the direct `ureq` and `sys-locale` Rust dependencies.
+```
+
+- [ ] **Step 2: Verify no forbidden files were touched**
+
+Run: `git status --porcelain | grep -E 'website/changelog|roadmap|package\.json|Cargo\.toml.*version|tauri\.conf\.json'`
+Expected: no output (none of those files are staged/modified beyond the allowed `Cargo.toml` dependency edit from Task 1 — and that edit did not touch the `version` field, confirmed in Task 1/Step 3).
+
+- [ ] **Step 3 (OPTIONAL): correct the stale doc line in the subdir CLAUDE.md**
+
+`apps/desktop/src-tauri/CLAUDE.md:142` currently reads "Pas de dépendances HTTP/async — Tauri gère la fenêtre, git est synchrone", which is no longer accurate (Aptabase brings reqwest+tokio). If updating, change it to:
+
+```markdown
+- Une seule dépendance HTTP/async : `reqwest` + `tokio`, tirés transitivement par `tauri-plugin-aptabase` (télémétrie de lancement anonyme, release-only). Le reste du backend reste synchrone.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md apps/desktop/src-tauri/CLAUDE.md
+git commit -m "docs: changelog + note Aptabase telemetry migration"
+```
+
+---
+
+### Task 7: End-to-end verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Release build is green**
+
+Run: `cd apps/desktop/src-tauri && cargo build --release 2>&1 | tail -3`
+Expected: `Finished release`.
+
+- [ ] **Step 2: Debug build is green and telemetry-free**
+
+Run: `cd apps/desktop/src-tauri && cargo build 2>&1 | tail -3 && grep -RnE "umami|ureq::|sys_locale::" src/ ; echo "grep_exit:$?"`
+Expected: `Finished dev`; `grep_exit:1` (no matches in `src/` except the acceptable comment in `network.rs` which does not match `ureq::` — it's `ureq,` in prose).
+
+- [ ] **Step 3: Confirm event semantics by reading the final code**
+
+Run: `cd apps/desktop/src-tauri && grep -n "track_event\|APTABASE_APP_KEY\|Builder::new(APTABASE" src/lib.rs`
+Expected: exactly one `track_event("launch", …)` call, one `APTABASE_APP_KEY` const, one `Builder::new(APTABASE_APP_KEY)` registration — all inside `#[cfg(not(debug_assertions))]` regions.
+
+- [ ] **Step 4: Manual runtime check (optional, requires the real App Key)**
+
+With `APTABASE_APP_KEY` set to the real key, run a release build (`cd apps/desktop && pnpm tauri build`) and launch the app once; confirm one "launch" event appears in the Aptabase dashboard within a few minutes. If still on the placeholder key, skip — code-level verification (Steps 1-3) is sufficient for merge; the dashboard check is a pre-release gate.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Keep same functional event (anonymous "launch", once/launch, release-only, fire-and-forget) → Task 3 Step 4 (single `track_event` under `#[cfg(not(debug_assertions))]`, no thread). ✔
+- Keep `install_id` (random UUID v4, `{data_local_dir}/gitwand/install_id`) → `get_or_create_install_id` unchanged; only its stray attribute removed. ✔
+- Keep same data in spirit (version, locale, install_id) → install_id sent explicitly; version + locale now auto-captured by plugin (Research #4), documented in code comment + changelog. ✔
+- Remove all Umami-specific code + `ureq` if unused elsewhere → Task 1 (dep) + Task 3 (code) + Task 3 Step 7 grep + verified `ureq` used only in the Umami POST (Research #7). ✔
+- Use `tauri-plugin-aptabase`, verified exact crate/API → Research #1-#6, Task 2/3. ✔
+- Note user must create Aptabase app + provide key; key is public-ish constant → "Open decisions" + Task 2 Step 1 + Research #5. ✔
+- No opt-out toggle in Settings → Global Constraints; no frontend files touched. ✔
+- Update the comment explaining the service choice / why Umami dropped → Task 3 Step 4 comment (concise, factual). ✔
+- Add `CHANGELOG.md` `[Unreleased]` entry; do NOT touch website changelog/roadmap/version files → Task 6 + Task 6 Step 2 guard. ✔
+- Respect perf invariant (measure new Cargo dep) + declare plugin correctly (normal plugin, no `[[bin]]`) → Task 5 + Task 2. ✔
+- Register plugin in `tauri::Builder` like other plugins → Task 2 Step 2. ✔
+- Latent `mobile_entry_point` bug: fix since we touch these lines → Task 3 Steps 2-3. ✔
+
+**Placeholder scan:** The only intentional placeholder is `A-EU-REPLACE_WITH_REAL_KEY`, explicitly flagged as an executor action and an "Open decision" (the real value is external/human-supplied, not derivable in-plan). No "TBD"/"handle edge cases"/"similar to Task N" placeholders.
+
+**Type consistency:** `track_event(name: &str, props: Option<serde_json::Value>)`, `Builder::new(&str).build()`, `EventTracker` trait, `APTABASE_APP_KEY: &str` — used identically everywhere referenced.


### PR DESCRIPTION
## Summary

- **Root cause**: Umami Cloud (`cloud.umami.is/api/send`) silently drops every launch ping — it filters non-browser `User-Agent` headers, replying HTTP 200 with a `{"beep":"boop"}` decoy and recording nothing. Verified with live test requests (default `ureq` UA, `curl`, and an honest custom UA were all filtered; only a spoofed browser UA passed — spoofing was rejected as fragile / against Umami's ToS).
- **Fix**: replace the raw `ureq` POST with the official `tauri-plugin-aptabase` (App-Key authenticated, no UA/bot filtering). Same anonymous, release-only "launch" event; same GDPR-safe random `install_id`; app version/locale now auto-captured by the plugin instead of sent manually.
- **Upstream blocker found & patched**: `tauri-plugin-aptabase` 1.0.0 panics at startup in release builds (`there is no reactor running`) because it uses raw `tokio::spawn` instead of `tauri::async_runtime::spawn` (upstream issues [#16](https://github.com/aptabase/tauri-plugin-aptabase/issues/16), [#22](https://github.com/aptabase/tauri-plugin-aptabase/issues/22); fix proposed in unmerged [PR #30](https://github.com/aptabase/tauri-plugin-aptabase/pull/30)). Patched via `[patch.crates-io]` against a self-hosted fork (`devlint/tauri-plugin-aptabase@fix/tokio-runtime-panic`) containing only the isolated one-line fix — not the third-party fork's unrelated dependency bumps.
- Fixed a latent, unrelated bug while touching these lines: `#[cfg_attr(mobile, tauri::mobile_entry_point)]` was misplaced on `get_or_create_install_id()` instead of `run()` since the original Umami commit.
- Dropped the now-unused `ureq` and direct `sys-locale` dependencies.

## Verification

- `cargo check` (debug) and `cargo check --release`: clean, no warnings.
- `pnpm test` (vitest): 358/358 passed.
- `pnpm test:parity`: 10/10 passed.
- Real `pnpm tauri build` + launching the produced `.app` binary: no crash (previously panicked before the patch, confirmed reproducible before/after).
- Sent a real test event matching the plugin's exact payload schema directly to `https://eu.aptabase.com/api/v0/events` with the production App Key — confirmed **live in the Aptabase dashboard** (1 event `launch`, macOS, France, v3.2.0).
- Supply-chain: independently cloned the patched fork and confirmed the commit is exactly a 1-line diff (`tokio::spawn` → `tauri::async_runtime::spawn`), and that its base is a genuine ancestor of upstream `aptabase/tauri-plugin-aptabase` main.
- Perf invariant (new Cargo dependency impact): release build +~49s (~15%), binary size +~520 KiB (~3.6%) — from `reqwest`/`tokio` pulled transitively by the plugin.

## Test plan

- [x] Release + debug builds compile cleanly
- [x] `pnpm test` and `pnpm test:parity` pass
- [x] Real release binary launches without crashing
- [x] Live event confirmed in Aptabase dashboard
- [ ] Monitor the Aptabase dashboard after the next tagged release for real installs (this PR only proves the plumbing works)