### PR TITLE
fix(desktop): fix git log pagination, caching, and prefetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <strong>A fast, native Git client with built-in smart conflict resolution</strong>
 </p>
-aasd
+
 <p align="center">
   <a href="#desktop-app">Desktop</a> &bull;
   <a href="#conflict-resolution-engine">Conflict engine</a> &bull;

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <strong>A fast, native Git client with built-in smart conflict resolution</strong>
 </p>
-
+aasd
 <p align="center">
   <a href="#desktop-app">Desktop</a> &bull;
   <a href="#conflict-resolution-engine">Conflict engine</a> &bull;

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1349,7 +1349,7 @@ function onPaletteAction(id: string) {
     case "push": handlePush(); break;
     case "pull": doPull(pullMode.value === "rebase"); break;
     case "sync": doSync(); break;
-    case "fetch": doFetch(); break;
+    case "fetch": doFetch(true); break;
     case "new-tab": handleOpenFolder(); break;
     case "view-dashboard": viewMode.value = "dashboard"; break;
     case "view-changes": viewMode.value = "changes"; break;
@@ -3060,7 +3060,7 @@ onUnmounted(() => {
       @open-folder="handleOpenFolder" @open-repo="handleOpenPath" @switch-tab="switchTab" @close-tab="closeRepoTab"
       @reorder-tabs="reorderTabs"
       @new-tab="handleOpenFolder" @open-clone="showCloneModal = true" @open-fork="showForkModal = true"
-      @toggle-theme="toggleTheme" @push="handlePush" @pull="() => doPull(pullMode === 'rebase')" @fetch="doFetch"
+      @toggle-theme="toggleTheme" @push="handlePush" @pull="() => doPull(pullMode === 'rebase')" @fetch="() => doFetch(true)"
       @sync="doSync" @publish="doPublish" @rebase-onto-remote="doRebaseOntoRemote" @merge-remote="doMergeRemote"
       @force-push="doForcePush" @discard-all="handleWipDiscardAll"
       @merge-branch="doMerge" @open-settings="settingsInitialTab = undefined; showSettings = true"

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -593,6 +593,12 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
   // prefetched/cached — filtered views stay on-demand.
   const LOG_CACHE = new Map<string, GitLogEntry[]>();
   const BG_PAGE = 500; // larger background page → fewer layout recomputes
+  // Ceiling on the automatic background prefetch. Beyond this the graph stays
+  // usable and scroll-loading still reaches older history on demand — we just
+  // stop eagerly pulling the whole DAG into memory / re-laying it out. A log
+  // capped here is NOT cached as complete, so `logHasMore` stays true and
+  // scroll pagination continues past the ceiling.
+  const PREFETCH_CEILING = 5000;
   let _prefetchToken = 0;
 
   function isCanonicalLogView(): boolean {
@@ -626,11 +632,14 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       folderPath.value === repo &&
       token === _prefetchToken &&
       isCanonicalLogView();
-    while (live() && logHasMore.value) {
+    while (live() && logHasMore.value && log.value.length < PREFETCH_CEILING) {
       await whenIdle();
       if (!live()) return;
       await loadMoreLog(BG_PAGE);
     }
+    // Cache only a fully-paged log (reached the end before the ceiling). A
+    // ceiling-capped log keeps `logHasMore` true and is left uncached so
+    // scroll-loading can still fetch the rest.
     if (live() && !logHasMore.value) {
       LOG_CACHE.set(repo, log.value.slice());
     }

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -458,7 +458,14 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    * Updates tracking refs so ahead/behind counts become accurate.
    * Used by both manual user action and the consolidated useRepoPoller.
    */
-  async function fetchRemote() {
+  /**
+   * @param full When true, also reload every cached collection (branches,
+   *   stashes, worktrees) on top of status + log. Used by the manual "up to
+   *   date" / sync click so one gesture refreshes the whole view. The 30s
+   *   background poll leaves it false to stay off the hot path (per the perf
+   *   invariants — no extra process spawns on the polling tick).
+   */
+  async function fetchRemote(full = false) {
     // Skip fetch during merge operations to avoid git lock conflicts
     if (
       !folderPath.value ||
@@ -480,6 +487,11 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       // Force: a fetch moves remote-tracking refs without moving local HEAD,
       // so the canonical fast path would otherwise keep stale origin/* labels.
       await loadLog(undefined, true);
+      // Manual sync: refresh the rest of the cached view so a deleted/renamed
+      // remote branch, a pruned ref, or a new tag surfaces without a reopen.
+      if (full) {
+        await Promise.all([loadBranches(), loadStashes(), loadWorktrees()]);
+      }
     } catch (err) {
       console.warn("[GitWand] fetch failed:", err);
     } finally {

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -477,7 +477,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       await loadStatus(folderPath.value);
       // v2.14 — Refresh log so clicking "Up to date" or periodic fetch
       // updates the Git Tree / History view with new remote commits.
-      await loadLog();
+      // Force: a fetch moves remote-tracking refs without moving local HEAD,
+      // so the canonical fast path would otherwise keep stale origin/* labels.
+      await loadLog(undefined, true);
     } catch (err) {
       console.warn("[GitWand] fetch failed:", err);
     } finally {
@@ -545,9 +547,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    * v2.14 — Now also refreshes the commit log so the Git Tree and History
    * views stay in sync with the repository state.
    */
-  async function refresh() {
+  async function refresh(forceLog = false) {
     if (!folderPath.value) return;
-    await Promise.all([loadStatus(folderPath.value), loadLog()]);
+    await Promise.all([loadStatus(folderPath.value), loadLog(undefined, forceLog)]);
     // Also refresh diff if a file is selected
     if (selectedFilePath.value) {
       await loadDiff(selectedFilePath.value, selectedFileStaged.value);
@@ -645,7 +647,15 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     }
   }
 
-  async function loadLog(count?: number) {
+  /**
+   * @param force When true, bypass the canonical fast-paths that trust an
+   *   unchanged top-commit hash (the in-memory `haveSameHead` keep and the
+   *   `LOG_CACHE` restore) and refetch fresh. Ref/decoration-only mutations
+   *   (push moving origin/HEAD, branch/tag/stash deletion, fetch) leave the top
+   *   commit untouched, so without this they'd serve a stale log. Refetches at
+   *   the current depth so a paginated view doesn't collapse back to page 1.
+   */
+  async function loadLog(count?: number, force = false) {
     if (!folderPath.value) return;
     try {
       const authorEmail =
@@ -659,7 +669,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       // views reload at least what's visible so polling doesn't collapse a
       // paginated log back to page 1.
       const pageSize = isCanon
-        ? LOG_PAGE
+        ? force
+          ? Math.max(LOG_PAGE, log.value.length)
+          : LOG_PAGE
         : (count ?? Math.max(LOG_PAGE, log.value.length));
       const entries = await getGitLog(
         folderPath.value,
@@ -677,18 +689,28 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       if (isCanon) {
         const cached = LOG_CACHE.get(folderPath.value);
         const haveSameHead =
-          log.value.length >= entries.length && log.value[0]?.hashFull === head;
+          !force &&
+          log.value.length >= entries.length &&
+          log.value[0]?.hashFull === head;
         if (haveSameHead) {
           // Poll while we already hold this page (or the full log / an in-flight
           // prefetch) and HEAD hasn't moved — keep it, don't collapse. Resume
           // the prefetch if it was interrupted.
           if (logHasMore.value) void prefetchAllPages();
-        } else if (cached && cached.length > 0 && cached[0]?.hashFull === head) {
+        } else if (
+          !force &&
+          cached &&
+          cached.length > 0 &&
+          cached[0]?.hashFull === head
+        ) {
           // HEAD unchanged since we cached the full history — restore instantly.
           log.value = cached;
           logHasMore.value = false;
         } else {
-          // Fresh repo, or HEAD moved: show page 1 and prefetch the rest.
+          // Fresh repo, HEAD moved, or a forced reload after a ref/decoration
+          // change: drop the stale cache and show fresh entries. The background
+          // prefetch below re-caches the full history with current decorations.
+          if (force) LOG_CACHE.delete(folderPath.value);
           log.value = entries;
           logHasMore.value = log.value.length < effectiveTotalCount();
           void prefetchAllPages();
@@ -945,7 +967,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
         successMessage.value = "push-done";
         forcePushPreferred.value = false;
       }
-      await refresh();
+      // Force: push advances origin/<branch> but not local HEAD, so the log's
+      // remote label must be re-pulled to move off the pre-push commit.
+      await refresh(true);
       // Publishing sets the branch upstream — reload branches so consumers
       // (e.g. the PR-create publish guard) see the new tracking state.
       await loadBranches();
@@ -979,7 +1003,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
         }
         forcePushPreferred.value = false;
       }
-      await refresh();
+      // Force: a pull updates remote-tracking refs and may fast-forward without
+      // the fast path noticing the decoration change.
+      await refresh(true);
     } catch (err: any) {
       error.value = `pull: ${err?.message ?? err}`;
     } finally {
@@ -994,7 +1020,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     isMerging.value = true;
     try {
       const result = await gitMerge(folderPath.value, branchName);
-      await refresh();
+      // Force: a fast-forward merge moves refs without a new merge commit.
+      await refresh(true);
 
       // Detect conflicts from both the server response and the git status
       const hasConflictedFiles =
@@ -1179,7 +1206,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       await gitStashDrop(folderPath.value, index);
       await refresh();
       await loadStashes();
-      await loadLog();
+      // Force: popping drops the stash ref, which the all-refs log renders.
+      await loadLog(undefined, true);
     } catch (err: any) {
       error.value = `stash pop: ${err?.message ?? err}`;
     }
@@ -1190,7 +1218,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     try {
       await gitStashDrop(folderPath.value, index);
       await loadStashes();
-      await loadLog();
+      // Force: the dropped stash ref is gone but HEAD is untouched, so the
+      // canonical fast path would keep showing it in the all-refs log.
+      await loadLog(undefined, true);
     } catch (err: any) {
       error.value = `stash drop: ${err?.message ?? err}`;
     }
@@ -1225,7 +1255,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     if (!folderPath.value) return false;
     try {
       await gitCreateBranch(folderPath.value, name, true);
-      await refresh();
+      // Force: the new branch ref sits on the current HEAD, so the log's
+      // decorations change without the top commit moving.
+      await refresh(true);
       await loadBranches();
       return true;
     } catch (err: any) {
@@ -1240,7 +1272,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     try {
       await gitSwitchBranch(folderPath.value, name);
       forcePushPreferred.value = false;
-      await refresh();
+      // Force: switching to a branch pointing at the same commit moves the
+      // HEAD marker without moving the top commit hash.
+      await refresh(true);
       await loadBranches();
       await loadWorktrees();
       return true;
@@ -1298,7 +1332,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     try {
       await gitDeleteBranch(folderPath.value, name, force);
       await loadBranches();
-      await loadLog();
+      // Force: the branch ref is gone but HEAD hasn't moved, so its label must
+      // be dropped from the log.
+      await loadLog(undefined, true);
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       // `git branch -d` refuses to drop a branch that isn't fully merged
@@ -1323,7 +1359,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     try {
       await gitDeleteRemoteBranch(folderPath.value, remote, name);
       await loadBranches();
-      await loadLog();
+      // Force: refs change without HEAD moving.
+      await loadLog(undefined, true);
     } catch (err: any) {
       error.value = `delete remote branch: ${err?.message ?? err}`;
     }
@@ -1333,7 +1370,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     if (!folderPath.value) return;
     try {
       await gitDeleteTag(folderPath.value, name);
-      await loadLog();
+      // Force: the tag ref is gone but HEAD hasn't moved.
+      await loadLog(undefined, true);
     } catch (err: any) {
       error.value = `delete tag: ${err?.message ?? err}`;
     }
@@ -1343,7 +1381,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     if (!folderPath.value) return;
     try {
       await gitDeleteRemoteTag(folderPath.value, remote, name);
-      await loadLog();
+      // Force: refs change without HEAD moving.
+      await loadLog(undefined, true);
     } catch (err: any) {
       error.value = `delete remote tag: ${err?.message ?? err}`;
     }
@@ -1360,7 +1399,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       if (status.value?.branch === oldName) {
         await loadStatus(folderPath.value);
       }
-      await loadLog();
+      // Force: renaming swaps the branch label in place without moving HEAD.
+      await loadLog(undefined, true);
     } catch (err: any) {
       error.value = `rename branch: ${err?.message ?? err}`;
     }

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -110,6 +110,16 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     activeScope.value ? Math.max(0, totalUnscopedCount.value - scopedTotalCount.value) : 0,
   );
 
+  /**
+   * Authoritative total commit count for the current log scope — the paging
+   * ceiling. Scoped total when a monorepo scope is active, otherwise the
+   * unscoped all-refs total. Drives `logHasMore` in all-refs mode where the
+   * page length is unreliable (see loadLog).
+   */
+  function effectiveTotalCount(): number {
+    return activeScope.value ? scopedTotalCount.value : totalUnscopedCount.value;
+  }
+
   /** Refresh the unscoped + scoped rev counts for the hidden-commit badge. */
   async function loadRevCounts() {
     if (!folderPath.value) return;
@@ -542,10 +552,16 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
         activeScope.value ?? undefined,                   // pathspec (monorepo scope)
       );
       log.value = entries;
-      // When the result is exactly one full page, assume more exist.
-      logHasMore.value = entries.length >= pageSize;
       // Refresh the hidden-commit badge counts alongside the scoped log.
       await loadRevCounts();
+      // hasMore: in branch-only mode a full page is exactly `pageSize`. In
+      // all-refs mode the backend appends stash start-points and filters the
+      // `index on`/`untracked files on` pseudo-commits, so a full page returns
+      // FEWER than `pageSize` — `entries.length >= pageSize` would wrongly read
+      // false and kill infinite scroll. Use the authoritative rev-count there.
+      logHasMore.value = isCurrentBranchOnly
+        ? entries.length >= pageSize
+        : log.value.length < effectiveTotalCount();
       // If a commit was selected but its diffs were lost, reload them
       if (selectedCommitHash.value && commitDiffs.value.length === 0) {
         commitDiffs.value = await getGitShow(folderPath.value, selectedCommitHash.value);
@@ -576,10 +592,20 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
         isCurrentBranchOnly ? (status.value?.branch ?? undefined) : undefined,
         activeScope.value ?? undefined,
       );
-      if (next.length > 0) {
-        log.value = [...log.value, ...next];
+      // Dedupe: in all-refs mode the `--skip` offset counts filtered-out stash
+      // pseudo-commits, so consecutive pages can overlap by a few commits.
+      // Drop any hash we already have before appending.
+      const seen = new Set(log.value.map((e) => e.hashFull));
+      const added = next.filter((e) => !seen.has(e.hashFull));
+      if (added.length > 0) {
+        log.value = [...log.value, ...added];
       }
-      logHasMore.value = next.length >= LOG_PAGE;
+      // Stop when a page adds nothing new (end of history, guards against an
+      // offset-drift infinite loop) or once we've reached the total. Branch-only
+      // mode has no stash pollution, so a short page also means the end.
+      logHasMore.value =
+        added.length > 0 &&
+        (isCurrentBranchOnly ? next.length >= LOG_PAGE : log.value.length < effectiveTotalCount());
     } catch (err: any) {
       error.value = `git log (page): ${err?.message ?? err}`;
     } finally {

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -51,7 +51,14 @@ import { requireOnline } from "../utils/networkGuard";
 import { t } from "./useI18n";
 import { useWorkspaceScope } from "./useWorkspaceScope";
 
-export type ViewMode = "dashboard" | "changes" | "history" | "graph" | "prs" | "launchpad" | "issue";
+export type ViewMode =
+  | "dashboard"
+  | "changes"
+  | "history"
+  | "graph"
+  | "prs"
+  | "launchpad"
+  | "issue";
 
 /** Modal-based confirmation (App.vue's `askConfirm`), injected to avoid native `confirm()`. */
 export type ConfirmFn = (opts: {
@@ -107,7 +114,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    * NOT scoped.length. Zero when no scope is active.
    */
   const hiddenCommitCount = computed(() =>
-    activeScope.value ? Math.max(0, totalUnscopedCount.value - scopedTotalCount.value) : 0,
+    activeScope.value
+      ? Math.max(0, totalUnscopedCount.value - scopedTotalCount.value)
+      : 0,
   );
 
   /**
@@ -117,16 +126,27 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    * page length is unreliable (see loadLog).
    */
   function effectiveTotalCount(): number {
-    return activeScope.value ? scopedTotalCount.value : totalUnscopedCount.value;
+    return activeScope.value
+      ? scopedTotalCount.value
+      : totalUnscopedCount.value;
   }
 
   /** Refresh the unscoped + scoped rev counts for the hidden-commit badge. */
   async function loadRevCounts() {
     if (!folderPath.value) return;
     try {
-      totalUnscopedCount.value = await getGitRevCount(folderPath.value, undefined, true);
+      totalUnscopedCount.value = await getGitRevCount(
+        folderPath.value,
+        undefined,
+        true,
+      );
       scopedTotalCount.value = activeScope.value
-        ? await getGitRevCount(folderPath.value, undefined, true, activeScope.value)
+        ? await getGitRevCount(
+            folderPath.value,
+            undefined,
+            true,
+            activeScope.value,
+          )
         : totalUnscopedCount.value;
     } catch {
       // Non-fatal — the badge just won't update. Don't surface to the user.
@@ -149,11 +169,16 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
   });
 
   // Restore from localStorage when status (and thus branch) becomes known.
-  watch(() => status.value?.branch, (branch) => {
-    if (!branch) return;
-    const key = forcePushKey();
-    forcePushPreferred.value = key ? localStorage.getItem(key) === "1" : false;
-  });
+  watch(
+    () => status.value?.branch,
+    (branch) => {
+      if (!branch) return;
+      const key = forcePushKey();
+      forcePushPreferred.value = key
+        ? localStorage.getItem(key) === "1"
+        : false;
+    },
+  );
 
   // Commit editor state
   const COMMIT_SIGNATURE = "\u{1FA84} Commit via GitWand";
@@ -166,7 +191,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
         const s = JSON.parse(raw);
         if (s.commitSignature === false) return "";
       }
-    } catch { /* ignore */ }
+    } catch {
+      /* ignore */
+    }
     return COMMIT_SIGNATURE;
   }
 
@@ -292,10 +319,23 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
 
   /** Quick stats for the header and graph. */
   const repoStats = computed(() => {
-    if (!status.value) return { staged: 0, unstaged: 0, untracked: 0, conflicted: 0, added: 0, modified: 0, deleted: 0, renamed: 0 };
+    if (!status.value)
+      return {
+        staged: 0,
+        unstaged: 0,
+        untracked: 0,
+        conflicted: 0,
+        added: 0,
+        modified: 0,
+        deleted: 0,
+        renamed: 0,
+      };
     const s = status.value;
 
-    const fileStates = new Map<string, "added" | "modified" | "deleted" | "renamed">();
+    const fileStates = new Map<
+      string,
+      "added" | "modified" | "deleted" | "renamed"
+    >();
 
     for (const path of s.untracked) {
       fileStates.set(path, "added");
@@ -316,7 +356,10 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       else if (!current) fileStates.set(f.path, "modified");
     }
 
-    let added = 0, modified = 0, deleted = 0, renamed = 0;
+    let added = 0,
+      modified = 0,
+      deleted = 0,
+      renamed = 0;
     for (const state of fileStates.values()) {
       if (state === "added") added++;
       else if (state === "modified") modified++;
@@ -332,7 +375,7 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       added,
       modified,
       deleted,
-      renamed
+      renamed,
     };
   });
 
@@ -347,7 +390,11 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
 
   /** Can we commit? (staged files + non-empty summary) */
   const canCommit = computed(() => {
-    return repoStats.value.staged > 0 && commitSummary.value.trim().length > 0 && !isCommitting.value;
+    return (
+      repoStats.value.staged > 0 &&
+      commitSummary.value.trim().length > 0 &&
+      !isCommitting.value
+    );
   });
 
   /**
@@ -413,7 +460,13 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    */
   async function fetchRemote() {
     // Skip fetch during merge operations to avoid git lock conflicts
-    if (!folderPath.value || isFetching.value || isMerging.value || hasConflicts.value) return;
+    if (
+      !folderPath.value ||
+      isFetching.value ||
+      isMerging.value ||
+      hasConflicts.value
+    )
+      return;
     // F1 — Mode hors-ligne: short-circuit before hitting the IPC so we
     // can never hang on the 5-min NETWORK timeout when the link is dead.
     if (!(await requireOnline("fetch"))) return;
@@ -444,7 +497,7 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
     selectedCommitHash.value = null;
     commitDiffs.value = [];
     log.value = [];
-    branches.value = [];        // ← reset so the palette doesn't show stale branches from the previous repo
+    branches.value = []; // ← reset so the palette doesn't show stale branches from the previous repo
     selectedFilePath.value = null;
     diff.value = null;
 
@@ -494,10 +547,7 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    */
   async function refresh() {
     if (!folderPath.value) return;
-    await Promise.all([
-      loadStatus(folderPath.value),
-      loadLog(),
-    ]);
+    await Promise.all([loadStatus(folderPath.value), loadLog()]);
     // Also refresh diff if a file is selected
     if (selectedFilePath.value) {
       await loadDiff(selectedFilePath.value, selectedFileStaged.value);
@@ -533,38 +583,124 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
   // Page size used for both initial load and subsequent pages.
   const LOG_PAGE = 100;
 
+  // ── Full-history background prefetch + per-repo session cache ────────────
+  // The graph anchors every branch on main/master and wants a smooth
+  // scroll-to-root, so instead of a bounded trunk seek we lazily page the whole
+  // history in the background (idle-scheduled, cancellable) and cache it per
+  // repo. Re-opening the repo restores the full log instantly.
+  //
+  // Only the canonical view (all refs, all authors, no monorepo scope) is
+  // prefetched/cached — filtered views stay on-demand.
+  const LOG_CACHE = new Map<string, GitLogEntry[]>();
+  const BG_PAGE = 500; // larger background page → fewer layout recomputes
+  let _prefetchToken = 0;
+
+  function isCanonicalLogView(): boolean {
+    return (
+      logBranchFilter.value === "all" &&
+      logAuthorFilter.value === "all" &&
+      !activeScope.value
+    );
+  }
+
+  /** Resolve on the next idle slice so background paging never blocks input. */
+  function whenIdle(): Promise<void> {
+    return new Promise((resolve) => {
+      const ric = (globalThis as { requestIdleCallback?: (cb: () => void, o?: { timeout: number }) => void }).requestIdleCallback;
+      if (typeof ric === "function") ric(() => resolve(), { timeout: 300 });
+      else setTimeout(resolve, 32);
+    });
+  }
+
+  /**
+   * Lazily page the rest of the history in the background, appending as it
+   * goes, then cache the complete log. Cancels if the repo changes, the view
+   * leaves canonical, or a newer prefetch supersedes this one.
+   */
+  async function prefetchAllPages() {
+    if (!isCanonicalLogView()) return;
+    const token = ++_prefetchToken;
+    const repo = folderPath.value;
+    if (!repo) return;
+    const live = () =>
+      folderPath.value === repo &&
+      token === _prefetchToken &&
+      isCanonicalLogView();
+    while (live() && logHasMore.value) {
+      await whenIdle();
+      if (!live()) return;
+      await loadMoreLog(BG_PAGE);
+    }
+    if (live() && !logHasMore.value) {
+      LOG_CACHE.set(repo, log.value.slice());
+    }
+  }
+
   async function loadLog(count?: number) {
     if (!folderPath.value) return;
     try {
       const authorEmail =
-        logAuthorFilter.value === "mine" ? (currentGitUser.value?.email ?? "") : undefined;
-      // When refreshing, reload at least as many commits as are currently visible
-      // so polling doesn't silently collapse a paginated log back to page 1.
-      const pageSize = count ?? Math.max(LOG_PAGE, log.value.length);
+        logAuthorFilter.value === "mine"
+          ? (currentGitUser.value?.email ?? "")
+          : undefined;
       const isCurrentBranchOnly = logBranchFilter.value === "current";
+      const isCanon = isCanonicalLogView();
+      // Canonical view is backed by the cache + background prefetch, so a poll
+      // only needs a cheap first-page probe to detect HEAD movement. Filtered
+      // views reload at least what's visible so polling doesn't collapse a
+      // paginated log back to page 1.
+      const pageSize = isCanon
+        ? LOG_PAGE
+        : (count ?? Math.max(LOG_PAGE, log.value.length));
       const entries = await getGitLog(
         folderPath.value,
         pageSize,
-        !isCurrentBranchOnly,                            // all refs (false when branch-only)
+        !isCurrentBranchOnly, // all refs (false when branch-only)
         authorEmail,
         0,
         isCurrentBranchOnly ? (status.value?.branch ?? undefined) : undefined,
-        activeScope.value ?? undefined,                   // pathspec (monorepo scope)
+        activeScope.value ?? undefined, // pathspec (monorepo scope)
       );
-      log.value = entries;
       // Refresh the hidden-commit badge counts alongside the scoped log.
       await loadRevCounts();
-      // hasMore: in branch-only mode a full page is exactly `pageSize`. In
-      // all-refs mode the backend appends stash start-points and filters the
-      // `index on`/`untracked files on` pseudo-commits, so a full page returns
-      // FEWER than `pageSize` — `entries.length >= pageSize` would wrongly read
-      // false and kill infinite scroll. Use the authoritative rev-count there.
-      logHasMore.value = isCurrentBranchOnly
-        ? entries.length >= pageSize
-        : log.value.length < effectiveTotalCount();
+
+      const head = entries[0]?.hashFull;
+      if (isCanon) {
+        const cached = LOG_CACHE.get(folderPath.value);
+        const haveSameHead =
+          log.value.length >= entries.length && log.value[0]?.hashFull === head;
+        if (haveSameHead) {
+          // Poll while we already hold this page (or the full log / an in-flight
+          // prefetch) and HEAD hasn't moved — keep it, don't collapse. Resume
+          // the prefetch if it was interrupted.
+          if (logHasMore.value) void prefetchAllPages();
+        } else if (cached && cached.length > 0 && cached[0]?.hashFull === head) {
+          // HEAD unchanged since we cached the full history — restore instantly.
+          log.value = cached;
+          logHasMore.value = false;
+        } else {
+          // Fresh repo, or HEAD moved: show page 1 and prefetch the rest.
+          log.value = entries;
+          logHasMore.value = log.value.length < effectiveTotalCount();
+          void prefetchAllPages();
+        }
+      } else {
+        log.value = entries;
+        // hasMore: in branch-only mode a full page is exactly `pageSize`. In
+        // all-refs mode the backend appends stash start-points and filters the
+        // `index on`/`untracked files on` pseudo-commits, so a full page returns
+        // FEWER than `pageSize` — `entries.length >= pageSize` would wrongly read
+        // false and kill infinite scroll. Use the authoritative rev-count there.
+        logHasMore.value = isCurrentBranchOnly
+          ? entries.length >= pageSize
+          : log.value.length < effectiveTotalCount();
+      }
       // If a commit was selected but its diffs were lost, reload them
       if (selectedCommitHash.value && commitDiffs.value.length === 0) {
-        commitDiffs.value = await getGitShow(folderPath.value, selectedCommitHash.value);
+        commitDiffs.value = await getGitShow(
+          folderPath.value,
+          selectedCommitHash.value,
+        );
       }
     } catch (err: any) {
       error.value = `git log: ${err?.message ?? err}`;
@@ -575,17 +711,19 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    * Append the next page of commits to the log.
    * Called when the CommitLog scroll list emits `load-more`.
    */
-  async function loadMoreLog() {
+  async function loadMoreLog(pageSize: number = LOG_PAGE) {
     if (!folderPath.value || !logHasMore.value || logLoadingMore.value) return;
     logLoadingMore.value = true;
     try {
       const authorEmail =
-        logAuthorFilter.value === "mine" ? (currentGitUser.value?.email ?? "") : undefined;
+        logAuthorFilter.value === "mine"
+          ? (currentGitUser.value?.email ?? "")
+          : undefined;
       const offset = log.value.length;
       const isCurrentBranchOnly = logBranchFilter.value === "current";
       const next = await getGitLog(
         folderPath.value,
-        LOG_PAGE,
+        pageSize,
         !isCurrentBranchOnly,
         authorEmail,
         offset,
@@ -605,7 +743,9 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       // mode has no stash pollution, so a short page also means the end.
       logHasMore.value =
         added.length > 0 &&
-        (isCurrentBranchOnly ? next.length >= LOG_PAGE : log.value.length < effectiveTotalCount());
+        (isCurrentBranchOnly
+          ? next.length >= pageSize
+          : log.value.length < effectiveTotalCount());
     } catch (err: any) {
       error.value = `git log (page): ${err?.message ?? err}`;
     } finally {
@@ -820,7 +960,10 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       } else {
         // Show success feedback
         const msg = (result.message || "").trim();
-        if (msg.includes("Already up to date") || msg.includes("Already up-to-date")) {
+        if (
+          msg.includes("Already up to date") ||
+          msg.includes("Already up-to-date")
+        ) {
           successMessage.value = "already-up-to-date";
         } else {
           successMessage.value = "sync-done";
@@ -845,7 +988,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       await refresh();
 
       // Detect conflicts from both the server response and the git status
-      const hasConflictedFiles = status.value && status.value.conflicted.length > 0;
+      const hasConflictedFiles =
+        status.value && status.value.conflicted.length > 0;
       const serverSaysConflicts = result.conflicts === true;
 
       if (hasConflictedFiles) {
@@ -919,7 +1063,8 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
       const result = await gitCherryPick(folderPath.value, hashes);
       await refresh();
 
-      const hasConflictedFiles = status.value && status.value.conflicted.length > 0;
+      const hasConflictedFiles =
+        status.value && status.value.conflicted.length > 0;
       const serverSaysConflicts = result.conflicts === true;
 
       if (hasConflictedFiles) {
@@ -1114,14 +1259,21 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
    * "switch branch: " / "create branch: " / "switch (stash): ") and returns
    * false; callers map that to their own user-facing message.
    */
-  async function carryChangesToBranch(name: string, isCreate: boolean): Promise<boolean> {
+  async function carryChangesToBranch(
+    name: string,
+    isCreate: boolean,
+  ): Promise<boolean> {
     if (!folderPath.value) return false;
-    const direct = isCreate ? await createBranch(name) : await switchBranch(name);
+    const direct = isCreate
+      ? await createBranch(name)
+      : await switchBranch(name);
     if (direct) return true;
     isSwitchingBranch.value = true;
     try {
       await gitStash(folderPath.value);
-      const switched = isCreate ? await createBranch(name) : await switchBranch(name);
+      const switched = isCreate
+        ? await createBranch(name)
+        : await switchBranch(name);
       await gitStashPop(folderPath.value);
       return switched;
     } catch (err: any) {


### PR DESCRIPTION
## Summary
Implements background prefetching and caching for the desktop commit log while fixing pagination and deduplication issues in all-refs mode. This resolves input blocking and layout bottlenecks on large repositories, ensuring Git decorations and collections stay up-to-date after ref-mutating operations.

## Changes
- Fix log pagination and commit deduplication in all-refs mode to prevent offset shifts from stash pseudo-commits.
- Cache the Git log and prefetch pages in the background on idle slices.
- Cap background prefetching at 5,000 entries to prevent excessive memory usage.
- Force refresh the commit log on ref and decoration updates, bypassing the cache.
- Reload branches, stashes, and worktrees during manual fetches while keeping polling lightweight.

## Why
It fixes 2 bug!
- We were not able to scroll far in the past of the GitTree
- The Git Tree was looking broken

### Before

<img width="1911" height="879" alt="image" src="https://github.com/user-attachments/assets/9926ce5d-6383-4ca0-937e-8e2f04058a5a" />

### After
<img width="1464" height="700" alt="image" src="https://github.com/user-attachments/assets/d428471e-776a-437a-9e4e-54a72a3c4ccc" />

## Test plan
- [ ] Verify commit log caching loads the canonical log instantly when reopening a repository.
- [ ] Confirm pagination and deduplication function correctly in all-refs mode when scrolling.
- [ ] Verify that manual fetch updates branches, stashes, and worktrees immediately.
- [ ] Check that ref-mutating actions (like push/pull) successfully bypass caching to show fresh decorations.
- [ ] Verify background prefetch memory and layout footprints remain capped under 5,000 entries on large repos.