### PR TITLE
fix: use English error message in classifier and remove stale TODO comment

### DIFF
--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -1821,7 +1821,7 @@ const ptBR: Locale = {
     dropAllButton: "Descartar tudo",
     dropAllTooltip: "Descartar todos os stashes",
     dropAllConfirm: "Descartar todos os stashes? Esta ação não pode ser desfeita.",
-    dropAllTitle: "Descartar todos os stashes?", // TODO: translate
+    dropAllTitle: "Descartar todos os stashes?",
     loading: "Carregando stashes…",
     empty: "Sem stashes. Use",
     emptyAction: "+ Stash",

--- a/packages/core/src/classifier.ts
+++ b/packages/core/src/classifier.ts
@@ -161,5 +161,5 @@ export function classifyConflict(hunk: ClassifyInput): ClassifyResult {
   }
 
   // Unreachable — complex.detect() always returns true
-  throw new Error("[GitWand] classifyConflict: aucun pattern n'a matché (complex manquant ?)");
+  throw new Error("[GitWand] classifyConflict: no pattern matched (complex missing ?)");
 }


### PR DESCRIPTION
classifier.ts had a french error message in an otherwise english codebase. looked like someone copy-pasted from another project and forgot to translate.\n\npt-br.ts had a // TODO: translate comment on a value that was already translated. just leftover noise.