### PR TITLE
fix: restore Amend and Split commit menu items in the Git Tree view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Amend and Split commit are reachable again from the commit graph** — both actions shipped in April with a full backend/dialog implementation, but the v2.15.0 "Git Tree" rewrite replaced the old flat commit-log view with the graph view and never carried the corresponding context-menu items over, leaving the two actions fully wired end to end with no button left to trigger them. Restored "Amend commit..." and "Split commit..." to the graph's right-click menu (#156).
+
 ## [3.6.2] - 2026-08-11
 
 ### Added

--- a/apps/desktop/src/components/CommitGraph.vue
+++ b/apps/desktop/src/components/CommitGraph.vue
@@ -1855,6 +1855,30 @@ const visibleCommits = computed<VisibleCommit[]>(() => {
         </svg>
         <span>{{ t('commitCtx.revert') }}</span>
       </li>
+      <li
+        class="commit-ctx-menu-item"
+        :class="{ 'commit-ctx-menu-item--disabled': !isCtxEntryHead }"
+        role="menuitem"
+        :title="!isCtxEntryHead ? t('commitCtx.amendHeadOnly') : undefined"
+        @click="isCtxEntryHead && onCtxEmit('edit-commit')"
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M11 2l3 3-8 8H3v-3l8-8z" stroke="currentColor" stroke-width="1.4" stroke-linejoin="round"/>
+        </svg>
+        <span>{{ t('commitCtx.amend') }}</span>
+      </li>
+      <li
+        class="commit-ctx-menu-item"
+        :class="{ 'commit-ctx-menu-item--disabled': isCtxEntryMerge || !isCtxEntryHead }"
+        role="menuitem"
+        :title="isCtxEntryMerge ? t('splitCommit.errorMergeCommit') : !isCtxEntryHead ? t('commitCtx.splitHeadOnly') : undefined"
+        @click="!isCtxEntryMerge && isCtxEntryHead && onCtxEmit('split-commit')"
+      >
+        <svg width="13" height="13" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path d="M8 2v5m0 0l-3-3m3 3l3-3M3 10h10M5 14h6" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+        </svg>
+        <span>{{ t('splitCommit.contextMenuAction') }}</span>
+      </li>
 
       <li class="commit-ctx-menu-sep" role="separator"></li>
 


### PR DESCRIPTION
## Summary

A user reported (#156) they could no longer find a way to amend the previous commit, and were right: the feature exists and is fully wired end to end, it is just unreachable from the current UI.

Amend shipped in April with its full chain (backend `git_amend_commit`, `EditCommitOverlay.vue` dialog, `App.vue` handler), triggered from a context-menu item in the old flat commit-log view (`CommitLog.vue`). In May, v2.15.0 replaced that view with the current "Git Tree" graph view (`CommitGraph.vue`) and its own independently-built context menu, but the Amend (and Split) menu items never got carried over. `App.vue`'s `@edit-commit`/`@split-commit` handlers and the dialog components were left mounted and idle the whole time, since nothing ever emitted those events.

This restores both menu items to `CommitGraph.vue`'s right-click menu, in the same position (right after Revert) and with the same HEAD-only / not-a-merge-commit guards as the old view. No backend, composable, or i18n changes needed, since the entire chain already existed and all the i18n keys (`commitCtx.amend`, `commitCtx.amendHeadOnly`, `splitCommit.contextMenuAction`, `commitCtx.splitHeadOnly`, `splitCommit.errorMergeCommit`) were already present in all 5 locales.

Fixes #156.

## Test plan
- [x] `vue-tsc --noEmit` clean, full desktop `vitest run` (689 tests) unaffected
- [x] Manual QA via `pnpm dev:web` against a real repo: right-clicked the HEAD commit in the graph view, confirmed both "Amend commit..." and "Split commit..." now appear (previously absent), guarded correctly (disabled with a tooltip on non-HEAD commits)
- [x] Actually completed an amend end to end: dialog opened pre-filled with the correct commit's message, confirmed, and verified on disk that `git log` showed the new SHA and new message
- [x] Confirmed Split also opens correctly (hunk-selection modal) on the HEAD commit from the same new menu item