### PR TITLE
style(files): move Save button next to the edit lock

### DIFF
--- a/apps/desktop/src/components/FileExplorerPanel.vue
+++ b/apps/desktop/src/components/FileExplorerPanel.vue
@@ -440,6 +440,20 @@ function onKeyDown(e: KeyboardEvent) {
           </svg>
           <span>{{ editLocked ? t("files.toolbarEdit") : t("files.toolbarLock") }}</span>
         </button>
+        <button
+          class="fe__action-btn"
+          :disabled="!activeTab || activeTab.binary || !explorer.isDirty(activeTab)"
+          :title="t('files.toolbarSave')"
+          @click="onToolbarSave"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
+            <polyline points="17 21 17 13 7 13 7 21"/>
+            <polyline points="7 3 7 8 15 8"/>
+          </svg>
+          <span>{{ t("files.toolbarSave") }}</span>
+        </button>
+        <span class="fe__header-divider" aria-hidden="true" />
         <button class="fe__action-btn" :disabled="editLocked" :title="t('files.toolbarUndo')" @click="onUndo">
           <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M3 7v6h6"/>
@@ -460,19 +474,6 @@ function onKeyDown(e: KeyboardEvent) {
             <line x1="16" y1="12" x2="22.5" y2="12"/>
           </svg>
           <span>{{ t("files.toolbarBlame") }}</span>
-        </button>
-        <button
-          class="fe__action-btn"
-          :disabled="!activeTab || activeTab.binary || !explorer.isDirty(activeTab)"
-          :title="t('files.toolbarSave')"
-          @click="onToolbarSave"
-        >
-          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/>
-            <polyline points="17 21 17 13 7 13 7 21"/>
-            <polyline points="7 3 7 8 15 8"/>
-          </svg>
-          <span>{{ t("files.toolbarSave") }}</span>
         </button>
       </div>
       <div class="fe__header-spacer" />


### PR DESCRIPTION
## Summary
This change reorders the FileExplorerPanel toolbar so the Save action sits alongside the edit-lock toggle, with a separator added for clearer visual grouping. It improves toolbar readability by keeping related editing actions together.

## Changes
- Move the Save button next to the edit-lock toggle in `FileExplorerPanel.vue`
- Add a separator to visually group the editing actions in the toolbar

## Test plan
- [x] Open the file explorer and confirm the Save button appears next to the edit lock
- [x] Verify the separator renders correctly between toolbar groups
- [ ] Confirm the Save action still persists file changes as expected
- [x] Check the toolbar layout across supported window sizes

## How it looks

<img width="393" height="58" alt="image" src="https://github.com/user-attachments/assets/c76ad68e-6c3d-45d5-ab98-b19e33269e9e" />