### PR TITLE
fix(desktop): reorder repo tabs via pointer events (mouse, touch, pen) + keyboard a11y

### DIFF
--- a/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
+++ b/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
@@ -1,0 +1,159 @@
+/**
+ * RepoTabStrip.vue — pointer-based drag-to-reorder regression guards.
+ *
+ * Native HTML5 drag-and-drop is unreliable in the WebKit webviews that power
+ * the packaged Tauri app, so tab reordering is driven by plain mouse events
+ * instead (see the "Drag to reorder" comment block in the component). That
+ * hand-rolled state machine has sharp edges a component test can pin down
+ * without a real browser: a click near a tab's own edge must not itself
+ * register as a reorder, and a drag must only ever be committed by the
+ * button (and only that button) that started it.
+ *
+ * Mounted with native `createApp` into jsdom (no @vue/test-utils dep),
+ * mirroring MergeEditor.test / LlmTracePanel.test / LaunchpadView.test.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { createApp, h, nextTick, type App } from "vue";
+import RepoTabStrip from "../header/RepoTabStrip.vue";
+import type { RepoTab } from "../../composables/useRepoTabs";
+
+function makeTabs(n: number): RepoTab[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: i + 1,
+    path: `/repo-${i}`,
+    name: `repo-${i}`,
+  }));
+}
+
+let app: App | null = null;
+let container: HTMLElement | null = null;
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  container?.remove();
+  container = null;
+});
+
+interface Mounted {
+  tabEls: HTMLElement[];
+  reorders: Array<[number, number]>;
+}
+
+function mount(tabs: RepoTab[]): Mounted {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  const reorders: Array<[number, number]> = [];
+
+  app = createApp({
+    render() {
+      return h(RepoTabStrip, {
+        tabs,
+        activeTabId: tabs[0]?.id ?? null,
+        onReorderTabs: (oldIndex: number, newIndex: number) => {
+          reorders.push([oldIndex, newIndex]);
+        },
+      });
+    },
+  });
+  app.mount(container);
+
+  const tabEls = Array.from(container.querySelectorAll<HTMLElement>(".repo-tab"));
+  return { tabEls, reorders };
+}
+
+/** Stubs the geometry each tab needs for the drag hit-test to run in jsdom. */
+function stubRects(tabEls: HTMLElement[], widths: number[]) {
+  let left = 0;
+  for (let i = 0; i < tabEls.length; i++) {
+    const width = widths[i];
+    const rect = { left, right: left + width, top: 0, bottom: 30, width, height: 30 } as DOMRect;
+    tabEls[i].getBoundingClientRect = () => rect;
+    left += width;
+  }
+}
+
+function fireMouse(target: EventTarget, type: string, opts: Partial<MouseEvent> & { clientX?: number; clientY?: number; button?: number }) {
+  const event = new MouseEvent(type, { bubbles: true, cancelable: true, button: opts.button ?? 0 });
+  Object.defineProperty(event, "clientX", { get: () => opts.clientX ?? 0 });
+  Object.defineProperty(event, "clientY", { get: () => opts.clientY ?? 15 });
+  target.dispatchEvent(event);
+}
+
+describe("RepoTabStrip — drag to reorder", () => {
+  it("a few pixels of wobble on a tab's right half does not reorder it", async () => {
+    // Regression: the hit-test used to compare the raw cursor position
+    // against each tab's center, so pressing the right half of a wide tab
+    // put the cursor on the far side of its own center *before any
+    // movement at all* — a subsequent few-pixel wobble (well under what
+    // anyone would call a drag) was enough to swap it with its neighbour.
+    const { tabEls, reorders } = mount(makeTabs(3));
+    stubRects(tabEls, [100, 100, 100]);
+
+    // Press near the right edge of tab 0 (center is at x=50).
+    fireMouse(tabEls[0], "mousedown", { clientX: 90 });
+    // Wobble 5px right — just past the 4px drag threshold.
+    fireMouse(window, "mousemove", { clientX: 95 });
+    fireMouse(window, "mouseup", { clientX: 95 });
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+
+  it("dragging a tab past its neighbour's center reorders it", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+    stubRects(tabEls, [100, 100, 100]);
+
+    // Press at the center of tab 0 and drag well past tab 1's center (150).
+    fireMouse(tabEls[0], "mousedown", { clientX: 50 });
+    fireMouse(window, "mousemove", { clientX: 160 });
+    fireMouse(window, "mouseup", { clientX: 160 });
+    await nextTick();
+
+    expect(reorders).toEqual([[0, 1]]);
+  });
+
+  it("a right-click released mid-drag does not commit or cancel it", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+    stubRects(tabEls, [100, 100, 100]);
+
+    fireMouse(tabEls[0], "mousedown", { clientX: 50, button: 0 });
+    fireMouse(window, "mousemove", { clientX: 160 });
+    // A right-button mouseup mid-drag must be ignored...
+    fireMouse(window, "mouseup", { clientX: 160, button: 2 });
+    await nextTick();
+    expect(reorders).toEqual([]);
+    // ...the left-button release still ends the drag normally.
+    fireMouse(window, "mouseup", { clientX: 160, button: 0 });
+    await nextTick();
+    expect(reorders).toEqual([[0, 1]]);
+  });
+
+  it("releasing far outside the strip cancels the drag instead of reordering", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+    stubRects(tabEls, [100, 100, 100]);
+
+    fireMouse(tabEls[0], "mousedown", { clientX: 50 });
+    // Drag past tab 1's center but with the cursor far below the strip.
+    fireMouse(window, "mousemove", { clientX: 160, clientY: 500 });
+    fireMouse(window, "mouseup", { clientX: 160, clientY: 500 });
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+
+  it("a window blur mid-drag cancels it", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+    stubRects(tabEls, [100, 100, 100]);
+
+    fireMouse(tabEls[0], "mousedown", { clientX: 50 });
+    fireMouse(window, "mousemove", { clientX: 160 });
+    window.dispatchEvent(new Event("blur"));
+    // The mouseup that follows (returning from another app) must not commit.
+    fireMouse(window, "mouseup", { clientX: 160 });
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+});

--- a/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
+++ b/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
@@ -222,24 +222,26 @@ describe("RepoTabStrip — drag to reorder", () => {
 });
 
 describe("RepoTabStrip — keyboard reordering", () => {
-  function fireCtrlArrow(target: EventTarget, key: "ArrowLeft" | "ArrowRight") {
-    target.dispatchEvent(new KeyboardEvent("keydown", { key, ctrlKey: true, bubbles: true, cancelable: true }));
+  function fireCtrlShiftArrow(target: EventTarget, key: "ArrowLeft" | "ArrowRight") {
+    target.dispatchEvent(
+      new KeyboardEvent("keydown", { key, ctrlKey: true, shiftKey: true, bubbles: true, cancelable: true }),
+    );
   }
 
-  it("Ctrl+ArrowRight moves the focused tab one slot right and announces it", async () => {
+  it("Ctrl+Shift+ArrowRight moves the focused tab one slot right and announces it", async () => {
     const { tabEls, reorders } = mount(makeTabs(3));
 
-    fireCtrlArrow(tabEls[0], "ArrowRight");
+    fireCtrlShiftArrow(tabEls[0], "ArrowRight");
     await nextTick();
 
     expect(reorders).toEqual([[0, 1]]);
     expect(container?.querySelector('[role="status"]')?.textContent).toBe("repo-0 moved to position 2 of 3");
   });
 
-  it("Ctrl+ArrowLeft moves the focused tab one slot left", async () => {
+  it("Ctrl+Shift+ArrowLeft moves the focused tab one slot left", async () => {
     const { tabEls, reorders } = mount(makeTabs(3));
 
-    fireCtrlArrow(tabEls[1], "ArrowLeft");
+    fireCtrlShiftArrow(tabEls[1], "ArrowLeft");
     await nextTick();
 
     expect(reorders).toEqual([[1, 0]]);
@@ -248,8 +250,8 @@ describe("RepoTabStrip — keyboard reordering", () => {
   it("does nothing at the boundary (first tab can't move left, last can't move right)", async () => {
     const { tabEls, reorders } = mount(makeTabs(3));
 
-    fireCtrlArrow(tabEls[0], "ArrowLeft");
-    fireCtrlArrow(tabEls[2], "ArrowRight");
+    fireCtrlShiftArrow(tabEls[0], "ArrowLeft");
+    fireCtrlShiftArrow(tabEls[2], "ArrowRight");
     await nextTick();
 
     expect(reorders).toEqual([]);
@@ -259,6 +261,23 @@ describe("RepoTabStrip — keyboard reordering", () => {
     const { tabEls, reorders } = mount(makeTabs(3));
 
     tabEls[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }));
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+
+  it("bare Ctrl+ArrowRight (no Shift) does not reorder", async () => {
+    // Regression: a bare Ctrl+Arrow is macOS's default Mission Control
+    // "switch Space" shortcut, intercepted by the OS before it would even
+    // reach the app — Shift is required precisely to stay clear of that (and
+    // of third-party window-manager shortcuts using the same bare combo).
+    // This only guards our own handler's condition; it can't simulate the
+    // OS swallowing the event outright.
+    const { tabEls, reorders } = mount(makeTabs(3));
+
+    tabEls[0].dispatchEvent(
+      new KeyboardEvent("keydown", { key: "ArrowRight", ctrlKey: true, bubbles: true, cancelable: true }),
+    );
     await nextTick();
 
     expect(reorders).toEqual([]);

--- a/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
+++ b/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
@@ -2,12 +2,22 @@
  * RepoTabStrip.vue — pointer-based drag-to-reorder regression guards.
  *
  * Native HTML5 drag-and-drop is unreliable in the WebKit webviews that power
- * the packaged Tauri app, so tab reordering is driven by plain mouse events
- * instead (see the "Drag to reorder" comment block in the component). That
- * hand-rolled state machine has sharp edges a component test can pin down
- * without a real browser: a click near a tab's own edge must not itself
- * register as a reorder, and a drag must only ever be committed by the
- * button (and only that button) that started it.
+ * the packaged Tauri app, so tab reordering is driven by Pointer Events
+ * instead (see the "Drag to reorder" comment block in the component) — one
+ * code path for mouse, touch and pen. That hand-rolled state machine has
+ * sharp edges a component test can pin down without a real browser: a click
+ * near a tab's own edge must not itself register as a reorder, a drag must
+ * only ever be committed by the button that started it, and a re-snapshot
+ * mid-drag (scroll, resize) must not double-count the dragged tab's own live
+ * offset.
+ *
+ * jsdom has no PointerEvent constructor and no setPointerCapture, so drags
+ * are driven with plain `Event` objects carrying the same fields the
+ * component reads off a real PointerEvent (clientX/clientY/button/pointerId)
+ * — dispatchEvent doesn't care which Event subclass a listener was declared
+ * against, only the `type` string. The component itself feature-detects
+ * setPointerCapture, so it degrades to window-listener-only tracking under
+ * jsdom exactly like it would in a webview that lacks pointer capture.
  *
  * Mounted with native `createApp` into jsdom (no @vue/test-utils dep),
  * mirroring MergeEditor.test / LlmTracePanel.test / LaunchpadView.test.
@@ -64,20 +74,29 @@ function mount(tabs: RepoTab[]): Mounted {
 }
 
 /** Stubs the geometry each tab needs for the drag hit-test to run in jsdom. */
-function stubRects(tabEls: HTMLElement[], widths: number[]) {
+function stubRects(tabEls: HTMLElement[], widths: number[], lefts?: number[]) {
   let left = 0;
   for (let i = 0; i < tabEls.length; i++) {
     const width = widths[i];
-    const rect = { left, right: left + width, top: 0, bottom: 30, width, height: 30 } as DOMRect;
+    const l = lefts ? lefts[i] : left;
+    const rect = { left: l, right: l + width, top: 0, bottom: 30, width, height: 30 } as DOMRect;
     tabEls[i].getBoundingClientRect = () => rect;
     left += width;
   }
 }
 
-function fireMouse(target: EventTarget, type: string, opts: Partial<MouseEvent> & { clientX?: number; clientY?: number; button?: number }) {
-  const event = new MouseEvent(type, { bubbles: true, cancelable: true, button: opts.button ?? 0 });
+let nextPointerId = 1;
+
+function firePointer(
+  target: EventTarget,
+  type: string,
+  opts: { clientX?: number; clientY?: number; button?: number; pointerId?: number },
+) {
+  const event = new Event(type, { bubbles: true, cancelable: true });
   Object.defineProperty(event, "clientX", { get: () => opts.clientX ?? 0 });
   Object.defineProperty(event, "clientY", { get: () => opts.clientY ?? 15 });
+  Object.defineProperty(event, "button", { get: () => opts.button ?? 0 });
+  Object.defineProperty(event, "pointerId", { get: () => opts.pointerId ?? nextPointerId });
   target.dispatchEvent(event);
 }
 
@@ -92,10 +111,10 @@ describe("RepoTabStrip — drag to reorder", () => {
     stubRects(tabEls, [100, 100, 100]);
 
     // Press near the right edge of tab 0 (center is at x=50).
-    fireMouse(tabEls[0], "mousedown", { clientX: 90 });
+    firePointer(tabEls[0], "pointerdown", { clientX: 90 });
     // Wobble 5px right — just past the 4px drag threshold.
-    fireMouse(window, "mousemove", { clientX: 95 });
-    fireMouse(window, "mouseup", { clientX: 95 });
+    firePointer(window, "pointermove", { clientX: 95 });
+    firePointer(window, "pointerup", { clientX: 95 });
     await nextTick();
 
     expect(reorders).toEqual([]);
@@ -106,9 +125,9 @@ describe("RepoTabStrip — drag to reorder", () => {
     stubRects(tabEls, [100, 100, 100]);
 
     // Press at the center of tab 0 and drag well past tab 1's center (150).
-    fireMouse(tabEls[0], "mousedown", { clientX: 50 });
-    fireMouse(window, "mousemove", { clientX: 160 });
-    fireMouse(window, "mouseup", { clientX: 160 });
+    firePointer(tabEls[0], "pointerdown", { clientX: 50 });
+    firePointer(window, "pointermove", { clientX: 160 });
+    firePointer(window, "pointerup", { clientX: 160 });
     await nextTick();
 
     expect(reorders).toEqual([[0, 1]]);
@@ -118,14 +137,14 @@ describe("RepoTabStrip — drag to reorder", () => {
     const { tabEls, reorders } = mount(makeTabs(3));
     stubRects(tabEls, [100, 100, 100]);
 
-    fireMouse(tabEls[0], "mousedown", { clientX: 50, button: 0 });
-    fireMouse(window, "mousemove", { clientX: 160 });
-    // A right-button mouseup mid-drag must be ignored...
-    fireMouse(window, "mouseup", { clientX: 160, button: 2 });
+    firePointer(tabEls[0], "pointerdown", { clientX: 50, button: 0 });
+    firePointer(window, "pointermove", { clientX: 160 });
+    // A right-button pointerup mid-drag must be ignored...
+    firePointer(window, "pointerup", { clientX: 160, button: 2 });
     await nextTick();
     expect(reorders).toEqual([]);
     // ...the left-button release still ends the drag normally.
-    fireMouse(window, "mouseup", { clientX: 160, button: 0 });
+    firePointer(window, "pointerup", { clientX: 160, button: 0 });
     await nextTick();
     expect(reorders).toEqual([[0, 1]]);
   });
@@ -134,10 +153,10 @@ describe("RepoTabStrip — drag to reorder", () => {
     const { tabEls, reorders } = mount(makeTabs(3));
     stubRects(tabEls, [100, 100, 100]);
 
-    fireMouse(tabEls[0], "mousedown", { clientX: 50 });
+    firePointer(tabEls[0], "pointerdown", { clientX: 50 });
     // Drag past tab 1's center but with the cursor far below the strip.
-    fireMouse(window, "mousemove", { clientX: 160, clientY: 500 });
-    fireMouse(window, "mouseup", { clientX: 160, clientY: 500 });
+    firePointer(window, "pointermove", { clientX: 160, clientY: 500 });
+    firePointer(window, "pointerup", { clientX: 160, clientY: 500 });
     await nextTick();
 
     expect(reorders).toEqual([]);
@@ -147,11 +166,99 @@ describe("RepoTabStrip — drag to reorder", () => {
     const { tabEls, reorders } = mount(makeTabs(3));
     stubRects(tabEls, [100, 100, 100]);
 
-    fireMouse(tabEls[0], "mousedown", { clientX: 50 });
-    fireMouse(window, "mousemove", { clientX: 160 });
+    firePointer(tabEls[0], "pointerdown", { clientX: 50 });
+    firePointer(window, "pointermove", { clientX: 160 });
     window.dispatchEvent(new Event("blur"));
-    // The mouseup that follows (returning from another app) must not commit.
-    fireMouse(window, "mouseup", { clientX: 160 });
+    // The pointerup that follows (returning from another app) must not commit.
+    firePointer(window, "pointerup", { clientX: 160 });
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+
+  it("a pointercancel mid-drag (e.g. a touch gesture interrupted) cancels it", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+    stubRects(tabEls, [100, 100, 100]);
+
+    firePointer(tabEls[0], "pointerdown", { clientX: 50 });
+    firePointer(window, "pointermove", { clientX: 160 });
+    firePointer(window, "pointercancel", { clientX: 160 });
+    firePointer(window, "pointerup", { clientX: 160 });
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+
+  it("a resize mid-drag re-snapshots without double-counting the dragged tab's own offset", async () => {
+    // Regression: re-snapshotting centers mid-drag (on scroll or resize) used
+    // to re-measure the dragged tab's rect as-is — but that rect already
+    // includes the live translateX a real browser would have painted, so the
+    // offset got added to the hit-test a second time and the drop landed one
+    // slot further than it should have.
+    const { tabEls, reorders } = mount(makeTabs(3));
+    // Resting centers: 50, 150, 250 (widths 100 each, lefts 0/100/200).
+    stubRects(tabEls, [100, 100, 100]);
+
+    firePointer(tabEls[0], "pointerdown", { clientX: 50 });
+    // Drag 100px right — didDrag flips true and snapshots the resting
+    // centers; hoveredIndex is still 0 (hasn't crossed tab 1's center yet).
+    firePointer(window, "pointermove", { clientX: 150 });
+
+    // Simulate the DOM now reflecting that 100px live translateX: tab 0's
+    // rect has visually shifted right by 100, exactly as a real browser
+    // would render it mid-drag (the other tabs don't move).
+    stubRects(tabEls, [100, 100, 100], [100, 100, 200]);
+    window.dispatchEvent(new Event("resize"));
+
+    // Move on to a total offset of 110px from the press point — enough to
+    // cross tab 1's resting center (150) but not tab 2's (250) once the
+    // resize re-snapshot has correctly stripped the baked-in offset back out.
+    firePointer(window, "pointermove", { clientX: 160 });
+    firePointer(window, "pointerup", { clientX: 160 });
+    await nextTick();
+
+    expect(reorders).toEqual([[0, 1]]);
+  });
+});
+
+describe("RepoTabStrip — keyboard reordering", () => {
+  function fireCtrlArrow(target: EventTarget, key: "ArrowLeft" | "ArrowRight") {
+    target.dispatchEvent(new KeyboardEvent("keydown", { key, ctrlKey: true, bubbles: true, cancelable: true }));
+  }
+
+  it("Ctrl+ArrowRight moves the focused tab one slot right and announces it", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+
+    fireCtrlArrow(tabEls[0], "ArrowRight");
+    await nextTick();
+
+    expect(reorders).toEqual([[0, 1]]);
+    expect(container?.querySelector('[role="status"]')?.textContent).toBe("repo-0 moved to position 2 of 3");
+  });
+
+  it("Ctrl+ArrowLeft moves the focused tab one slot left", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+
+    fireCtrlArrow(tabEls[1], "ArrowLeft");
+    await nextTick();
+
+    expect(reorders).toEqual([[1, 0]]);
+  });
+
+  it("does nothing at the boundary (first tab can't move left, last can't move right)", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+
+    fireCtrlArrow(tabEls[0], "ArrowLeft");
+    fireCtrlArrow(tabEls[2], "ArrowRight");
+    await nextTick();
+
+    expect(reorders).toEqual([]);
+  });
+
+  it("a plain ArrowRight (no modifier) does not reorder — only switches focus natively", async () => {
+    const { tabEls, reorders } = mount(makeTabs(3));
+
+    tabEls[0].dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true }));
     await nextTick();
 
     expect(reorders).toEqual([]);

--- a/apps/desktop/src/components/header/RepoTabStrip.vue
+++ b/apps/desktop/src/components/header/RepoTabStrip.vue
@@ -693,14 +693,22 @@ function onCloseClick(e: MouseEvent, tabId: number) {
   font-weight: var(--font-weight-medium);
   color: var(--color-text-muted);
   background: transparent;
-  border: 0;
+  /* Transparent by default so the active chip (below) and inactive chips share
+     the same box size — inactive tabs colour this border in. */
+  border: 1px solid transparent;
   cursor: pointer;
-  transition: color var(--transition-base), background var(--transition-base);
+  transition: color var(--transition-base), background var(--transition-base), border-color var(--transition-base);
   max-width: 200px;
   min-width: 0;
   flex-shrink: 1;
   user-select: none;
   white-space: nowrap;
+}
+
+/* Inactive tabs get a faint outline so they read as distinct chips and their
+   caret / close affordances feel reachable even without hovering. */
+.repo-tab:not(.repo-tab--active) {
+  border-color: color-mix(in srgb, var(--color-border) 45%, transparent);
 }
 
 .repo-tab:hover {
@@ -776,7 +784,7 @@ function onCloseClick(e: MouseEvent, tabId: number) {
   /* Follow the chip's own color logic, exactly like .repo-tab__name:
      muted by default, text on chip hover, accent when active. */
   color: inherit;
-  opacity: 0;
+  opacity: 0.4;
   cursor: pointer;
   transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
   margin: 0px -5px;
@@ -882,7 +890,7 @@ function onCloseClick(e: MouseEvent, tabId: number) {
   height: 18px;
   border-radius: var(--radius-pill);
   color: var(--color-text-muted);
-  opacity: 0;
+  opacity: 0.4;
   transition: opacity var(--transition-fast), background var(--transition-fast), color var(--transition-fast);
   padding: 0;
 }

--- a/apps/desktop/src/components/header/RepoTabStrip.vue
+++ b/apps/desktop/src/components/header/RepoTabStrip.vue
@@ -73,17 +73,21 @@ function isScratch(path: string): boolean {
 // Native HTML5 drag-and-drop is unreliable in WebKit (WKWebView on macOS,
 // WebKitGTK on Linux — both power the packaged Tauri app): `dragstart`
 // frequently never fires, so the tabs couldn't be reordered and no drop
-// indicator showed. We drive it with plain mouse events instead, which
-// behave identically across every webview. draggedIndex / hoveredIndex keep
-// the same meaning the CSS classes expect (source index / hovered target).
+// indicator showed. Pointer events drive it instead — one code path for
+// mouse, touch and pen — and the gesture is claimed via setPointerCapture so
+// a native touch-scroll can't steal it mid-drag. draggedIndex / hoveredIndex
+// keep the same meaning the CSS classes expect (source index / hovered
+// target).
 const draggedIndex = ref<number | null>(null);
 const hoveredIndex = ref<number | null>(null);
 const stripEl = ref<HTMLElement | null>(null);
 // Live horizontal offset of the tab being dragged, so it tracks the cursor.
 const dragOffsetX = ref(0);
+/** Rendered by the aria-live region — feedback for a keyboard reorder. */
+const announceText = ref("");
 
-// A press only becomes a drag past this threshold, so a plain click still
-// switches tabs instead of being swallowed as a (zero-distance) drag.
+// A press only becomes a drag past this threshold, so a plain click/tap
+// still switches tabs instead of being swallowed as a (zero-distance) drag.
 const DRAG_THRESHOLD_PX = 4;
 // How far above/below the strip the cursor can stray before a release reads
 // as "dropped outside" (cancelled) rather than a reorder.
@@ -91,6 +95,11 @@ const DRAG_VERTICAL_TOLERANCE_PX = 40;
 let pressIndex: number | null = null;
 let pressStartX = 0;
 let didDrag = false;
+// The element/pointer a drag claimed via setPointerCapture, so it can be
+// released again in finishDrag. Capture is best-effort: some webviews don't
+// implement it, so every use is feature-detected and wrapped in try/catch.
+let capturedEl: HTMLElement | null = null;
+let capturedPointerId: number | null = null;
 // Center-x of each tab captured when the drag begins. The dragged tab gets a
 // translateX to follow the cursor, which would move its own bounding rect — so
 // we hit-test against this snapshot (the other tabs don't move until drop).
@@ -99,9 +108,17 @@ let tabCenters: number[] = [];
 function snapshotCenters() {
   const root = stripEl.value;
   tabCenters = root
-    ? Array.from(root.querySelectorAll<HTMLElement>(".repo-tab")).map((el) => {
+    ? Array.from(root.querySelectorAll<HTMLElement>(".repo-tab")).map((el, i) => {
         const r = el.getBoundingClientRect();
-        return r.left + r.width / 2;
+        const center = r.left + r.width / 2;
+        // The dragged tab renders with a live translateX so it visually
+        // tracks the pointer; a re-snapshot mid-drag (scroll, resize) would
+        // otherwise measure that offset baked into its rect and then add
+        // dragOffsetX on top of it a second time in indexForDragOffset —
+        // strip it back out so this always holds each tab's *resting*
+        // position, exactly like the very first snapshot (taken at offset 0,
+        // before any transform is rendered).
+        return i === draggedIndex.value ? center - dragOffsetX.value : center;
       })
     : [];
 }
@@ -137,7 +154,7 @@ function onStripScroll() {
   if (didDrag) snapshotCenters();
 }
 
-function onTabMouseDown(e: MouseEvent, index: number, tabId: number) {
+function onTabPointerDown(e: PointerEvent, index: number, tabId: number) {
   if (e.button === 1) {
     // Middle-click closes, same as before.
     e.preventDefault();
@@ -146,26 +163,40 @@ function onTabMouseDown(e: MouseEvent, index: number, tabId: number) {
   }
   if (e.button !== 0) return;
   // Don't start a drag from the close affordance. (The caret already stops
-  // propagation on its own @mousedown, so it never reaches this handler.)
+  // propagation on its own @pointerdown, so it never reaches this handler.)
   if ((e.target as Element).closest?.(".repo-tab__close")) return;
   pressIndex = index;
   pressStartX = e.clientX;
   didDrag = false;
-  window.addEventListener("mousemove", onDragMove);
-  window.addEventListener("mouseup", onDragEnd);
+  capturedEl = e.currentTarget as HTMLElement;
+  capturedPointerId = e.pointerId;
+  window.addEventListener("pointermove", onDragMove);
+  window.addEventListener("pointerup", onDragEnd);
+  window.addEventListener("pointercancel", onDragCancel);
   window.addEventListener("blur", onDragCancel);
 }
 
-function onDragMove(e: MouseEvent) {
+function onDragMove(e: PointerEvent) {
   if (pressIndex === null) return;
   if (!didDrag) {
     if (Math.abs(e.clientX - pressStartX) < DRAG_THRESHOLD_PX) return;
     didDrag = true;
     draggedIndex.value = pressIndex;
     snapshotCenters();
+    // Claim the gesture so pointermove/pointerup keep targeting this tab
+    // even once the pointer leaves it — guards against a native touch-pan
+    // gesture on the strip's own overflow-x scroll winning the race and
+    // hijacking the drag partway through.
+    if (capturedEl && typeof capturedEl.setPointerCapture === "function") {
+      try {
+        capturedEl.setPointerCapture(e.pointerId);
+      } catch {
+        // Best-effort — the window listeners still drive the drag without it.
+      }
+    }
   }
-  // Suppress the text selection that a mouse-drag would otherwise paint over
-  // the tab labels and neighbouring header content.
+  // Suppress the text selection / touch-scroll a drag would otherwise paint
+  // over the tab labels and neighbouring header content.
   e.preventDefault();
   dragOffsetX.value = e.clientX - pressStartX;
   const stripRect = stripEl.value?.getBoundingClientRect();
@@ -181,9 +212,20 @@ function onDragMove(e: MouseEvent) {
 
 /** Detaches the drag's window listeners and resets its transient state. */
 function finishDrag(commit: boolean) {
-  window.removeEventListener("mousemove", onDragMove);
-  window.removeEventListener("mouseup", onDragEnd);
+  window.removeEventListener("pointermove", onDragMove);
+  window.removeEventListener("pointerup", onDragEnd);
+  window.removeEventListener("pointercancel", onDragCancel);
   window.removeEventListener("blur", onDragCancel);
+  if (capturedEl && capturedPointerId !== null && typeof capturedEl.releasePointerCapture === "function") {
+    try {
+      capturedEl.releasePointerCapture(capturedPointerId);
+    } catch {
+      // Already released (e.g. the browser dropped it and fired
+      // pointercancel first) — nothing left to release.
+    }
+  }
+  capturedEl = null;
+  capturedPointerId = null;
   if (
     commit &&
     didDrag &&
@@ -198,21 +240,22 @@ function finishDrag(commit: boolean) {
   hoveredIndex.value = null;
   dragOffsetX.value = 0;
   tabCenters = [];
-  // The click that follows a mouseup on the same element fires synchronously
-  // in the same task, before this timeout runs — so it's still suppressed
-  // below. Resetting on a deferred tick, rather than relying on that click
-  // reaching onTabClick, means the flag can't get stuck when the release
-  // lands off the dragged tab, which would otherwise swallow the very next
-  // keyboard tab activation.
+  // The click that follows a pointerup on the same element fires
+  // synchronously in the same task, before this timeout runs — so it's still
+  // suppressed below. Resetting on a deferred tick, rather than relying on
+  // that click reaching onTabClick, means the flag can't get stuck when the
+  // release lands off the dragged tab, which would otherwise swallow the
+  // very next keyboard tab activation.
   setTimeout(() => {
     didDrag = false;
   }, 0);
 }
 
-function onDragEnd(e: MouseEvent) {
-  // Only the left button can end a drag — a right/middle-click released
-  // mid-drag (e.g. after a middle-click closed a different tab) must not
-  // commit or abort this one.
+function onDragEnd(e: PointerEvent) {
+  // Only the button that can start a drag can end it — a right/middle-click
+  // released mid-drag (e.g. after a middle-click closed a different tab)
+  // must not commit or abort this one. Touch/pen contacts report button 0,
+  // same as a left click, so this doesn't affect them.
   if (e.button !== 0) return;
   finishDrag(true);
 }
@@ -230,6 +273,35 @@ watch(
     if (pressIndex !== null) onDragCancel();
   },
 );
+
+// ─── Keyboard reordering ─────────────────────────────────
+// The pointer/touch drag above has no keyboard equivalent, which would
+// otherwise leave reordering unreachable without a mouse, trackpad or
+// touchscreen. Ctrl/Cmd+ArrowLeft/Right nudges the focused tab one slot at a
+// time; the aria-live region above announces the result since the reorder
+// is a silent DOM move with nothing else for a screen reader to key off of.
+async function moveFocusedTab(index: number, tab: RepoTab, direction: -1 | 1) {
+  const newIndex = index + direction;
+  if (newIndex < 0 || newIndex >= props.tabs.length) return;
+  emit("reorderTabs", index, newIndex);
+  announceText.value = t("header.tabStripReorderAnnounce", tab.name, newIndex + 1, props.tabs.length);
+  // `tabs` is keyed by `tab.id`, so Vue moves the same DOM node rather than
+  // recreating it and focus should already follow — but re-focus explicitly
+  // by id once the reorder lands, in case the parent re-renders the list.
+  await nextTick();
+  stripEl.value?.querySelector<HTMLElement>(`[data-tab-id="${tab.id}"]`)?.focus();
+}
+
+function onTabKeydown(e: KeyboardEvent, index: number, tab: RepoTab) {
+  if (!(e.ctrlKey || e.metaKey)) return;
+  if (e.key === "ArrowLeft") {
+    e.preventDefault();
+    moveFocusedTab(index, tab, -1);
+  } else if (e.key === "ArrowRight") {
+    e.preventDefault();
+    moveFocusedTab(index, tab, 1);
+  }
+}
 
 // Pinned and recent repos shown in the + dropdown (excludes repos already
 // open in a tab). Capped at 8 combined entries so the menu stays compact;
@@ -328,6 +400,10 @@ watch(showMenu, (open) => {
 function onWindowChange() {
   if (showMenu.value) closeMenu();
   if (wtMenuTabId.value !== null) closeWorktreeMenu();
+  // A window resize (or a zoom-level change) shifts every tab's viewport
+  // position exactly like a strip scroll would — re-snapshot so the
+  // hit-test in onDragMove keeps hit-testing against live centers.
+  if (didDrag) snapshotCenters();
 }
 
 onMounted(() => {
@@ -344,8 +420,9 @@ onUnmounted(() => {
   window.removeEventListener("scroll", onWindowChange, true);
   stripEl.value?.removeEventListener("scroll", onStripScroll);
   // Guard against unmounting mid-drag leaking the window listeners.
-  window.removeEventListener("mousemove", onDragMove);
-  window.removeEventListener("mouseup", onDragEnd);
+  window.removeEventListener("pointermove", onDragMove);
+  window.removeEventListener("pointerup", onDragEnd);
+  window.removeEventListener("pointercancel", onDragCancel);
   window.removeEventListener("blur", onDragCancel);
 });
 
@@ -455,10 +532,17 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 
 <template>
   <div v-if="showStrip" ref="stripEl" class="repo-tab-strip" role="tablist">
+    <!-- Announces the result of a keyboard reorder (Ctrl/Cmd+Arrow) — the
+         move itself is a silent DOM splice with nothing else for a screen
+         reader to react to. -->
+    <span class="repo-tab-strip__sr-only" role="status" aria-live="polite">{{ announceText }}</span>
     <!-- Tabs — rendered only when there are multiple repos -->
     <template v-if="showTabs">
-      <!-- Reordered via pointer events (see onTabMouseDown), not native HTML5
-           drag, which is unreliable in the WebKit webviews powering the app. -->
+      <!-- Reordered via pointer events (see onTabPointerDown) — covers mouse,
+           touch and pen in one path — rather than native HTML5 drag, which is
+           unreliable in the WebKit webviews powering the app. Ctrl/Cmd+Arrow
+           reorders from the keyboard (see onTabKeydown) since the pointer
+           gesture has no keyboard equivalent otherwise. -->
       <button
         v-for="(tab, index) in tabs"
         :key="tab.id"
@@ -473,10 +557,13 @@ function onCloseClick(e: MouseEvent, tabId: number) {
           'repo-tab--drag-over-right': hoveredIndex === index && draggedIndex !== null && draggedIndex < index
         }"
         :aria-selected="tab.id === activeTabId ? 'true' : 'false'"
+        :aria-keyshortcuts="tabs.length > 1 ? 'Control+ArrowLeft Control+ArrowRight' : undefined"
+        :data-tab-id="tab.id"
         :title="tab.path"
         :style="draggedIndex === index ? { transform: `translateX(${dragOffsetX}px)` } : null"
         @click="(e) => onTabClick(e, tab)"
-        @mousedown="(e) => onTabMouseDown(e, index, tab.id)"
+        @pointerdown="(e) => onTabPointerDown(e, index, tab.id)"
+        @keydown="(e) => onTabKeydown(e, index, tab)"
       >
         <svg class="repo-tab__icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M2 3.5A1.5 1.5 0 013.5 2h3.586a1.5 1.5 0 011.06.44l.915.914a1 1 0 00.707.293H12.5A1.5 1.5 0 0114 5.147V12.5A1.5 1.5 0 0112.5 14h-9A1.5 1.5 0 012 12.5v-9z" stroke="currentColor" stroke-width="1.2" />
@@ -494,7 +581,7 @@ function onCloseClick(e: MouseEvent, tabId: number) {
           :aria-expanded="wtMenuTabId === tab.id ? 'true' : 'false'"
           aria-haspopup="menu"
           @click.stop="(e) => toggleWorktreeMenu(e, tab)"
-          @mousedown.stop
+          @pointerdown.stop
         >
           <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" stroke-width="1.4"
             stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -770,6 +857,24 @@ function onCloseClick(e: MouseEvent, tabId: number) {
   min-width: 0;
   flex-shrink: 1;
   user-select: none;
+  white-space: nowrap;
+  /* Claim horizontal pan gestures ourselves (pointer-based drag-to-reorder)
+     instead of letting a touch/pen device start the strip's native
+     overflow-x scroll first — that native gesture can otherwise win the
+     race and hijack the drag before our own pointermove handler ever sees
+     it move. Horizontal scrolling by touch still works from the strip's own
+     padding or empty space between tabs. */
+  touch-action: none;
+}
+
+/* Visually hidden but still reachable by screen readers — used for the
+   aria-live reorder announcement, which must never be visible. */
+.repo-tab-strip__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
   white-space: nowrap;
 }
 

--- a/apps/desktop/src/components/header/RepoTabStrip.vue
+++ b/apps/desktop/src/components/header/RepoTabStrip.vue
@@ -85,6 +85,9 @@ const dragOffsetX = ref(0);
 // A press only becomes a drag past this threshold, so a plain click still
 // switches tabs instead of being swallowed as a (zero-distance) drag.
 const DRAG_THRESHOLD_PX = 4;
+// How far above/below the strip the cursor can stray before a release reads
+// as "dropped outside" (cancelled) rather than a reorder.
+const DRAG_VERTICAL_TOLERANCE_PX = 40;
 let pressIndex: number | null = null;
 let pressStartX = 0;
 let didDrag = false;
@@ -103,13 +106,35 @@ function snapshotCenters() {
     : [];
 }
 
-/** Index of the tab slot under `clientX`, from the drag-start snapshot. */
-function tabIndexAtX(clientX: number): number | null {
-  if (tabCenters.length === 0) return null;
+/**
+ * Index of the slot the dragged tab's own (shifted) center now sits in,
+ * i.e. how many of the *other* tabs' (unmoving) centers it has been dragged
+ * past. Hit-testing against the dragged tab's own current center — its
+ * drag-start center plus the live offset — rather than the raw cursor
+ * position means a press anywhere within the tab (left half or right half)
+ * starts at offset 0, so a few pixels of hand wobble can't immediately swap
+ * it with a neighbour just because the press happened to land past its
+ * midpoint. Excluding the dragged tab's own original center from the count
+ * matters too: comparing against the full list would have that slot count
+ * against itself at offset 0, overshooting straight to `draggedIndex + 1`
+ * before any real movement happened.
+ */
+function indexForDragOffset(offsetX: number): number | null {
+  if (tabCenters.length === 0 || draggedIndex.value === null) return null;
+  const draggedCenter = tabCenters[draggedIndex.value] + offsetX;
+  let index = 0;
   for (let i = 0; i < tabCenters.length; i++) {
-    if (clientX < tabCenters[i]) return i;
+    if (i === draggedIndex.value) continue;
+    if (tabCenters[i] < draggedCenter) index++;
   }
-  return tabCenters.length - 1;
+  return index;
+}
+
+function onStripScroll() {
+  // Centers are snapshotted in viewport coordinates; scrolling the strip
+  // (it's overflow-x: auto) mid-drag shifts every tab, so re-snapshot to
+  // keep the hit-test honest.
+  if (didDrag) snapshotCenters();
 }
 
 function onTabMouseDown(e: MouseEvent, index: number, tabId: number) {
@@ -120,16 +145,15 @@ function onTabMouseDown(e: MouseEvent, index: number, tabId: number) {
     return;
   }
   if (e.button !== 0) return;
-  // Don't start a drag from the caret or close affordances.
-  if ((e.target as Element).closest?.(".repo-tab__caret, .repo-tab__close")) return;
-  // Stop the browser from starting a text selection on the press — the click
-  // still fires, so tab switching is unaffected.
-  e.preventDefault();
+  // Don't start a drag from the close affordance. (The caret already stops
+  // propagation on its own @mousedown, so it never reaches this handler.)
+  if ((e.target as Element).closest?.(".repo-tab__close")) return;
   pressIndex = index;
   pressStartX = e.clientX;
   didDrag = false;
   window.addEventListener("mousemove", onDragMove);
   window.addEventListener("mouseup", onDragEnd);
+  window.addEventListener("blur", onDragCancel);
 }
 
 function onDragMove(e: MouseEvent) {
@@ -144,13 +168,24 @@ function onDragMove(e: MouseEvent) {
   // the tab labels and neighbouring header content.
   e.preventDefault();
   dragOffsetX.value = e.clientX - pressStartX;
-  hoveredIndex.value = tabIndexAtX(e.clientX);
+  const stripRect = stripEl.value?.getBoundingClientRect();
+  const droppedOutside =
+    !!stripRect &&
+    (e.clientY < stripRect.top - DRAG_VERTICAL_TOLERANCE_PX ||
+      e.clientY > stripRect.bottom + DRAG_VERTICAL_TOLERANCE_PX);
+  // Cursor well above/below the strip (over app content, a native title bar,
+  // etc.) reads as "no drop target" — mirrors the old native DnD, where
+  // dragging outside any drop zone left the tab order untouched.
+  hoveredIndex.value = droppedOutside ? null : indexForDragOffset(dragOffsetX.value);
 }
 
-function onDragEnd() {
+/** Detaches the drag's window listeners and resets its transient state. */
+function finishDrag(commit: boolean) {
   window.removeEventListener("mousemove", onDragMove);
   window.removeEventListener("mouseup", onDragEnd);
+  window.removeEventListener("blur", onDragCancel);
   if (
+    commit &&
     didDrag &&
     draggedIndex.value !== null &&
     hoveredIndex.value !== null &&
@@ -163,9 +198,38 @@ function onDragEnd() {
   hoveredIndex.value = null;
   dragOffsetX.value = 0;
   tabCenters = [];
-  // Leave `didDrag` set so the click that follows a drag is suppressed;
-  // onTabClick resets it.
+  // The click that follows a mouseup on the same element fires synchronously
+  // in the same task, before this timeout runs — so it's still suppressed
+  // below. Resetting on a deferred tick, rather than relying on that click
+  // reaching onTabClick, means the flag can't get stuck when the release
+  // lands off the dragged tab, which would otherwise swallow the very next
+  // keyboard tab activation.
+  setTimeout(() => {
+    didDrag = false;
+  }, 0);
 }
+
+function onDragEnd(e: MouseEvent) {
+  // Only the left button can end a drag — a right/middle-click released
+  // mid-drag (e.g. after a middle-click closed a different tab) must not
+  // commit or abort this one.
+  if (e.button !== 0) return;
+  finishDrag(true);
+}
+
+function onDragCancel() {
+  finishDrag(false);
+}
+
+// A tab opening/closing mid-drag (deep link, programmatic close, …) leaves
+// draggedIndex/hoveredIndex and the center snapshot pointing at stale
+// positions — abort rather than risk committing a reorder against them.
+watch(
+  () => props.tabs.length,
+  () => {
+    if (pressIndex !== null) onDragCancel();
+  },
+);
 
 // Pinned and recent repos shown in the + dropdown (excludes repos already
 // open in a tab). Capped at 8 combined entries so the menu stays compact;
@@ -252,6 +316,7 @@ function onDocumentKey(e: KeyboardEvent) {
   if (e.key !== "Escape") return;
   if (showMenu.value) closeMenu();
   if (wtMenuTabId.value !== null) closeWorktreeMenu();
+  if (pressIndex !== null) onDragCancel();
 }
 
 // Reposition when the menu opens — and close on resize / strip scroll
@@ -270,15 +335,18 @@ onMounted(() => {
   document.addEventListener("keydown", onDocumentKey);
   window.addEventListener("resize", onWindowChange);
   window.addEventListener("scroll", onWindowChange, true);
+  stripEl.value?.addEventListener("scroll", onStripScroll, { passive: true });
 });
 onUnmounted(() => {
   document.removeEventListener("mousedown", onDocumentClick);
   document.removeEventListener("keydown", onDocumentKey);
   window.removeEventListener("resize", onWindowChange);
   window.removeEventListener("scroll", onWindowChange, true);
+  stripEl.value?.removeEventListener("scroll", onStripScroll);
   // Guard against unmounting mid-drag leaking the window listeners.
   window.removeEventListener("mousemove", onDragMove);
   window.removeEventListener("mouseup", onDragEnd);
+  window.removeEventListener("blur", onDragCancel);
 });
 
 /**

--- a/apps/desktop/src/components/header/RepoTabStrip.vue
+++ b/apps/desktop/src/components/header/RepoTabStrip.vue
@@ -277,9 +277,20 @@ watch(
 // ─── Keyboard reordering ─────────────────────────────────
 // The pointer/touch drag above has no keyboard equivalent, which would
 // otherwise leave reordering unreachable without a mouse, trackpad or
-// touchscreen. Ctrl/Cmd+ArrowLeft/Right nudges the focused tab one slot at a
-// time; the aria-live region above announces the result since the reorder
-// is a silent DOM move with nothing else for a screen reader to key off of.
+// touchscreen. Ctrl/Cmd+Shift+ArrowLeft/Right nudges the focused tab one slot
+// at a time; the aria-live region above announces the result since the
+// reorder is a silent DOM move with nothing else for a screen reader to key
+// off of.
+//
+// Bare Ctrl/Cmd+ArrowLeft/Right was tried first and rejected: on macOS,
+// Ctrl+Arrow is the *default* Mission Control "switch Space" shortcut,
+// handled by the OS before the keydown ever reaches any app — including a
+// browser, so it's not a Tauri-specific gap. Cmd+Arrow isn't bound by
+// default, but plenty of window-manager utilities (Rectangle, yabai, …) and
+// user remaps claim bare Cmd/Ctrl+Arrow too. Requiring Shift as well avoids
+// every OS-level and third-party shortcut we know of for this combo — the
+// same reasoning VS Code's editor-move commands are bound to Shift-modified
+// combos rather than a bare arrow.
 async function moveFocusedTab(index: number, tab: RepoTab, direction: -1 | 1) {
   const newIndex = index + direction;
   if (newIndex < 0 || newIndex >= props.tabs.length) return;
@@ -293,7 +304,7 @@ async function moveFocusedTab(index: number, tab: RepoTab, direction: -1 | 1) {
 }
 
 function onTabKeydown(e: KeyboardEvent, index: number, tab: RepoTab) {
-  if (!(e.ctrlKey || e.metaKey)) return;
+  if (!(e.ctrlKey || e.metaKey) || !e.shiftKey) return;
   if (e.key === "ArrowLeft") {
     e.preventDefault();
     moveFocusedTab(index, tab, -1);
@@ -532,17 +543,20 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 
 <template>
   <div v-if="showStrip" ref="stripEl" class="repo-tab-strip" role="tablist">
-    <!-- Announces the result of a keyboard reorder (Ctrl/Cmd+Arrow) — the
-         move itself is a silent DOM splice with nothing else for a screen
-         reader to react to. -->
+    <!-- Announces the result of a keyboard reorder (Ctrl/Cmd+Shift+Arrow) —
+         the move itself is a silent DOM splice with nothing else for a
+         screen reader to react to. -->
     <span class="repo-tab-strip__sr-only" role="status" aria-live="polite">{{ announceText }}</span>
     <!-- Tabs — rendered only when there are multiple repos -->
     <template v-if="showTabs">
       <!-- Reordered via pointer events (see onTabPointerDown) — covers mouse,
            touch and pen in one path — rather than native HTML5 drag, which is
-           unreliable in the WebKit webviews powering the app. Ctrl/Cmd+Arrow
-           reorders from the keyboard (see onTabKeydown) since the pointer
-           gesture has no keyboard equivalent otherwise. -->
+           unreliable in the WebKit webviews powering the app.
+           Ctrl/Cmd+Shift+Arrow reorders from the keyboard (see
+           onTabKeydown) since the pointer gesture has no keyboard
+           equivalent otherwise — Shift is required alongside Ctrl/Cmd
+           because a bare Ctrl+Arrow is macOS's default Mission Control
+           "switch Space" shortcut and never reaches the app at all. -->
       <button
         v-for="(tab, index) in tabs"
         :key="tab.id"
@@ -557,7 +571,7 @@ function onCloseClick(e: MouseEvent, tabId: number) {
           'repo-tab--drag-over-right': hoveredIndex === index && draggedIndex !== null && draggedIndex < index
         }"
         :aria-selected="tab.id === activeTabId ? 'true' : 'false'"
-        :aria-keyshortcuts="tabs.length > 1 ? 'Control+ArrowLeft Control+ArrowRight' : undefined"
+        :aria-keyshortcuts="tabs.length > 1 ? 'Control+Shift+ArrowLeft Control+Shift+ArrowRight Meta+Shift+ArrowLeft Meta+Shift+ArrowRight' : undefined"
         :data-tab-id="tab.id"
         :title="tab.path"
         :style="draggedIndex === index ? { transform: `translateX(${dragOffsetX}px)` } : null"

--- a/apps/desktop/src/components/header/RepoTabStrip.vue
+++ b/apps/desktop/src/components/header/RepoTabStrip.vue
@@ -69,38 +69,102 @@ function isScratch(path: string): boolean {
   return base.startsWith("gitwand-scratch-");
 }
 
-// ─── Drag and Drop (v2.15) ──────────────────────────────
+// ─── Drag to reorder — pointer-based ─────────────────────
+// Native HTML5 drag-and-drop is unreliable in WebKit (WKWebView on macOS,
+// WebKitGTK on Linux — both power the packaged Tauri app): `dragstart`
+// frequently never fires, so the tabs couldn't be reordered and no drop
+// indicator showed. We drive it with plain mouse events instead, which
+// behave identically across every webview. draggedIndex / hoveredIndex keep
+// the same meaning the CSS classes expect (source index / hovered target).
 const draggedIndex = ref<number | null>(null);
 const hoveredIndex = ref<number | null>(null);
+const stripEl = ref<HTMLElement | null>(null);
+// Live horizontal offset of the tab being dragged, so it tracks the cursor.
+const dragOffsetX = ref(0);
 
-function onDragStart(e: DragEvent, index: number) {
-  draggedIndex.value = index;
-  if (e.dataTransfer) {
-    e.dataTransfer.effectAllowed = "move";
-    // Required for some browsers to initiate drag
-    e.dataTransfer.setData("text/plain", index.toString());
-  }
+// A press only becomes a drag past this threshold, so a plain click still
+// switches tabs instead of being swallowed as a (zero-distance) drag.
+const DRAG_THRESHOLD_PX = 4;
+let pressIndex: number | null = null;
+let pressStartX = 0;
+let didDrag = false;
+// Center-x of each tab captured when the drag begins. The dragged tab gets a
+// translateX to follow the cursor, which would move its own bounding rect — so
+// we hit-test against this snapshot (the other tabs don't move until drop).
+let tabCenters: number[] = [];
+
+function snapshotCenters() {
+  const root = stripEl.value;
+  tabCenters = root
+    ? Array.from(root.querySelectorAll<HTMLElement>(".repo-tab")).map((el) => {
+        const r = el.getBoundingClientRect();
+        return r.left + r.width / 2;
+      })
+    : [];
 }
 
-function onDragOver(e: DragEvent, index: number) {
-  e.preventDefault(); // Required to allow drop
-  if (draggedIndex.value !== null && draggedIndex.value !== index) {
-    hoveredIndex.value = index;
+/** Index of the tab slot under `clientX`, from the drag-start snapshot. */
+function tabIndexAtX(clientX: number): number | null {
+  if (tabCenters.length === 0) return null;
+  for (let i = 0; i < tabCenters.length; i++) {
+    if (clientX < tabCenters[i]) return i;
   }
+  return tabCenters.length - 1;
 }
 
-function onDrop(e: DragEvent, index: number) {
+function onTabMouseDown(e: MouseEvent, index: number, tabId: number) {
+  if (e.button === 1) {
+    // Middle-click closes, same as before.
+    e.preventDefault();
+    emit("closeTab", tabId);
+    return;
+  }
+  if (e.button !== 0) return;
+  // Don't start a drag from the caret or close affordances.
+  if ((e.target as Element).closest?.(".repo-tab__caret, .repo-tab__close")) return;
+  // Stop the browser from starting a text selection on the press — the click
+  // still fires, so tab switching is unaffected.
   e.preventDefault();
-  if (draggedIndex.value !== null && draggedIndex.value !== index) {
-    emit("reorderTabs", draggedIndex.value, index);
+  pressIndex = index;
+  pressStartX = e.clientX;
+  didDrag = false;
+  window.addEventListener("mousemove", onDragMove);
+  window.addEventListener("mouseup", onDragEnd);
+}
+
+function onDragMove(e: MouseEvent) {
+  if (pressIndex === null) return;
+  if (!didDrag) {
+    if (Math.abs(e.clientX - pressStartX) < DRAG_THRESHOLD_PX) return;
+    didDrag = true;
+    draggedIndex.value = pressIndex;
+    snapshotCenters();
   }
-  draggedIndex.value = null;
-  hoveredIndex.value = null;
+  // Suppress the text selection that a mouse-drag would otherwise paint over
+  // the tab labels and neighbouring header content.
+  e.preventDefault();
+  dragOffsetX.value = e.clientX - pressStartX;
+  hoveredIndex.value = tabIndexAtX(e.clientX);
 }
 
 function onDragEnd() {
+  window.removeEventListener("mousemove", onDragMove);
+  window.removeEventListener("mouseup", onDragEnd);
+  if (
+    didDrag &&
+    draggedIndex.value !== null &&
+    hoveredIndex.value !== null &&
+    hoveredIndex.value !== draggedIndex.value
+  ) {
+    emit("reorderTabs", draggedIndex.value, hoveredIndex.value);
+  }
+  pressIndex = null;
   draggedIndex.value = null;
   hoveredIndex.value = null;
+  dragOffsetX.value = 0;
+  tabCenters = [];
+  // Leave `didDrag` set so the click that follows a drag is suppressed;
+  // onTabClick resets it.
 }
 
 // Pinned and recent repos shown in the + dropdown (excludes repos already
@@ -212,6 +276,9 @@ onUnmounted(() => {
   document.removeEventListener("keydown", onDocumentKey);
   window.removeEventListener("resize", onWindowChange);
   window.removeEventListener("scroll", onWindowChange, true);
+  // Guard against unmounting mid-drag leaking the window listeners.
+  window.removeEventListener("mousemove", onDragMove);
+  window.removeEventListener("mouseup", onDragEnd);
 });
 
 /**
@@ -300,18 +367,16 @@ function removeWorktree(w: WorktreeEntry) {
  * caret for the same action.
  */
 function onTabClick(e: MouseEvent, tab: RepoTab) {
+  // A drag just ended — swallow the trailing click so it doesn't switch tabs.
+  if (didDrag) {
+    didDrag = false;
+    return;
+  }
   if (tab.id === props.activeTabId) {
     if (hasWorktrees(tab.path)) toggleWorktreeMenu(e, tab);
     return;
   }
   emit("switchTab", tab.id);
-}
-
-function onMiddleClick(e: MouseEvent, tabId: number) {
-  if (e.button === 1) {
-    e.preventDefault();
-    emit("closeTab", tabId);
-  }
 }
 
 function onCloseClick(e: MouseEvent, tabId: number) {
@@ -321,9 +386,11 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 </script>
 
 <template>
-  <div v-if="showStrip" class="repo-tab-strip" role="tablist">
+  <div v-if="showStrip" ref="stripEl" class="repo-tab-strip" role="tablist">
     <!-- Tabs — rendered only when there are multiple repos -->
     <template v-if="showTabs">
+      <!-- Reordered via pointer events (see onTabMouseDown), not native HTML5
+           drag, which is unreliable in the WebKit webviews powering the app. -->
       <button
         v-for="(tab, index) in tabs"
         :key="tab.id"
@@ -339,14 +406,9 @@ function onCloseClick(e: MouseEvent, tabId: number) {
         }"
         :aria-selected="tab.id === activeTabId ? 'true' : 'false'"
         :title="tab.path"
-        draggable="true"
+        :style="draggedIndex === index ? { transform: `translateX(${dragOffsetX}px)` } : null"
         @click="(e) => onTabClick(e, tab)"
-        @mousedown="(e) => onMiddleClick(e, tab.id)"
-        @dragstart="(e) => onDragStart(e, index)"
-        @dragover="(e) => onDragOver(e, index)"
-        @dragleave="hoveredIndex = null"
-        @drop="(e) => onDrop(e, index)"
-        @dragend="onDragEnd"
+        @mousedown="(e) => onTabMouseDown(e, index, tab.id)"
       >
         <svg class="repo-tab__icon" width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
           <path d="M2 3.5A1.5 1.5 0 013.5 2h3.586a1.5 1.5 0 011.06.44l.915.914a1 1 0 00.707.293H12.5A1.5 1.5 0 0114 5.147V12.5A1.5 1.5 0 0112.5 14h-9A1.5 1.5 0 012 12.5v-9z" stroke="currentColor" stroke-width="1.2" />
@@ -652,8 +714,15 @@ function onCloseClick(e: MouseEvent, tabId: number) {
 }
 
 .repo-tab--dragging {
-  opacity: 0.4;
   cursor: grabbing;
+  /* Lifted above its neighbours and following the cursor via an inline
+     translateX. No transform transition here so it tracks the pointer 1:1. */
+  position: relative;
+  z-index: 3;
+  opacity: 0.3;
+  background: var(--color-bg-tertiary);
+  box-shadow: var(--shadow-md);
+  transition: none;
 }
 
 .repo-tab--drag-over-left,

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -108,6 +108,7 @@ const en = {
     tabStripRecentSection: "Recent repos",
     tabStripPinnedSection: "Pinned repos",
     tabStripNoRecent: "No recent repositories",
+    tabStripReorderAnnounce: "{0} moved to position {1} of {2}",
   },
 
   // ─── Sync split button (header primary action) ─────────

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -108,6 +108,7 @@ const es: Locale = {
     tabStripRecentSection: "Repos recientes",
     tabStripPinnedSection: "Repos favoritos",
     tabStripNoRecent: "Sin repositorios recientes",
+    tabStripReorderAnnounce: "{0} movido a la posición {1} de {2}",
   },
 
   // ─── Sync split button (header primary action) ─────────

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -102,6 +102,7 @@ const fr: Locale = {
     tabStripRecentSection: "Repos récents",
     tabStripPinnedSection: "Repos favoris",
     tabStripNoRecent: "Aucun dépôt récent",
+    tabStripReorderAnnounce: "{0} déplacé en position {1} sur {2}",
   },
 
   // ─── Sync split button (header primary action) ─────────

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -109,6 +109,7 @@ const ptBR: Locale = {
     tabStripRecentSection: "Repos recentes",
     tabStripPinnedSection: "Repos favoritos",
     tabStripNoRecent: "Nenhum repositório recente",
+    tabStripReorderAnnounce: "{0} movido para a posição {1} de {2}",
   },
 
   // ─── Sync split button (header primary action) ─────────

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -113,6 +113,7 @@ const zhCN: Locale = {
     tabStripRecentSection: "最近的仓库",
     tabStripPinnedSection: "收藏的仓库",
     tabStripNoRecent: "没有最近的仓库",
+    tabStripReorderAnnounce: "{0} 已移动到第 {1} 个位置(共 {2} 个)",
   },
 
   // ─── Sync split button (header primary action) ─────────


### PR DESCRIPTION
## Summary
The native HTML5 drag-and-drop is unreliable in the WebKit webviews that host the Tauri app, where `dragstart` often fails to fire. This change drives tab reordering with pointer events instead (mouse, touch and pen in one code path), adds a keyboard equivalent for accessibility, and improves the visibility of inactive repo tabs.

## Changes
- Replace native HTML5 drag-and-drop with pointer-event-driven tab reordering in `RepoTabStrip.vue`
- Add a subtle outline to inactive repo tabs so they remain distinguishable
- Increase the opacity of tab affordances (caret, close button) so they stay perceptible without hover

## Accessibility & cross-input follow-ups
- Migrated mouse events → Pointer Events (`setPointerCapture`, feature-detected) — touch/pen drag now works, not just mouse.
- Added Ctrl/Cmd+Shift+ArrowLeft/Right keyboard reordering with an `aria-live` announcement — screen reader / keyboard-only users previously had no way to reorder tabs at all. (Shift is required alongside Ctrl/Cmd: a bare Ctrl+Arrow is macOS's default Mission Control "switch Space" shortcut, intercepted by the OS before any app — browsers included — ever sees the keydown.)
- Re-snapshot tab centers on window resize mid-drag, not just on strip scroll.
- Fixed a double-counting bug in the mid-drag re-snapshot logic (the dragged tab's live `translateX` was being measured back into the snapshot, then added a second time) that would otherwise have shipped a new drag-offset bug on scroll/resize.
- Fixed several correctness issues found in code review: an asymmetric hit-test that could trigger an accidental reorder from a few pixels of hand wobble, drags committing on any mouse button or with no way to cancel, a stale `didDrag` flag that could swallow a keyboard tab activation, and a click-to-focus regression from an unconditional `preventDefault()`.

## Test plan
- [ ] Drag a repo tab to a new position and confirm the order updates
- [ ] Verify reordering works inside the Tauri desktop app (WebKit webview)
- [ ] Confirm active and inactive tabs are visually distinguishable
- [ ] Check caret and close affordances are visible without hovering
- [ ] Reorder a tab via keyboard (focus a tab, `Ctrl/Cmd+Shift+ArrowLeft/Right`) and confirm both the order update and the screen-reader announcement
- [ ] Confirm touch/pen drag reordering works on a touch-capable device, if available
- [ ] Resize the window mid-drag and confirm the drop still lands on the intended tab

## How it looks

#### Before
<img width="510" height="62" alt="image" src="https://github.com/user-attachments/assets/c1b99a82-88c1-41a2-97d4-dfaad7fda103" />

#### Now
<img width="510" height="62" alt="image" src="https://github.com/user-attachments/assets/60eadeb8-182f-40f9-9841-4889621b7750" />
