### PR TITLE
style(CommitGraph): animate width and fix loading layout shifts

### DIFF
--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -997,6 +997,38 @@ watch(() => props.commits.length, () => {
   _loadMorePending = false;
 });
 
+// Pagination loads pages in short bursts, so `loadingMore` flickers off between
+// consecutive pages — binding the spinner to it directly makes it remount (and
+// its rotation restart) on every page. Keep it visible across those gaps and
+// hide it only once no new page has started for a beat, or nothing is left.
+const showLoadingMore = ref(false);
+let _loadingHideTimer: ReturnType<typeof setTimeout> | null = null;
+function clearLoadingHideTimer() {
+  if (_loadingHideTimer !== null) {
+    clearTimeout(_loadingHideTimer);
+    _loadingHideTimer = null;
+  }
+}
+watch(() => props.loadingMore, (loading) => {
+  if (loading) {
+    clearLoadingHideTimer();
+    showLoadingMore.value = true;
+  } else if (showLoadingMore.value) {
+    clearLoadingHideTimer();
+    _loadingHideTimer = setTimeout(() => {
+      _loadingHideTimer = null;
+      showLoadingMore.value = false;
+    }, 600);
+  }
+});
+watch(() => props.hasMore, (has) => {
+  if (!has) {
+    clearLoadingHideTimer();
+    showLoadingMore.value = false;
+  }
+});
+onUnmounted(clearLoadingHideTimer);
+
 function measureViewport() {
   if (scrollContainer.value) clientHeight.value = scrollContainer.value.clientHeight;
 }
@@ -1455,9 +1487,12 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
           </template>
         </div>
       </div>
-      <div v-if="hasMore" class="cg-load-more">
-        <span v-if="loadingMore" class="cg-load-more__spinner" aria-label="Loading more commits"></span>
-      </div>
+    </div>
+    <!-- Load-more indicator: overlaid bottom-right so it never reflows the graph.
+         Must NOT live inside .cg-scroll (flex row) — as a flex child it becomes
+         a phantom right column that shifts the whole tree when it appears. -->
+    <div v-if="showLoadingMore" class="cg-load-more">
+      <span class="cg-load-more__spinner" aria-label="Loading more commits"></span>
     </div>
   </div>
   <div v-else class="cg-empty muted">
@@ -2235,6 +2270,7 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
   display: flex;
   flex-direction: column;
   height: 100%;
+  position: relative;
 }
 
 .cg-scroll {
@@ -2524,10 +2560,17 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
 }
 
 .cg-load-more {
+  position: absolute;
+  bottom: 10px;
+  right: 14px;
+  z-index: 2;
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 10px 0 12px;
+  padding: 5px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg);
+  pointer-events: none;
 }
 
 .cg-load-more__spinner {

--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -796,8 +796,25 @@ const NODE_R = 4; // node circle radius
 const GRAPH_PAD = 12; // left padding before first lane
 const SVG_MIN_W = 60; // minimum graph column width
 
-const graphWidth = computed(() => {
+const graphWidthRaw = computed(() => {
   return Math.max(SVG_MIN_W, GRAPH_PAD + (layout.value.maxLane + 1) * LANE_W + GRAPH_PAD);
+});
+
+// While a pagination burst is running, the DAG is cut mid-history: branches
+// whose merge-base sits on a page not loaded yet hold transient extra lanes,
+// so maxLane (and thus the graph column width) can spike for one page and
+// settle on the next — visible as the left column twitching. Ratchet the
+// width while loading (grow only) and re-adopt the exact computed value once
+// the burst ends, so a repo/filter switch can still shrink it.
+let _burstMaxWidth = 0;
+const graphWidth = computed(() => {
+  const w = graphWidthRaw.value;
+  if (showLoadingMore.value) {
+    if (w > _burstMaxWidth) _burstMaxWidth = w;
+    return _burstMaxWidth;
+  }
+  _burstMaxWidth = w;
+  return w;
 });
 
 const totalHeight = computed(() => renderedCommits.value.length * ROW_H);

--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -1257,11 +1257,13 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
     </div>
     <div class="cg-scroll" ref="scrollContainer" @scroll="onScroll">
       <!-- SVG graph column -->
+      <!-- No viewBox: it was identity (0 0 w h) so coordinates are plain px;
+           with a viewBox the CSS width transition would stretch the drawing
+           instead of just revealing/clipping the extra lane space. -->
       <svg
         class="cg-svg"
-        :width="graphWidth"
         :height="totalHeight"
-        :viewBox="`0 0 ${graphWidth} ${totalHeight}`"
+        :style="{ width: graphWidth + 'px' }"
       >
         <defs>
           <!-- Trunk lane multi-color gradient (vibrant for nodes/edges) -->
@@ -2304,6 +2306,7 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
   left: 0;
   z-index: 1;
   background: var(--color-bg);
+  transition: width 0.25s ease;
 }
 
 .cg-node,


### PR DESCRIPTION
## Summary
This PR improves the visual stability and transition animations of the commits graph / GitTree. It prevents layout shifts and flickering during pagination by positioning the loading spinner in an absolute position at the bottom right of the view and maintaining the graph's maximum width, while also ensuring smooth width resizing without stretching the graph content.

## Changes
- Remove the SVG `viewBox` attribute from the commit graph to prevent content stretching during width transitions
- Keep the maximum graph width during loading to prevent layout shifts in the left column
- Position the loading spinner absolutely at the bottom right to avoid pushing graph content
- Maintain spinner visibility briefly after a page loads to prevent visual flickering

## Test plan
- [ ] Verify that resizing the commit graph triggers a smooth transition without stretching the SVG drawing
- [ ] Paginate through commits and check that the left column does not jump or jitter
- [ ] Confirm the loading spinner displays at the bottom right and does not cause layout shifting
- [ ] Verify the spinner remains visible briefly to prevent flickering on fast loads