### PR TITLE
fix: add GDK_BACKEND=x11 Linux startup fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Linux: added a further startup fallback, `GDK_BACKEND=x11` (never overriding a value already set in the environment), for systems where `Could not create default EGL display: EGL_BAD_PARAMETER` still occurs after the v3.6.2 fallbacks. Confirmed via a report with `ldd` output that this is a genuine native-Wayland EGL negotiation failure on the host system, not an AppImage-bundled-library mismatch. Forcing GTK onto XWayland sidesteps that negotiation, at the cost of native Wayland's fractional scaling and lower input latency (#135).
+
 ## [3.6.2] - 2026-08-11
 
 ### Added

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -306,6 +306,18 @@ pub fn run() {
         if std::env::var("LIBGL_ALWAYS_SOFTWARE").is_err() {
             std::env::set_var("LIBGL_ALWAYS_SOFTWARE", "1");
         }
+        // #135 follow-up 2: LIBGL_ALWAYS_SOFTWARE forces the GL renderer once an
+        // EGL context exists, but doesn't help when the failure happens earlier,
+        // at EGL *platform display* acquisition under native Wayland. Confirmed
+        // via `ldd` from an affected user that this isn't an AppImage-bundled-library
+        // issue (EGL/GL/Mesa all resolved to the host system, not the bundle) but a
+        // genuine native-Wayland EGL negotiation failure. Forcing GTK onto XWayland
+        // sidesteps that negotiation entirely, at the cost of native Wayland's
+        // fractional scaling and lower input latency. Never override a value the
+        // user or environment already set deliberately.
+        if std::env::var("GDK_BACKEND").is_err() {
+            std::env::set_var("GDK_BACKEND", "x11");
+        }
     }
 
     // macOS GUI apps launched from Finder/Dock get a minimal launchd env


### PR DESCRIPTION
## Summary

Follow-up to #152/#155. After v3.6.2 shipped `LIBGL_ALWAYS_SOFTWARE` as a broader Linux render fallback, a reporter on Fedora 44 (Gnome, AppImage) confirmed the telemetry panic is gone but the EGL abort persists: `Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...`.

Their `ldd` output rules out the AppImage-bundled-library theory noted as a follow-up in the design doc: `libEGL.so.1`, `libGL.so.1`, `libGLX.so.0`, and `libGLdispatch.so.0` all resolve to the host system's `/lib64`, not the AppImage's bundled libraries. This is a genuine native-Wayland EGL negotiation failure on the host, and `LIBGL_ALWAYS_SOFTWARE` doesn't help because it only affects the GL renderer once an EGL context exists, not the earlier EGL *platform display* acquisition step that's actually failing.

Added `GDK_BACKEND=x11` (guarded, never overriding a value already set) alongside the existing Linux fallbacks. This forces GTK onto XWayland, sidestepping the native-Wayland EGL negotiation entirely. Applied unconditionally for all Linux users, matching this codebase's existing precedent for the other two fallbacks (accepting the performance/scaling trade-off broadly to guarantee startup).

Addresses the ongoing thread on #135.

## Trade-off, stated plainly

Forcing XWayland means: no native Wayland fractional scaling, and typically a bit more input latency than native Wayland compositing. This is a heavier trade-off than the existing `LIBGL_ALWAYS_SOFTWARE` fallback, but is the standard, well-known workaround for this exact class of WebKitGTK/Wayland EGL failure, and the guard means anyone who already sets `GDK_BACKEND` themselves is unaffected.

## Test plan
- [x] `cargo check` / `cargo test --lib` pass (188 tests)
- [ ] Unverified against the actual reporting environment (Fedora 44 / Gnome / AppImage) — no Linux GPU/EGL harness available locally or in CI. Needs a report-back from the affected user, same loop as the prior two rounds on #135.