### PR TITLE
fix: GitLab PR overview shows GitHub CLI error + glab mr list --state flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **GitLab PR overview** — the PR panel no longer shows the GitHub-specific "GitHub CLI not installed" message for GitLab repos; the CLI-missing error and its install hint are now forge-specific (GitHub/`gh` vs GitLab/`glab`). Also fixed `glab mr list` failing with "Unknown flag: --state" — GitLab's CLI uses per-state boolean flags (`--opened`/`--closed`/`--merged`/`--all`), not `gh`'s generic `--state <value>` (#138).
+
 ## [3.6.0] - 2026-07-20
 
 ### Added

--- a/apps/desktop/src-tauri/src/commands/gitlab.rs
+++ b/apps/desktop/src-tauri/src/commands/gitlab.rs
@@ -86,6 +86,23 @@ fn gl_state(state: &str) -> String {
     }
 }
 
+/// Map our canonical MR state ("opened"/"closed"/"merged"/"all") to the
+/// corresponding `glab mr list` boolean flag.
+///
+/// Unlike `gh`, `glab mr list` has no generic `--state <value>` flag — it
+/// exposes one boolean flag per state (`--opened` is the CLI's own default,
+/// plus `--closed` / `--merged` / `--all`). Passing `--state <value>` (the
+/// `gh` convention) is rejected by `glab` with "Unknown flag: --state"
+/// (issue #138).
+fn gl_state_flag(state: &str) -> &'static str {
+    match state {
+        "closed" => "--closed",
+        "merged" => "--merged",
+        "all" => "--all",
+        _ => "--opened",
+    }
+}
+
 // ─── MR → PullRequest mapping ─────────────────────────────────────────────────
 
 /// Map a GitLab MR JSON object to a PullRequest.
@@ -221,12 +238,7 @@ pub(crate) async fn gl_list_mrs(
     limit: Option<i64>,
     offset: Option<i64>,
 ) -> Result<Vec<PullRequest>, String> {
-    let st = match state.as_str() {
-        "closed" => "closed",
-        "merged" => "merged",
-        "all" => "all",
-        _ => "opened",
-    };
+    let flag = gl_state_flag(&state);
     let page = limit.unwrap_or(10).max(1);
     let off = offset.unwrap_or(0).max(0);
     let total = (page + off).to_string();
@@ -234,7 +246,7 @@ pub(crate) async fn gl_list_mrs(
     let output = hidden_cmd("glab")
         .args([
             "mr", "list",
-            "--state", st,
+            flag,
             "--per-page", &total,
             "--output", "json",
         ])
@@ -298,14 +310,9 @@ pub(crate) async fn gl_list_mrs(
 /// Returns 0 on non-fatal errors so the Launchpad badge can still render.
 #[tauri::command]
 pub(crate) async fn gl_mr_count(cwd: String, state: String) -> Result<i64, String> {
-    let st = match state.as_str() {
-        "closed" => "closed",
-        "merged" => "merged",
-        "all" => "all",
-        _ => "opened",
-    };
+    let flag = gl_state_flag(&state);
     let output = hidden_cmd("glab")
-        .args(["mr", "list", "--state", st, "--per-page", "100", "--output", "json"])
+        .args(["mr", "list", flag, "--per-page", "100", "--output", "json"])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("glab mr count: {}", e))?;
@@ -1372,5 +1379,36 @@ mod gl_list_issues_tests {
         assert_eq!(i.labels, vec!["bug".to_string(), "p1".to_string()]);
         assert_eq!(i.milestone, "M1");
         assert_eq!(i.url, "https://gitlab.com/o/r/-/issues/12");
+    }
+}
+
+/// Issue #138 — `glab mr list` has no generic `--state <value>` flag like
+/// `gh`; it takes one boolean flag per state. Regression coverage for
+/// `gl_state_flag`, consumed by both `gl_list_mrs` and `gl_mr_count`'s
+/// `hidden_cmd("glab").args([...])` argument construction.
+#[cfg(test)]
+mod gl_state_flag_tests {
+    use super::gl_state_flag;
+
+    #[test]
+    fn maps_closed_to_the_closed_flag() {
+        assert_eq!(gl_state_flag("closed"), "--closed");
+    }
+
+    #[test]
+    fn maps_merged_to_the_merged_flag() {
+        assert_eq!(gl_state_flag("merged"), "--merged");
+    }
+
+    #[test]
+    fn maps_all_to_the_all_flag() {
+        assert_eq!(gl_state_flag("all"), "--all");
+    }
+
+    #[test]
+    fn maps_opened_and_any_other_value_to_the_opened_flag() {
+        assert_eq!(gl_state_flag("opened"), "--opened");
+        assert_eq!(gl_state_flag("open"), "--opened");
+        assert_eq!(gl_state_flag(""), "--opened");
     }
 }

--- a/apps/desktop/src/components/PrListSidebar.vue
+++ b/apps/desktop/src/components/PrListSidebar.vue
@@ -229,7 +229,7 @@ function setUserFilter(mode: 'all' | 'assigned' | 'reviews') {
     <div v-if="panel.error.value" class="pls-msg pls-msg--error">
       <span>{{ panel.error.value }}</span>
       <template v-if="panel.errorAction.value === 'open-settings' && openSettings">
-        <span class="pls-msg-hint">{{ t('pr.error.ghNotInstalledHint') }}</span>
+        <span class="pls-msg-hint">{{ t('pr.error.cliNotInstalledHint', panel.forgeLabel.value) }}</span>
         <button class="pls-msg-action" @click="openSettings('accounts')">{{ t('pr.error.openSettings') }}</button>
       </template>
       <button class="pls-msg-action" @click="panel.loadPrs">{{ t('pr.error.retry') }}</button>

--- a/apps/desktop/src/composables/__tests__/usePrPanel-cli-missing.test.ts
+++ b/apps/desktop/src/composables/__tests__/usePrPanel-cli-missing.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Issue #138 — Bug A: `loadPrs()`'s CLI-missing detection is forge-agnostic
+ * (it matches "No such file or directory" / "ENOENT" / "program not found"
+ * for any forge's CLI binary), but it always surfaced the GitHub-specific
+ * `pr.error.ghNotInstalled` message ("GitHub CLI not installed — install it
+ * from cli.github.com."), even when the active forge was GitLab (`glab`
+ * missing) or another CLI-backed forge. This regression-tests that the
+ * error message + install URL now match the active forge.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+// See usePrPanel.test.ts's comment on why `vi.hoisted()` is required here —
+// usePrPanel.ts's import chain evaluates the mock factories before a plain
+// top-level `const x = vi.fn()` in this file would have run.
+const { listPRs, gitRemoteInfo } = vi.hoisted(() => ({
+  listPRs: vi.fn(),
+  gitRemoteInfo: vi.fn(),
+}));
+
+vi.mock("../../utils/backend", () => ({
+  gitRemoteInfo: (...args: unknown[]) => gitRemoteInfo(...args),
+  gitFileCount: vi.fn(async () => 0),
+  ghForkInfo: vi.fn(async () => ({ isFork: false, origin: "", parent: "" })),
+  ghPrFreshnessSignal: vi.fn(),
+  detectClaudeCli: vi.fn(async () => ({
+    found: false, path: "", version: "", logged_in: false, status: "not_found",
+  })),
+}));
+
+// `forge` is derived from `forgeFromRemoteInfo(remote.value)` once `loadRemote()`
+// resolves `gitRemoteInfo()`. Mocking `forgeFromRemoteInfo` directly (rather than
+// relying on the real provider registry + URL sniffing) lets each test pin the
+// active forge's `name` precisely.
+const forgeStub = vi.hoisted(() => ({ current: { name: "github", listPRs: (..._a: unknown[]) => Promise.resolve([]) } }));
+vi.mock("../forge/useForge", () => ({
+  forgeFromRemoteInfo: vi.fn(() => forgeStub.current),
+  githubProvider: { name: "github", listPRs: vi.fn(async () => []) },
+}));
+
+import { usePrPanel } from "../usePrPanel";
+import { _resetPrCacheForTesting } from "../usePrCache";
+
+describe("usePrPanel — forge-specific CLI-missing error (issue #138)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetPrCacheForTesting();
+    listPRs.mockReset();
+    gitRemoteInfo.mockReset();
+  });
+
+  it("surfaces a GitHub-specific message when gh is missing on a GitHub repo", async () => {
+    gitRemoteInfo.mockResolvedValue({ name: "origin", url: "https://github.com/o/r", provider: "github", owner: "o", repo: "r" });
+    forgeStub.current = { name: "github", listPRs: vi.fn(async () => { throw new Error("Failed to run gh pr list (is gh installed?): No such file or directory (os error 2)"); }) };
+
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+    await panel.loadPrs();
+
+    expect(panel.error.value).toContain("GitHub CLI");
+    expect(panel.error.value).toContain("cli.github.com");
+    expect(panel.error.value).not.toContain("GitLab");
+    expect(panel.errorAction.value).toBe("open-settings");
+  });
+
+  it("surfaces a GitLab-specific message when glab is missing on a GitLab repo", async () => {
+    gitRemoteInfo.mockResolvedValue({ name: "origin", url: "https://gitlab.com/o/r", provider: "gitlab", owner: "o", repo: "r" });
+    forgeStub.current = { name: "gitlab", listPRs: vi.fn(async () => { throw new Error("Failed to run glab mr list (is glab installed?): No such file or directory (os error 2)"); }) };
+
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+    await panel.loadPrs();
+
+    expect(panel.error.value).toContain("GitLab");
+    expect(panel.error.value).not.toContain("GitHub CLI");
+    expect(panel.error.value).not.toContain("cli.github.com");
+    expect(panel.errorAction.value).toBe("open-settings");
+  });
+});

--- a/apps/desktop/src/composables/usePrPanel.ts
+++ b/apps/desktop/src/composables/usePrPanel.ts
@@ -50,6 +50,18 @@ const FORGE_LABELS: Record<string, string> = {
 };
 
 /**
+ * CLI name + install URL per forge, used when `loadPrs()` detects the
+ * forge's CLI binary is missing (issue #138). Only forges backed by a CLI
+ * binary need an entry here — Bitbucket/Azure go through `curl`/OAuth, not
+ * a locally-installed CLI, so they fall back to the GitHub entry (which
+ * only ever fires if a future CLI-backed forge is added without a mapping).
+ */
+const CLI_MISSING_INFO: Record<string, { cli: string; url: string }> = {
+  github: { cli: "GitHub CLI", url: "cli.github.com" },
+  gitlab: { cli: "GitLab CLI", url: "gitlab.com/gitlab-org/cli" },
+};
+
+/**
  * Whether a PR's `mergeable` state means the branch has conflicts and cannot
  * merge. Forges spell this differently (GitHub `CONFLICTING`, GitLab
  * `CONFLICTS`, others `DIRTY`), so normalise here and reuse everywhere a
@@ -598,7 +610,8 @@ export function usePrPanel(cwd: Ref<string>, opts: PrPanelOptions = {}) {
         // Our own error prefix
         (msg.includes("gh") && msg.includes("installed"));
       if (isGhMissing) {
-        error.value = t("pr.error.ghNotInstalled");
+        const info = CLI_MISSING_INFO[forge.value.name] ?? CLI_MISSING_INFO.github;
+        error.value = t("pr.error.cliNotInstalled", info.cli, info.url);
         errorAction.value = "open-settings";
       } else if (msg.includes("gh auth") || msg.includes("authentication") || msg.includes("token") || msg.includes("401")) {
         error.value = t("pr.error.noToken");

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -1049,8 +1049,8 @@ const en = {
     error: {
       noToken: "GitHub authentication required \u2014 run `gh auth login` in your terminal.",
       noRemote: "No GitHub remote found \u2014 make sure this repo has a GitHub origin.",
-      ghNotInstalled: "GitHub CLI not installed \u2014 install it from cli.github.com.",
-      ghNotInstalledHint: "Or add your GitHub account from the settings.",
+      cliNotInstalled: "{0} not installed \u2014 install it from {1}.",
+      cliNotInstalledHint: "Or add your {0} account from the settings.",
       openSettings: "Open settings",
       unknown: "Failed to load pull requests.",
       retry: "Retry",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -1033,8 +1033,8 @@ const es: Locale = {
     error: {
       noToken: "Autenticación de GitHub requerida — ejecuta `gh auth login` en tu terminal.",
       noRemote: "No se encontró un remote de GitHub — verifica que este repo tenga un origin de GitHub.",
-      ghNotInstalled: "GitHub CLI no instalado — instálalo desde cli.github.com.",
-      ghNotInstalledHint: "O añade tu cuenta de GitHub desde los ajustes.",
+      cliNotInstalled: "{0} no instalado — instálalo desde {1}.",
+      cliNotInstalledHint: "O añade tu cuenta de {0} desde los ajustes.",
       openSettings: "Abrir ajustes",
       unknown: "Error al cargar los pull requests.",
       retry: "Reintentar",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -1042,8 +1042,8 @@ const fr: Locale = {
     error: {
       noToken: "Authentification GitHub requise — lancez `gh auth login` dans votre terminal.",
       noRemote: "Aucune remote GitHub — vérifiez que ce dépôt a une origin GitHub.",
-      ghNotInstalled: "GitHub CLI non installé — installez-le depuis cli.github.com.",
-      ghNotInstalledHint: "Ou ajoutez votre compte GitHub depuis les réglages.",
+      cliNotInstalled: "{0} non installé — installez-le depuis {1}.",
+      cliNotInstalledHint: "Ou ajoutez votre compte {0} depuis les réglages.",
       openSettings: "Ouvrir les réglages",
       unknown: "Impossible de charger les pull requests.",
       retry: "Réessayer",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -1034,8 +1034,8 @@ const ptBR: Locale = {
     error: {
       noToken: "Autenticação do GitHub necessária — execute `gh auth login` no seu terminal.",
       noRemote: "Nenhum remote do GitHub encontrado — verifique se este repo tem uma origin do GitHub.",
-      ghNotInstalled: "GitHub CLI não instalado — instale em cli.github.com.",
-      ghNotInstalledHint: "Ou adicione sua conta do GitHub nas configurações.",
+      cliNotInstalled: "{0} não instalado — instale em {1}.",
+      cliNotInstalledHint: "Ou adicione sua conta do {0} nas configurações.",
       openSettings: "Abrir configurações",
       unknown: "Falha ao carregar os pull requests.",
       retry: "Tentar novamente",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -1022,8 +1022,8 @@ const zhCN: Locale = {
     error: {
       noToken: "需要 GitHub 认证 — 在终端运行 `gh auth login`。",
       noRemote: "未找到 GitHub 远程仓库 — 请确认此仓库有 GitHub origin。",
-      ghNotInstalled: "未安装 GitHub CLI — 请从 cli.github.com 安装。",
-      ghNotInstalledHint: "或在设置中添加你的 GitHub 账户。",
+      cliNotInstalled: "未安装 {0} — 请从 {1} 安装。",
+      cliNotInstalledHint: "或在设置中添加你的 {0} 账户。",
       openSettings: "打开设置",
       unknown: "加载 pull request 失败。",
       retry: "重试",


### PR DESCRIPTION
## Summary
- The PR panel's "CLI binary missing" detection is forge-agnostic, but always rendered the GitHub-specific "GitHub CLI not installed — install it from cli.github.com" message even on GitLab repos. Error/hint messages are now forge-specific via a new parameterized `pr.error.cliNotInstalled`/`cliNotInstalledHint` key (replacing the GitHub-only `ghNotInstalled*` keys), synced across all 5 locales.
- `glab mr list --state <value>` is a `gh`-only flag convention — `glab` exposes one boolean flag per state (`--opened`/`--closed`/`--merged`/`--all`). Fixed both `gl_list_mrs` and `gl_mr_count` in `gitlab.rs` to use the correct flag via a shared `gl_state_flag()` helper.

## Test plan
- [x] New composable test (`usePrPanel-cli-missing.test.ts`): GitHub vs GitLab CLI-missing errors render distinct, correct messages
- [x] New Rust unit tests for `gl_state_flag()`: closed/merged/all/opened+fallback — `cargo test --lib gitlab::` passes (5/5)
- [x] Full frontend suite: 653/653 pass across 85 files

Fixes #138