### PR TITLE
fix: translate remaining French console.error to English

### DIFF
--- a/packages/core/src/resolver/index.ts
+++ b/packages/core/src/resolver/index.ts
@@ -297,7 +297,7 @@ export async function resolveAsync(
   if (llmEnabled) setLlmFallbackEnabled(false);
 
   if (options.verbose && llmEnabled && result.resolutions.some((r) => !r.autoResolved && r.hunk.type === "llm_proposed")) {
-    console.error("[GitWand] LLM fallback activé — phase 5 en attente des hunks llm_proposed non résolus.");
+    console.error("[GitWand] LLM fallback triggered — phase 5 waiting for unresolved llm_proposed hunks.");
   }
 
   // Rien à valider si la résolution n'est pas complète et pas de LLM fallback


### PR DESCRIPTION
One leftover console.error in the resolver was still in French after the i18n sweep. everything else already routes through the errors.* namespace. https://github.com/devlint/GitWand/pull/131#issuecomment-xxxx