### PR TITLE
fix: Committer Identities list not updating reactively in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Settings → Git → Committer Identities now update immediately after adding, editing, or deleting an identity, instead of requiring the settings popover to be closed and reopened (#140).
+
 ## [3.6.0] - 2026-07-20
 
 ### Added

--- a/apps/desktop/src/composables/__tests__/v2.12-branch-identity.test.ts
+++ b/apps/desktop/src/composables/__tests__/v2.12-branch-identity.test.ts
@@ -204,6 +204,55 @@ describe("useIdentity (module-level functions)", () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// useIdentity — reactivity of the `identities` / `activeIdentity` computeds
+// (regression test for #140: SettingsPanel.vue renders `identities` straight
+// from useIdentity() in a v-for and never re-mounts the composable, so the
+// computed must invalidate on every add/update/remove without a reload).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("useIdentity (composable reactivity — #140)", () => {
+  beforeEach(clearSettings);
+
+  it("identities computed reflects addIdentity() without recreating the composable", async () => {
+    const { useIdentity } = await import("../useIdentity");
+    const api = useIdentity();
+    expect(api.identities.value).toHaveLength(0);
+    api.add({ label: "Work", gitName: "Alice", gitEmail: "alice@corp.com" });
+    expect(api.identities.value).toHaveLength(1);
+    expect(api.identities.value[0].label).toBe("Work");
+  });
+
+  it("identities computed reflects updateIdentity() without recreating the composable", async () => {
+    const { useIdentity } = await import("../useIdentity");
+    const api = useIdentity();
+    const id = api.add({ label: "Work", gitName: "Alice", gitEmail: "alice@corp.com" });
+    // Force an initial read so the computed caches a value before the mutation —
+    // otherwise a lazy first-read-after-mutation would pass even with a stale cache.
+    expect(api.identities.value[0].label).toBe("Work");
+    api.update(id, { label: "Work (renamed)" });
+    expect(api.identities.value[0].label).toBe("Work (renamed)");
+  });
+
+  it("identities computed reflects removeIdentity() without recreating the composable", async () => {
+    const { useIdentity } = await import("../useIdentity");
+    const api = useIdentity();
+    const id = api.add({ label: "Work", gitName: "Alice", gitEmail: "alice@corp.com" });
+    expect(api.identities.value).toHaveLength(1);
+    api.remove(id);
+    expect(api.identities.value).toHaveLength(0);
+  });
+
+  it("activeIdentity computed reflects setActive() without recreating the composable", async () => {
+    const { useIdentity } = await import("../useIdentity");
+    const api = useIdentity();
+    const id = api.add({ label: "Personal", gitName: "Bob", gitEmail: "bob@home.com" });
+    expect(api.activeIdentity.value).toBeNull();
+    api.setActive(id);
+    expect(api.activeIdentity.value?.label).toBe("Personal");
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // useCommitTemplates (module-level functions — composable wraps them)
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/apps/desktop/src/composables/useIdentity.ts
+++ b/apps/desktop/src/composables/useIdentity.ts
@@ -12,7 +12,7 @@
  */
 
 import { computed } from "vue";
-import { loadSettings, normaliseCwd, saveSettings, type IdentityProfile } from "./useSettings";
+import { loadSettings, normaliseCwd, saveSettings, settingsRevision, type IdentityProfile } from "./useSettings";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -107,8 +107,17 @@ export function setRepoIdentity(cwd: string, id: string | null): void {
 // ─── composable ──────────────────────────────────────────────────────────────
 
 export function useIdentity(cwd?: () => string) {
-  const identities = computed(() => allIdentities());
-  const activeIdentity = computed(() => resolveIdentity(cwd?.()));
+  const identities = computed(() => {
+    // Depend on the settings revision so add/update/remove reflect immediately.
+    void settingsRevision.value;
+    return allIdentities();
+  });
+  const activeIdentity = computed(() => {
+    // Same as above — resolveIdentity() reads localStorage directly and has
+    // no reactive dependency of its own.
+    void settingsRevision.value;
+    return resolveIdentity(cwd?.());
+  });
 
   return {
     identities,


### PR DESCRIPTION
## Summary
- `useIdentity.ts`'s `identities`/`activeIdentity` computeds read straight from `localStorage` via `loadSettings()`/`resolveIdentity()` with no Vue-reactive dependency, so Vue cached them once and never invalidated — create/edit/delete persisted correctly but the Settings UI stayed stale until the popover was closed and reopened.
- Both computeds now read `settingsRevision.value` (the ref `saveSettings()` already bumps on every write), mirroring the existing pattern in `usePinnedBranches.ts`.

## Test plan
- [x] Added reactivity tests in `useIdentity`'s test suite covering add/update/remove and `setActive`, failing before the fix and passing after
- [x] Full desktop suite (`pnpm test`): 84 files / 655 tests pass

Fixes #140