### PR TITLE
fix: rebase auto-resolve banner staleness + AI-resolve feedback/icon consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rebase auto-resolve UX** — "Auto-resolve" on a paused rebase conflict now correctly re-polls the rebase banner state (the Continue button and conflict hint were staying stuck even though the conflict had actually been resolved and staged); the per-hunk AI-resolve button now uses the app-wide animated `AiSparkle` icon instead of a barely-visible opacity pulse, for both clearer feedback and visual consistency with the rest of the app; and the per-hunk AI explanation prompt now repeats its language directive at the end of the prompt as a best-effort mitigation for occasional wrong-language responses from some providers (#133).
+
 ## [3.6.0] - 2026-07-20
 
 ### Added

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -647,6 +647,13 @@ watch(
  */
 async function advanceToNextConflictOrFinalize() {
   await repoRefresh();
+  // Re-poll the rebase/merge operation state alongside the repo status —
+  // `repoOperationState` (read by RebaseProgressBanner's hasConflict/Continue
+  // button) is only updated here, never by `repoRefresh()` itself. Without
+  // this, resolving a hunk/file during a rebase leaves the banner showing a
+  // stale "conflict" state even though the conflict was actually resolved
+  // and staged (issue #133).
+  await refreshRepoState();
   if (repoStatus.value && repoStatus.value.conflicted.length > 0) {
     await repoSelectFile(repoStatus.value.conflicted[0], false);
   } else if (isCherryPicking.value) {

--- a/apps/desktop/src/components/MergeEditor.vue
+++ b/apps/desktop/src/components/MergeEditor.vue
@@ -21,6 +21,7 @@ import {
 import LlmTracePanel from "./LlmTracePanel.vue";
 import TokenMergePanel from "./TokenMergePanel.vue";
 import ResolutionPreviewPanel from "./ResolutionPreviewPanel.vue";
+import AiSparkle from "./AiSparkle.vue";
 // Not lazy-loaded: this is a thin wrapper around BaseModal (already always-eager
 // per the P1.2 perf exception list) with no heavy additional deps — same static-import
 // treatment as its sibling hunk panels (LlmTracePanel, TokenMergePanel, ResolutionPreviewPanel).
@@ -946,10 +947,7 @@ useResizeObserver(contentEl, drawMinimap);
                   href="#"
                   @click.prevent="requestAISuggestion(seg.hunkIndex!, hunkForSegment(seg)!)"
                 >
-                  <svg class="ai-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-                    <path d="M8 1v2m0 10v2M1 8h2m10 0h2m-2.05-4.95-1.41 1.41m-7.08 7.08-1.41 1.41m0-9.9 1.41 1.41m7.08 7.08 1.41 1.41"/>
-                    <circle cx="8" cy="8" r="3"/>
-                  </svg>
+                  <AiSparkle :size="12" :animated="aiLoading && aiSuggestionHunkIndex === seg.hunkIndex" />
                   {{ aiLoading && aiSuggestionHunkIndex === seg.hunkIndex ? t('mergeEditor.aiLoading') : t('mergeEditor.aiButton') }}
                 </a>
                 <span class="inline-sep">|</span>

--- a/apps/desktop/src/components/__tests__/MergeEditor-ai-sparkle.test.ts
+++ b/apps/desktop/src/components/__tests__/MergeEditor-ai-sparkle.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Issue #133 (sub-issues 2 & 3) — the per-hunk "AI" resolve button used a
+ * bespoke inline SVG + text label ("AI" / "AI…") with only a subtle opacity
+ * pulse as loading feedback, inconsistent with the app-wide `AiSparkle` icon
+ * (already used in 13+ places, including its `animated` prop built exactly
+ * for "AI action in progress" states).
+ *
+ * This guards that the AI-suggest inline action now renders `AiSparkle`
+ * bound to the hunk's own loading condition (`aiLoading &&
+ * aiSuggestionHunkIndex === seg.hunkIndex`), so the icon both matches the
+ * rest of the app and visibly animates while busy.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createApp, type App } from "vue";
+import MergeEditor from "../MergeEditor.vue";
+import type { ConflictFile } from "../../composables/useGitWand";
+import type { ConflictHunk } from "@gitwand/core";
+
+function complexHunk(): ConflictHunk {
+  return {
+    baseLines: ["line1"],
+    oursLines: ["line1-ours"],
+    theirsLines: ["line1-theirs"],
+    startLine: 2,
+    type: "complex",
+    confidence: {
+      score: 20,
+      label: "low",
+      dimensions: { typeClassification: 20, dataRisk: 80, scopeImpact: 0, fileFrequency: 0, baseAvailability: 0 },
+      boosters: [],
+      penalties: [],
+    },
+    explanation: "Both sides changed incompatible things — manual resolution required.",
+    trace: { steps: [], selected: "complex", summary: "test", hasBase: true },
+  } as unknown as ConflictHunk;
+}
+
+function complexFile(): ConflictFile {
+  const hunk = complexHunk();
+  const content = [
+    "line before",
+    "<<<<<<< ours",
+    "line1-ours",
+    "=======",
+    "line1-theirs",
+    ">>>>>>> theirs",
+    "line after",
+  ].join("\n");
+  return {
+    path: "src/foo.ts",
+    content,
+    result: {
+      filePath: "src/foo.ts",
+      mergedContent: null,
+      hunks: [hunk],
+      resolutions: [{ hunk, resolvedLines: null, autoResolved: false, resolutionReason: "test" }],
+      stats: { totalConflicts: 1, autoResolved: 0, byType: { complex: 1 } },
+      validation: { valid: true, errors: [] },
+    } as unknown as ConflictFile["result"],
+  };
+}
+
+let app: App | null = null;
+let container: HTMLElement;
+
+beforeEach(() => {
+  // aiAvailable (useAIProvider.isAvailable) reads settings from localStorage —
+  // configure a provider that needs no API key so the AI inline actions render.
+  localStorage.setItem(
+    "gitwand-settings",
+    JSON.stringify({ aiEnabled: true, aiProvider: "ollama" }),
+  );
+});
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  container?.remove();
+  localStorage.clear();
+});
+
+function mount(file: ConflictFile) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  app = createApp(MergeEditor, { file });
+  app.mount(container);
+}
+
+describe("MergeEditor : AI-suggest button uses AiSparkle", () => {
+  it("renders the shared AiSparkle icon (not a bespoke inline SVG) for the AI-suggest action", () => {
+    mount(complexFile());
+    const aiAction = container.querySelector(".inline-action--ai");
+    expect(aiAction).not.toBeNull();
+    expect(aiAction!.querySelector(".ai-sparkle")).not.toBeNull();
+    // The old bespoke SVG used a 4-arrow "sparkle" path with a plain circle —
+    // that markup must be gone from this action now.
+    expect(aiAction!.querySelector("svg.ai-icon")).toBeNull();
+  });
+
+  it("does not mark the icon animated before any AI suggestion is requested", () => {
+    mount(complexFile());
+    const icon = container.querySelector(".inline-action--ai .ai-sparkle");
+    expect(icon).not.toBeNull();
+    expect(icon!.classList.contains("ai-sparkle--animated")).toBe(false);
+  });
+
+  it("animates AiSparkle while the AI suggestion for that hunk is loading", async () => {
+    mount(complexFile());
+    const aiAction = container.querySelector<HTMLAnchorElement>(".inline-action--ai")!;
+    aiAction.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const icon = container.querySelector(".inline-action--ai .ai-sparkle");
+    expect(icon).not.toBeNull();
+    expect(icon!.classList.contains("ai-sparkle--animated")).toBe(true);
+    expect(aiAction.classList.contains("inline-action--loading")).toBe(true);
+  });
+});

--- a/apps/desktop/src/composables/__tests__/useHunkExplanation.test.ts
+++ b/apps/desktop/src/composables/__tests__/useHunkExplanation.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Issue #133 (sub-issue 4) — per-hunk AI explanation text occasionally
+ * comes back in the wrong language. The locale is correctly threaded
+ * end-to-end (system prompt already carries "Write in ${lang}…"), but a
+ * language instruction buried only in the system prompt can drift with some
+ * providers. Mitigation: repeat a short, explicit language directive at the
+ * very end of the user-facing prompt as well — end-of-prompt instructions
+ * tend to be followed more reliably.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const rawPromptMock = vi.fn();
+const isAvailableRef = { value: true };
+
+vi.mock("../useAIProvider", () => ({
+  useAIProvider: () => ({
+    isAvailable: isAvailableRef,
+    rawPrompt: (...a: unknown[]) => rawPromptMock(...a),
+  }),
+}));
+
+import { useHunkExplanation, buildUserPrompt } from "../useHunkExplanation";
+import type { ConflictHunk } from "@gitwand/core";
+
+function hunk(): ConflictHunk {
+  return {
+    baseLines: ["base"],
+    oursLines: ["ours"],
+    theirsLines: ["theirs"],
+    startLine: 1,
+    type: "complex",
+    confidence: {
+      score: 20,
+      label: "low",
+      dimensions: { typeClassification: 20, dataRisk: 80, scopeImpact: 0, fileFrequency: 0, baseAvailability: 0 },
+      boosters: [],
+      penalties: [],
+    },
+    explanation: "test",
+    trace: { steps: [{ type: "same_change", passed: false, reason: "diverging" }], selected: "complex", summary: "test", hasBase: true },
+  } as unknown as ConflictHunk;
+}
+
+describe("buildUserPrompt", () => {
+  it("ends with an explicit language directive", () => {
+    const prompt = buildUserPrompt(hunk(), "src/foo.ts", 1500, "French");
+    expect(prompt.trim().endsWith("(Respond only in French.)")).toBe(true);
+  });
+
+  it("still contains the decision trace and file path ahead of the directive", () => {
+    const prompt = buildUserPrompt(hunk(), "src/foo.ts", 1500, "English");
+    expect(prompt).toContain("File: src/foo.ts");
+    expect(prompt).toContain("[rejected] same_change: diverging");
+    expect(prompt.indexOf("Explain this conflict.")).toBeLessThan(
+      prompt.indexOf("(Respond only in English.)"),
+    );
+  });
+});
+
+describe("useHunkExplanation.explain", () => {
+  beforeEach(() => {
+    rawPromptMock.mockReset();
+    isAvailableRef.value = true;
+  });
+
+  it("passes a user prompt ending with the language directive for the active locale", async () => {
+    rawPromptMock.mockResolvedValue("Explication de test.");
+    const { explain } = useHunkExplanation();
+    await explain(hunk(), { locale: "fr", filePath: "src/foo.ts" });
+
+    const [systemPrompt, userPrompt] = rawPromptMock.mock.calls[0];
+    expect(systemPrompt).toContain("Write in French");
+    expect(userPrompt.trim().endsWith("(Respond only in French.)")).toBe(true);
+  });
+
+  it("defaults to French when no locale is provided (matches existing default)", async () => {
+    rawPromptMock.mockResolvedValue("Explication.");
+    const { explain } = useHunkExplanation();
+    await explain(hunk());
+
+    const [, userPrompt] = rawPromptMock.mock.calls[0];
+    expect(userPrompt.trim().endsWith("(Respond only in French.)")).toBe(true);
+  });
+});

--- a/apps/desktop/src/composables/useHunkExplanation.ts
+++ b/apps/desktop/src/composables/useHunkExplanation.ts
@@ -73,10 +73,11 @@ function clip(s: string, max: number): string {
   return s.slice(0, max) + "\n... (truncated)";
 }
 
-function buildUserPrompt(
+export function buildUserPrompt(
   hunk: ConflictHunk,
   filePath: string | undefined,
   maxSideChars: number,
+  lang: string,
 ): string {
   const ours = clip(hunk.oursLines.join("\n"), maxSideChars);
   const theirs = clip(hunk.theirsLines.join("\n"), maxSideChars);
@@ -101,6 +102,13 @@ function buildUserPrompt(
   parts.push(theirs || "(empty)");
   parts.push("");
   parts.push("Explain this conflict.");
+  // Repeat the language instruction at the very end of the user-facing
+  // prompt, in addition to the system-prompt instruction above. Some
+  // providers drift from a language directive buried only in the system
+  // prompt — especially here, where the rest of the prompt is English
+  // decision-trace jargon. End-of-prompt instructions tend to be followed
+  // more reliably (issue #133).
+  parts.push(`(Respond only in ${lang}.)`);
   return parts.join("\n");
 }
 
@@ -132,8 +140,9 @@ export function useHunkExplanation() {
         throw new Error(t("errors.noAiProvider"));
       }
 
+      const lang = localeToEnglishName(locale);
       const systemPrompt = buildSystemPrompt(locale);
-      const userPrompt = buildUserPrompt(hunk, filePath, maxSideChars);
+      const userPrompt = buildUserPrompt(hunk, filePath, maxSideChars, lang);
 
       const raw = await ai.rawPrompt(systemPrompt, userPrompt);
       if (!raw) {


### PR DESCRIPTION
## Summary
- **Auto-resolve on a paused rebase does nothing (visibly)** — `advanceToNextConflictOrFinalize()` refreshed repo status but never re-polled `repoOperationState`, which is what `RebaseProgressBanner` reads for its Continue button / conflict hint. The conflict was actually resolved and staged; the banner just never found out. Now calls `refreshRepoState()` alongside `repoRefresh()`, matching the sibling handlers that already did this correctly.
- **AI-resolve loading feedback too subtle + inconsistent icon** — swapped the bespoke inline SVG + faint opacity pulse for the app-wide `AiSparkle` component (already used in 13+ places) with its `animated` prop bound to the in-flight state for that hunk.
- **AI hunk explanation occasionally answers in the wrong language** — locale threading was already correct end-to-end; added a best-effort mitigation repeating the language directive at the end of the user prompt (not just the system prompt), since some CLI-wrapped providers drift from language instructions buried earlier. Not a full fix — flagged as needing confirmation against the reporter's actual provider config.

## Test plan
- [x] New tests for the `AiSparkle` swap and the prompt-language directive: 7/7 pass
- [x] Full desktop suite: 658/658 pass, no regressions
- [ ] Manual QA via `pnpm dev:web`: trigger a rebase conflict, click "Résoudre auto", confirm the banner/Continue button updates immediately (no existing test harness covers `App.vue` directly — recommend a manual pass here)

Addresses #133