### PR TITLE
test(core): golden-funnel CI gate — the resolution funnel can't drift silently

### DIFF
--- a/docs/superpowers/specs/2026-07-07-recoverable-before-model-metric-design.md
+++ b/docs/superpowers/specs/2026-07-07-recoverable-before-model-metric-design.md
@@ -4,7 +4,7 @@ Status: **Draft / for spec** · Target: **PR #117** (`feat/merge-conflicts-token
 
 ## 1. Origin & motivation
 
-A technical exchange on the Show HN thread surfaced two linked issues in the resolution pipeline:
+A technical exchange on the r/git thread surfaced two linked issues in the resolution pipeline:
 
 1. **Coupling bug** — `refactoringAware` and `llmFallback` are *independent* opt-ins. A user can enable the LLM path without the deterministic rename recoverer, so the model gets invoked on conflicts that were deterministically recoverable.
 2. **Missing metric** — the engine reports `~95% auto-resolved` as a flat number. What's actually decision-useful is: *of the residual left after the cheap deterministic passes, how much is still recoverable deterministically before the model is ever invoked.*

--- a/packages/core/src/__tests__/golden-funnel.default.json
+++ b/packages/core/src/__tests__/golden-funnel.default.json
@@ -1,0 +1,26 @@
+{
+  "fixtures": 46,
+  "totalHunks": 46,
+  "autoResolved": 31,
+  "byType": {
+    "complex": 20,
+    "delete_no_change": 2,
+    "generated_file": 1,
+    "insertion_at_boundary": 4,
+    "non_overlapping": 4,
+    "one_side_change": 5,
+    "reorder_only": 1,
+    "same_change": 3,
+    "token_level_merge": 1,
+    "value_only_change": 4,
+    "whitespace_only": 1
+  },
+  "tiers": {
+    "trivial": 25,
+    "advancedDeterministic": 1,
+    "model": 0,
+    "unresolved": 20,
+    "residual": 21,
+    "aiReachable": 20
+  }
+}

--- a/packages/core/src/__tests__/golden-funnel.refactoring.json
+++ b/packages/core/src/__tests__/golden-funnel.refactoring.json
@@ -1,0 +1,27 @@
+{
+  "fixtures": 46,
+  "totalHunks": 46,
+  "autoResolved": 31,
+  "byType": {
+    "complex": 19,
+    "delete_no_change": 2,
+    "generated_file": 1,
+    "insertion_at_boundary": 4,
+    "non_overlapping": 4,
+    "one_side_change": 5,
+    "refactoring_aware_merge": 1,
+    "reorder_only": 1,
+    "same_change": 3,
+    "token_level_merge": 1,
+    "value_only_change": 4,
+    "whitespace_only": 1
+  },
+  "tiers": {
+    "trivial": 25,
+    "advancedDeterministic": 2,
+    "model": 0,
+    "unresolved": 19,
+    "residual": 21,
+    "aiReachable": 19
+  }
+}

--- a/packages/core/src/__tests__/golden-funnel.test.ts
+++ b/packages/core/src/__tests__/golden-funnel.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Golden funnel — le gate CI anti-rot de la métrique recoverable-before-model.
+ *
+ * Origine : un commentaire du thread Show HN — « feels like the kind of number
+ * that quietly rots the second nobody's watching it ». Réponse : le funnel
+ * complet (byType agrégé sur tout le corpus + résumé par tier + compteurs
+ * d'auto-résolution) est snapshotté dans `golden-funnel.json`, committé, et
+ * comparé ici à chaque run CI. Tout changement de moteur qui déplace le funnel
+ * doit toucher le fichier golden DANS LA MÊME PR — le nombre ne peut plus
+ * dériver en silence, il ne peut que changer explicitement, sous review.
+ *
+ * ## Ce que ce gate ajoute aux assertions existantes
+ *
+ * - `corpus.test.ts` vérifie le type de `hunks[0]` par fixture ; ici on agrège
+ *   TOUS les hunks de TOUTES les fixtures, dans deux configurations (défaut et
+ *   refactoringAware) — un pattern qui se met à en shadower un autre, ou qui
+ *   cesse de matcher sur un cas secondaire, apparaît dans le diff du golden.
+ * - Les nombres dérivés (residual, aiReachable, recoverableBeforeModel) sont
+ *   snapshotté s en absolu — comptes, pas ratios : sur un corpus de cette
+ *   taille un ratio fait des embardées à chaque fixture ajoutée.
+ *
+ * ## Anti-Goodhart — la paire obligatoire
+ *
+ * Un gate « aiReachable ne doit pas croître » pris SEUL inciterait à rendre
+ * les patterns plus agressifs pour garder le chiffre vert — exactement la
+ * maladie « des patterns qui concurrencent l'IA au lieu de la backstopper ».
+ * C'est pourquoi le golden snapshotte AUSSI `autoResolved` (une agressivité
+ * nouvelle se voit comme un saut d'auto-résolution dans le même diff), et ce
+ * test n'a de sens qu'à côté des assertions zéro-faux-positif de
+ * `corpus.test.ts` (« complex n'est jamais auto-résolu »). L'un sans l'autre
+ * est pire que rien.
+ *
+ * ## Mise à jour
+ *
+ * Changement de funnel intentionnel (nouveau pattern, fixture ajoutée, fix de
+ * classification) :
+ *
+ *   npx vitest run src/__tests__/golden-funnel.test.ts -u
+ *
+ * puis relire le diff de `golden-funnel.json` dans la PR comme n'importe quel
+ * changement de comportement.
+ */
+
+import { describe, it, expect } from "vitest";
+import { resolve } from "../resolver.js";
+import { summarizeTiers } from "../stats/tiers.js";
+import { CORPUS } from "./corpus.js";
+import type { ConflictType } from "../types.js";
+
+interface FunnelSnapshot {
+  fixtures: number;
+  totalHunks: number;
+  autoResolved: number;
+  byType: Record<string, number>;
+  tiers: {
+    trivial: number;
+    advancedDeterministic: number;
+    model: number;
+    unresolved: number;
+    residual: number;
+    aiReachable: number;
+  };
+}
+
+/** Agrège le funnel sur tout le corpus pour une configuration d'options donnée. */
+function computeFunnel(extraOptions: Record<string, unknown>): FunnelSnapshot {
+  const byType: Partial<Record<ConflictType, number>> = {};
+  let totalHunks = 0;
+  let autoResolved = 0;
+
+  for (const fixture of CORPUS) {
+    const result = resolve(fixture.input, fixture.filePath, {
+      ...(fixture.options ?? {}),
+      ...extraOptions,
+    });
+    totalHunks += result.stats.totalConflicts;
+    autoResolved += result.stats.autoResolved;
+    for (const [type, count] of Object.entries(result.stats.byType)) {
+      if (count > 0) {
+        const t = type as ConflictType;
+        byType[t] = (byType[t] ?? 0) + count;
+      }
+    }
+  }
+
+  const tiers = summarizeTiers(byType as Record<ConflictType, number>);
+  return {
+    fixtures: CORPUS.length,
+    totalHunks,
+    autoResolved,
+    // Tri des clés pour un diff stable et lisible
+    byType: Object.fromEntries(Object.entries(byType).sort(([a], [b]) => a.localeCompare(b))),
+    tiers: {
+      trivial: tiers.byTier.trivial,
+      advancedDeterministic: tiers.byTier.advancedDeterministic,
+      model: tiers.byTier.model,
+      unresolved: tiers.byTier.unresolved,
+      residual: tiers.residual,
+      aiReachable: tiers.aiReachable,
+    },
+  };
+}
+
+describe("Golden funnel — le funnel de résolution ne change jamais en silence", () => {
+  it("configuration par défaut", async () => {
+    const funnel = computeFunnel({});
+    await expect(JSON.stringify(funnel, null, 2) + "\n")
+      .toMatchFileSnapshot("./golden-funnel.default.json");
+  });
+
+  it("configuration refactoringAware activé", async () => {
+    const funnel = computeFunnel({ refactoringAware: { enabled: true } });
+    await expect(JSON.stringify(funnel, null, 2) + "\n")
+      .toMatchFileSnapshot("./golden-funnel.refactoring.json");
+  });
+
+  it("invariant : activer refactoringAware ne fait jamais CROÎTRE le bucket AI-reachable", () => {
+    const off = computeFunnel({});
+    const on = computeFunnel({ refactoringAware: { enabled: true } });
+    expect(on.tiers.aiReachable).toBeLessThanOrEqual(off.tiers.aiReachable);
+  });
+});

--- a/packages/core/src/__tests__/golden-funnel.test.ts
+++ b/packages/core/src/__tests__/golden-funnel.test.ts
@@ -1,7 +1,7 @@
 /**
  * Golden funnel — le gate CI anti-rot de la métrique recoverable-before-model.
  *
- * Origine : un commentaire du thread Show HN — « feels like the kind of number
+ * Origine : un commentaire du thread r/git — « feels like the kind of number
  * that quietly rots the second nobody's watching it ». Réponse : le funnel
  * complet (byType agrégé sur tout le corpus + résumé par tier + compteurs
  * d'auto-résolution) est snapshotté dans `golden-funnel.json`, committé, et


### PR DESCRIPTION
## What

A "golden funnel" CI gate: the full resolution funnel (byType aggregated across every hunk of every corpus fixture, auto-resolution counts, tier summary in absolute numbers) is snapshotted into two committed JSON files (`golden-funnel.default.json`, `golden-funnel.refactoring.json`) and compared on every CI run.

## Why

Follow-up to the r/git discussion — the comment that originated the recoverable-before-model metric (PR #117) followed up with: *"you gonna actually gate CI on the AI-reachable bucket not growing, or just track it? feels like the kind of number that quietly rots the second nobody's watching it."*

Fair point: the existing regression guard only covers `token_level_merge`'s behavior, and the real-world corpus measurements were manual runs. This gate makes silent drift impossible: vitest refuses to write a divergent snapshot under `CI=true`, so any engine change that moves the funnel must update the golden files **in the same PR** — classification drift becomes an explicit, reviewable diff.

## Anti-Goodhart

A bare "aiReachable must not grow" gate would create pressure to make patterns more aggressive just to keep the number green — exactly the "patterns competing with the AI path" disease the original comment called out. Hence the pairing:
- `autoResolved` is snapshotted alongside `aiReachable` — newly aggressive patterns show up as an auto-resolution jump in the same diff;
- the gate complements the existing zero-false-positive assertions in `corpus.test.ts`.

Bonus: a standing invariant is asserted — enabling `refactoringAware` never grows the AI-reachable bucket (20 → 19 on the current corpus).

## Updating the golden files

```
npx vitest run src/__tests__/golden-funnel.test.ts -u
```
then review the JSON diff in the PR like any other behavior change.

## Tests

core 965 ✅ (+3), snapshots stable across re-runs.
