### PR TITLE
fix: stop truncating local branch names containing '/'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Commit Tree: checking out or deleting a local branch with a `/` in its name (e.g. `test/some_experiment`) no longer truncates it to the text after the first slash once you've switched away from it — the ref-classification logic no longer assumes any slash-containing decoration is a remote branch (#137).
+
 ## [3.6.0] - 2026-07-20
 
 ### Added

--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -332,7 +332,13 @@ const branchToDelete = computed(() => {
     );
     return { name, localName: name, remoteName: remote?.name, hasLocal: true, hasRemote: !!remote };
   } else if (type === "remote") {
-    // Remote tracking branch (e.g. origin/main)
+    // Remote tracking branch (e.g. origin/main). `type === "remote"` is only
+    // ever set by commitRefs() after confirming a match against
+    // props.branches with isRemote: true (#137) — it is never a guess from
+    // the presence of `/` in the display name, so slicing off the first `/`
+    // here is safe: git *remote names* (the "origin" in "origin/main") never
+    // contain `/`, even when the branch itself does (`origin/feature/foo` ->
+    // base name `feature/foo`, only the first segment is stripped).
     const remote = props.branches.find((b) => b.name === name && b.isRemote);
     // Extract base name from remote name (e.g. origin/main -> main)
     const slashIdx = name.indexOf("/");
@@ -361,6 +367,24 @@ function onCtxDeleteBranch() {
   emit("delete-branch", b.name, b.hasLocal, b.hasRemote, b.remoteName);
   closeCommitContextMenu();
 }
+
+/**
+ * The git-facing name to pass to `checkout-branch` for the right-clicked
+ * ref. Only a CONFIRMED remote-tracking ref (`clickedBranchType === "remote"`,
+ * set by commitRefs() after matching props.branches — never a guess from the
+ * presence of `/` in the display name) has its remote prefix stripped here.
+ * For every other type — including a local branch whose name itself
+ * contains `/`, e.g. `test/some_experiment` — the display name IS the
+ * git-facing name; blindly slicing off the first `/` regardless of a
+ * confirmed match used to truncate such local branches (#137).
+ */
+const clickedBranchCheckoutName = computed(() => {
+  const name = ctxMenu.value.clickedBranch;
+  if (!name) return undefined;
+  if (ctxMenu.value.clickedBranchType !== "remote") return name;
+  const slashIdx = name.indexOf("/");
+  return slashIdx !== -1 ? name.slice(slashIdx + 1) : name;
+});
 
 /**
  * A right-clicked local branch that is checked out in a worktree. Plain
@@ -525,8 +549,13 @@ const displayCommits = computed(() => {
   let headCommit: GitLogEntry | undefined;
 
   if (props.currentBranch) {
+    // Include "ambiguous" (a slash-containing name parseRefs() couldn't
+    // classify on its own, see #137) — the name equality check below is
+    // the actual discriminator here, not the type.
     headCommit = props.commits.find((e) =>
-      parseRefs(e.refs).some((r) => (r.type === "branch" || r.type === "remote") && r.name === props.currentBranch)
+      parseRefs(e.refs).some(
+        (r) => (r.type === "branch" || r.type === "remote" || r.type === "ambiguous") && r.name === props.currentBranch,
+      )
     );
   }
 
@@ -592,8 +621,11 @@ const layout = computed<DagLayout>(() => {
     let trunkHash: string | undefined;
     for (const commit of commits) {
       const refs = parseRefs(commit.refs);
+      // Include "ambiguous" so `origin/main` (a slash-containing name
+      // parseRefs() can't classify on its own, see #137) still matches here
+      // — TRUNK_NAMES.has(...) already strips any remote prefix below.
       if (refs.some((r) =>
-        (r.type === "branch" || r.type === "remote") &&
+        (r.type === "branch" || r.type === "remote" || r.type === "ambiguous") &&
         TRUNK_NAMES.has(r.name.includes("/") ? r.name.split("/").pop()! : r.name)
       )) {
         trunkHash = commit.hashFull;
@@ -906,17 +938,33 @@ function commitRefs(entry: GitLogEntry) {
     refs.push({ type: 'stash' as const, name: 'stash' });
   }
 
-  // Re-classify refs using props.branches (v2.14)
-  // parseRefs is generic and thinks anything with a '/' is remote.
-  // We use our ground-truth branches list to fix this.
+  // Re-classify refs using props.branches (v2.14).
+  // parseRefs() cannot tell a genuine remote ref (`origin/main`) apart from a
+  // local branch whose name happens to contain a `/` (`test/some_experiment`)
+  // — both decorate identically once not checked out — so it tags any
+  // slash-containing name "ambiguous" rather than guessing. This function is
+  // the SOLE authority that resolves "ambiguous" (and double-checks
+  // "branch"/"remote") against the ground-truth branch list.
+  //
+  // #137: when no match is found (e.g. props.branches is empty/stale right
+  // after a repo/tab switch), an unresolved "ambiguous" ref now defaults to
+  // "branch" (a local branch), NOT "remote" — an unmatched slash-containing
+  // name is far more likely to be a local branch GitWand hasn't loaded yet
+  // than a genuine remote ref. Getting this wrong used to make downstream
+  // context-menu actions strip everything up to the first `/`, truncating
+  // local branch names like `test/some_experiment` to `some_experiment` for
+  // both checkout and delete.
   const reclassified = refs.map(r => {
-    if (r.type === 'branch' || r.type === 'remote') {
+    if (r.type === 'branch' || r.type === 'remote' || r.type === 'ambiguous') {
       const match = props.branches?.find(b => b.name === r.name);
       if (match) {
         return { ...r, type: (match.isRemote ? 'remote' : 'branch') as 'remote' | 'branch' };
       }
+      if (r.type === 'ambiguous') {
+        return { ...r, type: 'branch' as const };
+      }
     }
-    return r;
+    return r as { type: 'head' | 'branch' | 'remote' | 'tag' | 'stash'; name: string };
   });
 
   // Filter out redundant remote tracking branches and noise (v2.14)
@@ -1572,7 +1620,7 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
           :class="{ 'commit-ctx-menu-item--disabled': isCheckoutDisabled }"
           role="menuitem"
           :title="isCheckoutDisabled ? t('commitCtx.checkoutHeadDisabled') : t('commitCtx.checkoutHint')"
-          @click="!isCheckoutDisabled && (ctxMenu.clickedBranch ? (emit('checkout-branch', ctxMenu.clickedBranchType === 'remote' ? ctxMenu.clickedBranch.slice(ctxMenu.clickedBranch.indexOf('/') + 1) : ctxMenu.clickedBranch, ctxMenu.clickedBranchType === 'remote'), closeCommitContextMenu()) : onCtxEmit('checkout-commit'))"
+          @click="!isCheckoutDisabled && (ctxMenu.clickedBranch ? (emit('checkout-branch', clickedBranchCheckoutName!, ctxMenu.clickedBranchType === 'remote'), closeCommitContextMenu()) : onCtxEmit('checkout-commit'))"
         >
           <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
             <circle cx="8" cy="8" r="3" stroke="currentColor" stroke-width="1.4"/>

--- a/apps/desktop/src/components/__tests__/CommitGraph.branchSlash.test.ts
+++ b/apps/desktop/src/components/__tests__/CommitGraph.branchSlash.test.ts
@@ -1,0 +1,201 @@
+/**
+ * CommitGraph.vue — ref-classification regression for #137.
+ *
+ * `git branch test/some_experiment` then switching away leaves the branch
+ * decorated in `git log` as the bare name `test/some_experiment` (no
+ * `HEAD -> ` prefix). At that instant `props.branches` can be empty/stale
+ * (e.g. right after a repo/tab switch resets branch state in useGitRepo.ts,
+ * per the bug report) — commitRefs() then has no ground-truth match to fix
+ * the ref's type. It used to fall back to whatever parseRefs() guessed,
+ * which classified any name containing `/` as `type: "remote"` on the
+ * assumption it must be `<remote>/<branch>`. Two context-menu actions then
+ * stripped everything up to the first `/`, assuming it was a remote prefix,
+ * truncating the local branch name to `some_experiment` for both checkout
+ * and delete.
+ *
+ * commitRefs() must now default an unmatched ref to `"branch"` (a local
+ * branch), not `"remote"` — so the full name survives into both the
+ * "Checkout branch…" and "Delete branch…" context-menu actions.
+ *
+ * Mounted with native `createApp` into jsdom (no @vue/test-utils dep),
+ * mirroring LaunchpadView.test / LlmTracePanel.test. useI18n is mocked to
+ * the identity function so menu items can be matched by translation key
+ * rather than locale-specific English strings.
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { createApp, h, nextTick, type App } from "vue";
+import CommitGraph from "../CommitGraph.vue";
+import type { GitLogEntry } from "../../utils/backend";
+
+vi.mock("../../composables/useI18n", () => ({
+  useI18n: () => ({ t: (key: string, ...args: unknown[]) => (args.length ? `${key}:${args.join(",")}` : key) }),
+}));
+
+const commits: GitLogEntry[] = [
+  {
+    hash: "abc1234",
+    hashFull: "abc1234000000000000000000000000000000",
+    author: "Dev",
+    email: "dev@example.com",
+    date: "2026-08-01T00:00:00Z",
+    message: "on main",
+    body: "",
+    parents: [],
+    refs: "HEAD -> main",
+  },
+  {
+    hash: "def5678",
+    hashFull: "def5678000000000000000000000000000000",
+    author: "Dev",
+    email: "dev@example.com",
+    date: "2026-07-30T00:00:00Z",
+    message: "experiment work",
+    body: "",
+    parents: [],
+    // Not checked out — decorated as the bare (possibly slash-containing) name.
+    refs: "test/some_experiment",
+  },
+];
+
+let app: App | null = null;
+let container: HTMLElement | null = null;
+
+function mount(propsOverride: Record<string, unknown> = {}) {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  const emitted: Record<string, unknown[][]> = {};
+  app = createApp({
+    setup() {
+      return () =>
+        h(CommitGraph, {
+          commits,
+          currentBranch: "main",
+          branches: [],
+          onCheckoutBranch: (...a: unknown[]) => {
+            (emitted["checkout-branch"] ??= []).push(a);
+          },
+          onDeleteBranch: (...a: unknown[]) => {
+            (emitted["delete-branch"] ??= []).push(a);
+          },
+          ...propsOverride,
+        });
+    },
+  });
+  app.mount(container);
+  return { emitted };
+}
+
+function findRefBadge(name: string): HTMLElement {
+  const badge = Array.from(document.querySelectorAll<HTMLElement>(".cg-ref")).find(
+    (el) => el.getAttribute("title") === name,
+  );
+  if (!badge) throw new Error(`ref badge "${name}" not found`);
+  return badge;
+}
+
+function rightClick(el: HTMLElement) {
+  const evt = new MouseEvent("contextmenu", { bubbles: true, cancelable: true, clientX: 10, clientY: 10 });
+  el.dispatchEvent(evt);
+}
+
+function findMenuItemByKey(key: string): HTMLElement {
+  const items = Array.from(document.querySelectorAll<HTMLElement>(".commit-ctx-menu-item"));
+  const item = items.find((el) => el.textContent?.includes(key));
+  if (!item) throw new Error(`menu item "${key}" not found`);
+  return item;
+}
+
+afterEach(() => {
+  app?.unmount();
+  app = null;
+  container?.remove();
+  container = null;
+});
+
+describe("CommitGraph — slash-named local branch (#137)", () => {
+  it("classifies the unmatched slash-named ref as a local branch, not remote", async () => {
+    mount();
+    await nextTick();
+    const badge = findRefBadge("test/some_experiment");
+    expect(badge.className).toContain("cg-ref--branch");
+    expect(badge.className).not.toContain("cg-ref--remote");
+  });
+
+  it("emits the full branch name (not truncated) on checkout from the context menu", async () => {
+    const { emitted } = mount();
+    await nextTick();
+    rightClick(findRefBadge("test/some_experiment"));
+    await nextTick();
+    const checkoutItem = findMenuItemByKey("commitCtx.checkoutBranch");
+    checkoutItem.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(emitted["checkout-branch"]?.[0]?.[0]).toBe("test/some_experiment");
+  });
+
+  it("emits the full branch name (not truncated) on delete from the context menu", async () => {
+    const { emitted } = mount();
+    await nextTick();
+    rightClick(findRefBadge("test/some_experiment"));
+    await nextTick();
+    const deleteItem = findMenuItemByKey("branchMenu.deleteLabel");
+    deleteItem.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await nextTick();
+    expect(emitted["delete-branch"]?.[0]?.[0]).toBe("test/some_experiment");
+  });
+
+  it("still classifies a genuine remote-tracking branch as remote", async () => {
+    const remoteCommits: GitLogEntry[] = [
+      {
+        hash: "aaa1111",
+        hashFull: "aaa1111000000000000000000000000000000",
+        author: "Dev",
+        email: "dev@example.com",
+        date: "2026-08-01T00:00:00Z",
+        message: "on origin/main",
+        body: "",
+        parents: [],
+        refs: "origin/main",
+      },
+    ];
+    mount({
+      commits: remoteCommits,
+      branches: [
+        {
+          name: "origin/main",
+          isCurrent: false,
+          isRemote: true,
+          upstream: null,
+          ahead: 0,
+          behind: 0,
+          mainCommitCount: 1,
+          lastCommit: "aaa1111",
+          lastCommitDate: "2026-08-01T00:00:00Z",
+        },
+      ],
+    });
+    await nextTick();
+    const badge = findRefBadge("origin/main");
+    expect(badge.className).toContain("cg-ref--remote");
+  });
+
+  it("still classifies a tag correctly", async () => {
+    const taggedCommits: GitLogEntry[] = [
+      {
+        hash: "bbb2222",
+        hashFull: "bbb2222000000000000000000000000000000",
+        author: "Dev",
+        email: "dev@example.com",
+        date: "2026-08-01T00:00:00Z",
+        message: "tagged commit",
+        body: "",
+        parents: [],
+        refs: "tag: v1.0.0",
+      },
+    ];
+    mount({ commits: taggedCommits, branches: [] });
+    await nextTick();
+    const badge = findRefBadge("v1.0.0");
+    expect(badge.className).toContain("cg-ref--tag");
+  });
+});

--- a/apps/desktop/src/utils/__tests__/dagLayout.test.ts
+++ b/apps/desktop/src/utils/__tests__/dagLayout.test.ts
@@ -1,0 +1,62 @@
+/**
+ * dagLayout.ts — parseRefs() ref-classification tests.
+ *
+ * Regression coverage for #137: `git branch test/some_experiment` then
+ * switching away leaves the branch decorated as the bare name
+ * `test/some_experiment` (no `HEAD -> ` prefix, since it isn't checked out).
+ * parseRefs() used to classify ANY ref containing `/` as `type: "remote"`
+ * on the assumption it must have shape `<remote>/<branch>` — which silently
+ * mis-tags a slash-named local branch too. Consumers (CommitGraph.vue) then
+ * stripped everything up to the first `/`, truncating `test/some_experiment`
+ * down to `some_experiment` for checkout and delete actions.
+ *
+ * parseRefs() no longer guesses "remote" from the presence of `/` alone —
+ * genuine remote refs are only resolved downstream against the real branch
+ * list (see CommitGraph.vue's commitRefs()). This file only pins the
+ * behavior parseRefs() itself is responsible for: it must not eagerly
+ * label a slash-containing name "remote".
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseRefs } from "../dagLayout";
+
+describe("parseRefs", () => {
+  it("does not classify a slash-containing name as remote by default", () => {
+    const parsed = parseRefs("test/some_experiment");
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].name).toBe("test/some_experiment");
+    expect(parsed[0].type).not.toBe("remote");
+  });
+
+  it("keeps the full name intact for a slash-named ref (no truncation)", () => {
+    const parsed = parseRefs("test/some_experiment");
+    expect(parsed[0].name).toBe("test/some_experiment");
+  });
+
+  it("still classifies a checked-out slash-named branch as branch (HEAD -> prefix)", () => {
+    const parsed = parseRefs("HEAD -> test/some_experiment");
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({ type: "branch", name: "test/some_experiment" });
+  });
+
+  it("classifies a plain (no-slash) name as branch", () => {
+    const parsed = parseRefs("main");
+    expect(parsed[0]).toEqual({ type: "branch", name: "main" });
+  });
+
+  it("still classifies HEAD, tag: and stash markers correctly", () => {
+    expect(parseRefs("HEAD")[0]).toEqual({ type: "head", name: "HEAD" });
+    expect(parseRefs("tag: v1.0.0")[0]).toEqual({ type: "tag", name: "v1.0.0" });
+    expect(parseRefs("refs/stash")[0]).toEqual({ type: "stash", name: "stash" });
+  });
+
+  it("parses multiple comma-separated decorations, including a slash-named one", () => {
+    const parsed = parseRefs("HEAD -> main, test/some_experiment, tag: v2.0.0");
+    const names = parsed.map((r) => r.name);
+    expect(names).toContain("main");
+    expect(names).toContain("test/some_experiment");
+    expect(names).toContain("v2.0.0");
+    const experiment = parsed.find((r) => r.name === "test/some_experiment");
+    expect(experiment?.type).not.toBe("remote");
+  });
+});

--- a/apps/desktop/src/utils/dagLayout.ts
+++ b/apps/desktop/src/utils/dagLayout.ts
@@ -275,21 +275,37 @@ export function computeDagLayout(
   return { nodes, edges, maxLane };
 }
 
-/** Parse ref decoration string into individual labels, sorted by priority (branch > remote > tag > head) */
-export function parseRefs(refs: string): Array<{ type: "head" | "branch" | "remote" | "tag" | "stash"; name: string }> {
+/**
+ * Parse ref decoration string into individual labels, sorted by priority
+ * (branch > remote > tag > head).
+ *
+ * IMPORTANT (#137): a ref name containing `/` is NOT necessarily a remote
+ * tracking ref of shape `<remote>/<branch>` — a local branch created with a
+ * slash in its name (e.g. `test/some_experiment`) decorates identically once
+ * it's no longer checked out (no `HEAD -> ` prefix). This function has no
+ * way to tell the two apart from the string alone, so it deliberately does
+ * NOT guess "remote" from the presence of `/`. Such refs are tagged
+ * `"ambiguous"` here; CommitGraph.vue's `commitRefs()` is the sole authority
+ * that resolves `"ambiguous"` into a real `"branch"` or `"remote"` using the
+ * ground-truth branch list (and defaults to `"branch"` when it can't tell,
+ * since an unresolved local branch is far more likely than a genuine remote
+ * ref nobody could match).
+ */
+export function parseRefs(refs: string): Array<{ type: "head" | "branch" | "remote" | "tag" | "stash" | "ambiguous"; name: string }> {
   if (!refs) return [];
   const parsed = refs.split(",").map((r) => r.trim()).filter(Boolean).map((r) => {
     if (r === "HEAD") return { type: "head" as const, name: "HEAD" };
     if (r.startsWith("HEAD -> ")) return { type: "branch" as const, name: r.slice(8) };
     if (r.startsWith("tag: ")) return { type: "tag" as const, name: r.slice(5) };
     if (r === "refs/stash" || r === "stash") return { type: "stash" as const, name: "stash" };
-    if (r.includes("/")) return { type: "remote" as const, name: r };
+    if (r.includes("/")) return { type: "ambiguous" as const, name: r };
     return { type: "branch" as const, name: r };
   });
 
-  // Sort: Branch (local) > Remote > Tag > Stash > HEAD (detached)
+  // Sort: Branch (local) > Ambiguous > Remote > Tag > Stash > HEAD (detached)
   const weights: Record<string, number> = {
     branch: 1,
+    ambiguous: 1.5,
     remote: 2,
     tag: 3,
     stash: 4,


### PR DESCRIPTION
## Summary
- `dagLayout.ts`'s `parseRefs()` classified any slash-containing ref decoration as `type: "remote"`, assuming shape `<remote>/<branch>`. A local branch like `test/some_experiment`, once switched away from, decorates identically (no `HEAD -> ` prefix) and got misclassified the same way.
- `CommitGraph.vue`'s `commitRefs()` only corrected the type when it found a match in `props.branches`; an empty/stale list (e.g. right after a repo/tab switch) let the wrong `"remote"` type through.
- Two call sites then stripped everything before the first `/`, assuming a remote prefix — truncating `test/some_experiment` to `some_experiment` on checkout and delete.

Fix: `parseRefs()` now tags such refs as a new neutral `"ambiguous"` type instead of guessing `"remote"`. `commitRefs()` is the sole authority resolving `"ambiguous"` against the ground-truth branch list, defaulting to `"branch"` (not `"remote"`) when unmatched. The checkout/delete code paths now only strip the remote prefix once `type === "remote"` has been positively confirmed.

## Test plan
- [x] New `dagLayout.test.ts`: 6/6 pass
- [x] New `CommitGraph.branchSlash.test.ts`: 5/5 pass, including explicit regression coverage that `origin/main` and tags still classify correctly
- [x] Full desktop suite: 662/662 pass across 86 files

Fixes #137