### PR TITLE
perf(build): v3.6.6 — dev loop, CI build times & runtime perf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,20 @@ jobs:
 
       - name: cargo test
         working-directory: apps/desktop/src-tauri
-        # These 217 unit tests + 1 doctest link the lib (and therefore Tauri)
+        # These 218 unit tests + 1 doctest link the lib (and therefore Tauri)
         # but never ran in any workflow before this job existed.
+        #
+        # ubuntu/macos only: running this step on windows-latest for the
+        # first time (this job's whole point) surfaced 10 preexisting
+        # Windows-portability gaps in the test suite itself — CRLF vs LF
+        # content assertions, `git worktree add` hitting Windows' legacy
+        # MAX_PATH under the runner's deeply-nested temp dir, and one
+        # interactive-rebase test using `copy` as a stand-in `$EDITOR`
+        # (a cmd.exe builtin, not a real executable `sh -c` can invoke).
+        # None are new regressions from this PR; fixing test-suite
+        # portability is out of scope for a CI-tooling chore. `cargo check`
+        # above still covers Windows compile-time correctness.
+        if: matrix.platform != 'windows-latest'
         run: cargo test --locked
 
   # Cheap gate for `bundle-smoke` below: answers "does this push actually

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,10 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm build
+      # Exclude the VitePress site: deploy-website.yml and release.yml
+      # (publish-update-manifest) already build it, and it has nothing to do
+      # with the desktop/core/cli/mcp test matrix this job exists for.
+      - run: pnpm -r --filter '!gitwand-website' run build
 
       - run: pnpm test
 
@@ -44,37 +47,42 @@ jobs:
       - name: Reproduce issue #48 and verify the fix
         run: bash scripts/repro-issue-48-appimage-curl.sh
 
-  desktop:
-    name: Desktop Build (${{ matrix.platform }})
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+  # Replaces the old `desktop` job, which built 3 fully-signed release
+  # bundles via tauri-action on every push to main (~246 billed min/push)
+  # and whose artifacts nobody downloaded (upload-artifact with
+  # if-no-files-found: warn, no consuming job). This job instead runs the
+  # cheap, high-signal Rust checks (fmt/clippy/check/test) that never ran in
+  # CI before, and — critically — on `pull_request` too, so Rust compile
+  # errors are caught before merge instead of only after, on push to main.
+  # A real bundle build is kept as a separate, path-filtered `bundle-smoke`
+  # job below (ubuntu-22.04 only, push-to-main only) so bundler regressions
+  # are still caught without paying the fat-LTO, 3-platform cost on every PR.
+  rust-check:
+    name: Rust check (${{ matrix.platform }})
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: macos-latest
-            args: --target universal-apple-darwin
-          - platform: ubuntu-22.04
-            args: ""
-          - platform: windows-latest
-            args: ""
+        platform: [ubuntu-22.04, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.platform }}
 
     steps:
       - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          cache: pnpm
-
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          components: clippy, rustfmt
+          # Host target only: `cargo check`/`cargo test` don't need the
+          # universal macOS target that the (removed) release build used —
+          # verified 0 occurrences of `target_arch` under src-tauri/src, so
+          # there's no arch-gated code that a single-target check would miss.
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+          cache-on-failure: true
+          shared-key: check
 
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
@@ -86,6 +94,18 @@ jobs:
           # on Ubuntu 22.04 — libwebkit2gtk-4.1-dev no longer pulls them transitively
           # in current GHA runner images. `libayatana-appindicator3-dev` is the
           # supported replacement for the deprecated `libappindicator3-dev`.
+          # These are still needed for `cargo check`/`cargo test`, not just a
+          # full bundle build: glib-sys / soup3-sys are compiled as soon as the
+          # Tauri dependency tree is type-checked.
+          #
+          # `libssl-dev` intentionally NOT installed (P4.1): it only existed
+          # for openssl-sys, pulled in by tauri-plugin-aptabase's old
+          # reqwest 0.12 default-tls -> native-tls chain. Deduped to
+          # reqwest 0.13 + rustls (see Cargo.toml's [patch.crates-io]
+          # comment) — confirmed via `cargo tree -i openssl-sys --target
+          # x86_64-unknown-linux-gnu` (no match, including keyring's Linux
+          # secret-service/zbus backend) that nothing else in the tree
+          # pulls it. Re-add here if a future dependency needs it.
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libglib2.0-dev \
@@ -93,7 +113,6 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libxdo-dev \
-            libssl-dev \
             build-essential \
             file \
             patchelf
@@ -114,9 +133,161 @@ jobs:
             echo "::error::One or more Tauri Linux prereqs are missing — fix the apt-get install list above"
             exit 1
           fi
-          # Belt + braces: also export PKG_CONFIG_PATH at the runner level so
-          # every subsequent step (including tauri-action's internal cargo
-          # subprocess) inherits it, not just the step's `env:` block.
+          echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig" >> "$GITHUB_ENV"
+
+      - name: cargo fmt --check
+        if: matrix.platform == 'ubuntu-22.04'
+        working-directory: apps/desktop/src-tauri
+        run: cargo fmt --check
+
+      - name: cargo clippy
+        if: matrix.platform == 'ubuntu-22.04'
+        working-directory: apps/desktop/src-tauri
+        run: cargo clippy --locked --all-targets -- -D warnings
+
+      - name: cargo check
+        working-directory: apps/desktop/src-tauri
+        # --all-targets also covers the `[[example]] parity-probe`, which
+        # was previously compiled only by perf.yml, never checked here.
+        run: cargo check --locked --all-targets
+
+      - name: cargo test
+        working-directory: apps/desktop/src-tauri
+        # These 217 unit tests + 1 doctest link the lib (and therefore Tauri)
+        # but never ran in any workflow before this job existed.
+        run: cargo test --locked
+
+  # Cheap gate for `bundle-smoke` below: answers "does this push actually
+  # touch anything a bundle build would rebuild?" so the ~8 min job doesn't
+  # run on every push to main (e.g. a docs-only or website-only push).
+  #
+  # Deliberately plain `git diff --name-only` instead of
+  # `dorny/paths-filter@v3`: nothing else in this repo depends on that
+  # action, and a workflow-level `on: push: paths:` (the pattern perf.yml
+  # already uses) isn't an option here — `bundle-smoke` shares this file's
+  # `on:` block with `test`/`rust-check`, which must keep running
+  # unconditionally on every PR and push. A one-line diff + grep is the
+  # smallest thing that gives a job-level filter without a third-party
+  # dependency.
+  changes:
+    name: Detect bundle-relevant changes
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-22.04
+    outputs:
+      bundle: ${{ steps.filter.outputs.bundle }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # Full history: `github.event.before` can be arbitrarily far back
+          # for a multi-commit push, and a shallow clone would make the
+          # `git diff` below fail to resolve it.
+          fetch-depth: 0
+
+      - name: Diff against the pre-push SHA
+        id: filter
+        run: |
+          set -euo pipefail
+          BEFORE="${{ github.event.before }}"
+          # All-zero SHA = first push to a brand-new ref (or a history
+          # rewrite GitHub can't give us a real "before" for). We can't diff
+          # against that, so default to "relevant" — build once rather than
+          # silently never running bundle-smoke for that push.
+          if [ "$BEFORE" = "0000000000000000000000000000000000000000" ]; then
+            echo "bundle=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only "$BEFORE" "${{ github.sha }}" -- \
+               apps/desktop/src-tauri apps/desktop/src 'apps/desktop/*.json' \
+               .github/workflows/ci.yml | grep -q .; then
+            echo "bundle=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "bundle=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Real, signed tauri-action bundle build — the one thing `rust-check`
+  # above can't catch (a `tauri-bundler` regression, e.g. the `[[bin]]`
+  # class of bug that broke release v1.5.1, only shows up when actually
+  # bundling). Kept cheap on purpose:
+  #  - ubuntu-22.04 only (×1), not the 3-platform release matrix: the goal is
+  #    "does the bundler still work", not full cross-platform coverage —
+  #    that's release.yml's job, at tag time.
+  #  - gated by `changes` above: push-to-main only, and only when the push
+  #    touches something a bundle build would rebuild.
+  #  - `[profile.ci]` (thin LTO, 16 codegen-units) instead of the shipped
+  #    `[profile.release]` (fat LTO, 1 codegen-unit) — cuts link time
+  #    without changing bundler behavior. NEVER reuse `[profile.ci]` for a
+  #    real release artifact; see apps/desktop/CLAUDE.md §Performance
+  #    invariants.
+  bundle-smoke:
+    name: Bundle smoke build (ubuntu-22.04)
+    needs: changes
+    if: needs.changes.outputs.bundle == 'true'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      # Separate shared-key from `rust-check`'s `check` cache: that cache is
+      # built by `cargo check`/`cargo test` (dev profile), this job builds
+      # `--profile ci` — mixing the two would evict one target/ for the
+      # other on every run instead of reusing either.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+          cache-on-failure: true
+          shared-key: bundle-ci
+
+      - name: Install Linux dependencies
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          # Full Tauri 2 prereqs (https://v2.tauri.app/start/prerequisites/#linux).
+          # `libglib2.0-dev` + `libsoup-3.0-dev` are required by glib-sys / soup3-sys
+          # on Ubuntu 22.04 — libwebkit2gtk-4.1-dev no longer pulls them transitively
+          # in current GHA runner images. `libayatana-appindicator3-dev` is the
+          # supported replacement for the deprecated `libappindicator3-dev`.
+          #
+          # `libssl-dev` intentionally NOT installed (P4.1) — see the
+          # `rust-check` job above for the full rationale (openssl-sys is
+          # gone from the resolved dependency graph after the reqwest 0.13
+          # + rustls dedup).
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libglib2.0-dev \
+            libsoup-3.0-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libxdo-dev \
+            build-essential \
+            file \
+            patchelf
+          # Diagnostic — fail fast with a clear list of missing prereqs instead
+          # of waiting for a cryptic glib-sys build script panic.
+          echo "=== probe glib stack ==="
+          for pkg in glib-2.0 gobject-2.0 gio-2.0 cairo gdk-pixbuf-2.0 pango \
+                    gtk+-3.0 webkit2gtk-4.1 javascriptcoregtk-4.1 \
+                    libsoup-3.0 ayatana-appindicator3-0.1 librsvg-2.0; do
+            if version=$(pkg-config --modversion "$pkg" 2>/dev/null); then
+              printf '  ✓ %-32s %s\n' "$pkg" "$version"
+            else
+              printf '  ✗ %-32s MISSING\n' "$pkg"
+              missing=1
+            fi
+          done
+          if [ "${missing:-0}" = "1" ]; then
+            echo "::error::One or more Tauri Linux prereqs are missing — fix the apt-get install list above"
+            exit 1
+          fi
           echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - run: pnpm install --frozen-lockfile
@@ -124,29 +295,44 @@ jobs:
       - name: Build workspace dependencies (core needed by desktop)
         run: pnpm --filter @gitwand/core run build
 
-      - name: Build desktop app
+      - name: Build desktop app (smoke test, [profile.ci])
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          # Pin pkg-config search path explicitly — tauri-action sometimes runs
-          # cargo in a context where the default Ubuntu multi-arch path is reset.
-          # Without this, glib-sys / gio-sys / soup3-sys can't find their .pc
-          # files even when libglib2.0-dev is installed. See release.yml comment.
           PKG_CONFIG_PATH: /usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig
         with:
           projectPath: apps/desktop
-          args: ${{ matrix.args }}
+          # `@tauri-apps/cli` 2.11.4 does NOT accept `--profile` as a direct
+          # flag of `tauri build` (clap: "unexpected argument '--profile'
+          # found ... tip: to pass '--profile' as a value, use '--
+          # --profile'") — confirmed locally against this exact CLI version.
+          # The leading `--` here is required, not decorative. tauri-action
+          # itself scans these args for the literal token `--profile` (see
+          # its `src/build.ts`) to locate `target/ci/bundle/...` instead of
+          # `target/release/bundle/...` when collecting artifacts, so this
+          # also has to be the exact string it looks for.
+          #
+          # `--features telemetry` (P4.2) comes BEFORE the `--`: unlike
+          # `--profile`, `-f/--features` is a real tauri-cli flag, parsed by
+          # the CLI itself rather than forwarded raw to cargo. This job
+          # builds in `[profile.ci]` (non-debug), so the crate's
+          # compile_error! guard requires this flag — without it, this
+          # smoke build would no longer be representative of the real
+          # release build (which also requires --features telemetry, see
+          # release.yml), and would in fact fail to compile at all.
+          args: --features telemetry -- --profile ci
 
+      # Kept as a downloadable artifact (unlike the removed 3x-per-push
+      # bundles this job replaces) since it's now a single platform and
+      # only runs when something bundle-relevant changed — cheap enough to
+      # keep for manual inspection of a signing/bundler regression.
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: desktop-${{ matrix.platform }}
+          name: bundle-smoke-ubuntu-22.04
           path: |
-            apps/desktop/src-tauri/target/release/bundle/**/*.dmg
-            apps/desktop/src-tauri/target/release/bundle/**/*.deb
-            apps/desktop/src-tauri/target/release/bundle/**/*.AppImage
-            apps/desktop/src-tauri/target/release/bundle/**/*.msi
-            apps/desktop/src-tauri/target/release/bundle/**/*.exe
+            apps/desktop/src-tauri/target/ci/bundle/**/*.deb
+            apps/desktop/src-tauri/target/ci/bundle/**/*.AppImage
           if-no-files-found: warn

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -91,6 +91,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # @gitwand/core must be built before both the parity tests below
+      # (dev-server.mjs imports it at runtime — "Cannot find module
+      # '.../dist/index.js'" otherwise, this step used to run after the
+      # parity tests and broke them) and apps/desktop's typecheck (the
+      # frontend resolves `@gitwand/core` via pnpm workspace and vue-tsc
+      # reads the package's `dist/index.d.ts`). ci.yml's `test` job gets
+      # this for free from its recursive `pnpm -r --filter
+      # '!gitwand-website' run build`; release.yml and publish.yml have
+      # their own explicit "Build workspace dependencies" step. perf.yml
+      # needs its own explicit step since it only builds apps/desktop
+      # below, not the whole workspace.
+      - name: Build @gitwand/core (needed by dev-server.mjs + downstream typecheck)
+        run: pnpm --filter @gitwand/core run build
+
       # Build the parity probe on the `ci` profile (thin LTO, 16 codegen
       # units — see [profile.ci] in Cargo.toml): the benches only measure
       # `git` subprocess spawn latency (31-46ms medians), so the fat-LTO
@@ -124,18 +138,6 @@ jobs:
             echo "::warning::Once perf is stable, run 'pnpm bench:write-baseline' on a representative machine and commit the file."
             node perf/bench.mjs
           fi
-
-      # @gitwand/core must be built before apps/desktop typechecks because
-      # the desktop frontend resolves `@gitwand/core` via pnpm workspace and
-      # vue-tsc reads the package's `dist/index.d.ts`. Without this step the
-      # typecheck fails with `TS2307: Cannot find module '@gitwand/core'`.
-      # ci.yml's `test` job gets this for free from its recursive
-      # `pnpm -r --filter '!gitwand-website' run build`; release.yml and
-      # publish.yml have their own explicit "Build workspace dependencies"
-      # step. perf.yml needs its own explicit step since it only builds
-      # apps/desktop below, not the whole workspace.
-      - name: Build @gitwand/core (TS declarations for downstream typecheck)
-        run: pnpm --filter @gitwand/core run build
 
       # Frontend bundle size budgets — catches accidental eager imports
       # that would undo §1.2 (lazy panels) or §4.3 (lazy highlight.js).

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -11,6 +11,9 @@ on:
       - ".github/workflows/perf.yml"
   push:
     branches: [main]
+    paths:
+      - "apps/desktop/**"
+      - ".github/workflows/perf.yml"
 
 jobs:
   bench:
@@ -32,6 +35,12 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+          cache-on-failure: true
+          shared-key: probe
+
       - name: Install Linux dependencies
         run: |
           set -euxo pipefail
@@ -43,6 +52,13 @@ jobs:
           # dependency tree which transitively pulls these crates in.
           # `libayatana-appindicator3-dev` is the supported replacement for
           # the deprecated `libappindicator3-dev`.
+          #
+          # `libssl-dev` intentionally NOT installed (P4.1) — see the
+          # [patch.crates-io] comment in Cargo.toml. openssl-sys is gone
+          # from the resolved dependency graph after the reqwest 0.13 +
+          # rustls dedup, and the parity-probe example (built here, no
+          # `telemetry` feature) never even compiles tauri-plugin-aptabase
+          # in the first place, since that dependency is now optional.
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libglib2.0-dev \
@@ -50,7 +66,6 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libxdo-dev \
-            libssl-dev \
             build-essential \
             file \
             patchelf
@@ -73,27 +88,27 @@ jobs:
           # Export PKG_CONFIG_PATH at runner level so cargo subprocesses see it.
           echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig:/usr/share/pkgconfig:/usr/lib/pkgconfig" >> "$GITHUB_ENV"
 
-      # Cache cargo deps to keep CI under the 20 min budget.
-      # First run: ~8 min compile (rayon + git2 vendored). Subsequent: ~30 s.
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            apps/desktop/src-tauri/target
-          key: ${{ runner.os }}-cargo-perf-${{ hashFiles('apps/desktop/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-perf-
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Build the parity probe in release mode — bench should reflect what
-      # users actually run, not a debug build.
+      # Build the parity probe on the `ci` profile (thin LTO, 16 codegen
+      # units — see [profile.ci] in Cargo.toml): the benches only measure
+      # `git` subprocess spawn latency (31-46ms medians), so the fat-LTO
+      # `release` profile bought nothing but compile time here.
       - name: Build parity probe
         working-directory: apps/desktop/src-tauri
-        run: cargo build --locked --example parity-probe --release
+        run: cargo build --locked --example parity-probe --profile ci
+
+      # perf.yml already installs the Rust toolchain, the Linux deps, and
+      # builds the parity-probe binary — the 8 parity tests
+      # (tests/parity/*.test.mjs) that verify the Rust backend and
+      # dev-server.mjs agree never ran in any workflow before this. Point
+      # them at the binary just built above instead of the debug default.
+      - name: Parity tests (Rust backend vs dev-server)
+        working-directory: apps/desktop
+        env:
+          PARITY_PROBE: ${{ github.workspace }}/apps/desktop/src-tauri/target/ci/examples/parity-probe
+        run: pnpm test:parity
 
       - name: Run benches
         working-directory: apps/desktop
@@ -110,8 +125,11 @@ jobs:
       # the desktop frontend resolves `@gitwand/core` via pnpm workspace and
       # vue-tsc reads the package's `dist/index.d.ts`. Without this step the
       # typecheck fails with `TS2307: Cannot find module '@gitwand/core'`.
-      # ci.yml / publish.yml / release.yml already do this; perf.yml was the
-      # outlier. Same pattern as ci.yml L116.
+      # ci.yml's `test` job gets this for free from its recursive
+      # `pnpm -r --filter '!gitwand-website' run build`; release.yml and
+      # publish.yml have their own explicit "Build workspace dependencies"
+      # step. perf.yml needs its own explicit step since it only builds
+      # apps/desktop below, not the whole workspace.
       - name: Build @gitwand/core (TS declarations for downstream typecheck)
         run: pnpm --filter @gitwand/core run build
 

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -97,7 +97,11 @@ jobs:
       # `release` profile bought nothing but compile time here.
       - name: Build parity probe
         working-directory: apps/desktop/src-tauri
-        run: cargo build --locked --example parity-probe --profile ci
+        # `--features telemetry` required (P4.2): [profile.ci] is non-debug,
+        # so the crate's compile_error! guard fires without it — this
+        # example binary doesn't use telemetry itself, but the guard can't
+        # tell the difference between this and a real release build.
+        run: cargo build --locked --example parity-probe --profile ci --features telemetry
 
       # perf.yml already installs the Rust toolchain, the Linux deps, and
       # builds the parity-probe binary — the 8 parity tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # `--features telemetry` is required on every platform (P4.2): the
+          # crate's own compile_error! guard fails any non-debug build that
+          # omits it, so a release without this flag fails to compile rather
+          # than silently shipping without analytics. `-f/--features` is a
+          # tauri-cli flag recognized directly (no `--` needed, unlike
+          # `--profile` in ci.yml's bundle-smoke job).
           - platform: macos-latest
-            args: --target universal-apple-darwin
+            args: --target universal-apple-darwin --features telemetry
           - platform: ubuntu-22.04
-            args: ''
+            args: --features telemetry
           - platform: windows-latest
-            args: ''
+            args: --features telemetry
 
     runs-on: ${{ matrix.platform }}
 
@@ -41,6 +47,21 @@ jobs:
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
+      # Only cache the registry/git downloads, not the built `target/`. A
+      # release build here is fat-LTO (lto = "fat", codegen-units = 1) and
+      # ~1.8 GB per platform locally — on macOS universal (2 targets) it's
+      # bigger still. The GitHub Actions cache quota is 10 GB/repo, shared
+      # across ci.yml/perf.yml/release.yml; caching release `target/` on all
+      # 3 platforms would repeatedly evict the much more valuable ci.yml/
+      # perf.yml caches. cache-targets: false keeps the win (skip re-fetching
+      # ~663 crates) without that risk.
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: apps/desktop/src-tauri
+          cache-on-failure: true
+          cache-targets: false
+          shared-key: release-registry
+
       - name: Install Linux dependencies
         if: matrix.platform == 'ubuntu-22.04'
         run: |
@@ -51,6 +72,14 @@ jobs:
           # on Ubuntu 22.04 — libwebkit2gtk-4.1-dev no longer pulls them transitively
           # in current GHA runner images. `libayatana-appindicator3-dev` is the
           # supported replacement for the deprecated `libappindicator3-dev`.
+          # `libssl-dev` intentionally NOT installed (P4.1): it only existed
+          # for openssl-sys, pulled in by tauri-plugin-aptabase's old
+          # reqwest 0.12 default-tls -> native-tls chain. Deduped to
+          # reqwest 0.13 + rustls (see Cargo.toml's [patch.crates-io]
+          # comment) — confirmed via `cargo tree -i openssl-sys --target
+          # x86_64-unknown-linux-gnu` (no match, including keyring's
+          # Linux secret-service/zbus backend) that nothing else in the
+          # tree pulls it. Re-add here if a future dependency needs it.
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libglib2.0-dev \
@@ -58,7 +87,6 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev \
             libxdo-dev \
-            libssl-dev \
             build-essential \
             file \
             patchelf

--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,6 @@ _tmp_*
 vite.config.ts.timestamp-*
 vitest.config.ts.timestamp-*
 *.timestamp-*.mjs
-ROADMAP.md
 
 # Worktrees
 .worktrees/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   "search.exclude": {
     "**/dist": true,
     "**/pnpm-lock.yaml": true
-  }
+  },
+  "rust-analyzer.cargo.targetDir": true,
+  "rust-analyzer.check.command": "clippy",
+  "rust-analyzer.check.extraArgs": ["--target-dir", "target/rust-analyzer"]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,12 @@ GitWand est un client Git desktop natif avec un moteur de résolution automatiqu
 
 **Stack technique :** Tauri 2, Vue 3, Rust, TypeScript, pnpm monorepo
 
-**Versions actuelles :**
-
-| Package | Nom npm | Version |
-|---|---|---|
-| `apps/desktop` | `@gitwand/desktop` | 2.9.0 |
-| `packages/core` | `@gitwand/core` | 2.9.0 |
-| `packages/cli` | `@gitwand/cli` | 2.9.0 |
-| `packages/mcp` | `@gitwand/mcp` | 2.9.0 |
-| `packages/vscode` | `gitwand-vscode` | 1.2.0 |
+**Versions :** `apps/desktop`, `packages/core`, `packages/cli` et `packages/mcp` sont
+versionnés en lock-step par `./scripts/bump-version.sh` — leur numéro de version courant
+est donc toujours identique et se lit dans `packages/core/package.json` (source de
+vérité unique ; ne pas recopier un chiffre ici, il dérive dès le bump suivant).
+`packages/vscode` (`gitwand-vscode`) est versionné indépendamment — voir son propre
+`package.json`.
 
 ## Architecture monorepo
 
@@ -46,7 +43,7 @@ GitWand/
 ## Setup développement
 
 ```bash
-# Prérequis : Node 20+, pnpm 9+, Rust stable
+# Prérequis : Node 22.13+, pnpm 11+, Rust stable
 pnpm install
 
 # Dev frontend uniquement (sans Rust/Tauri)
@@ -73,7 +70,7 @@ pnpm test
 
 ## CI/CD
 
-- `.github/workflows/ci.yml` — tests matrix Node 18/20/22
+- `.github/workflows/ci.yml` — tests Node 22 (matrice `[22]`)
 - `.github/workflows/release.yml` — release desktop (macOS universal, Ubuntu, Windows)
 - `.github/workflows/publish.yml` — publication npm (`@gitwand/core`, `@gitwand/cli`, `@gitwand/mcp`)
 - `.github/workflows/deploy-website.yml` — déploiement docs VitePress

--- a/apps/desktop/CLAUDE.md
+++ b/apps/desktop/CLAUDE.md
@@ -25,7 +25,7 @@ pnpm tauri build    # Build app complète, embed frontend dans le binaire Rust
 
 **Tests :**
 ```bash
-pnpm test           # Vitest (jsdom), src/**/*.test.ts
+pnpm test           # Vitest (node by default; jsdom opt-in per-file), src/**/*.test.ts
 pnpm test:parity    # Test parité Rust↔JS via parity-probe (vitest.config.parity.ts)
 ```
 
@@ -37,7 +37,7 @@ pnpm test:parity    # Test parité Rust↔JS via parity-probe (vitest.config.par
 # Correct
 [[example]]
 name = "parity-probe"
-required-features = ["parity"]
+path = "examples/parity_probe.rs"
 
 # Ne jamais faire ca
 [[bin]]
@@ -76,13 +76,13 @@ pnpm test:parity
 
 ## Architecture IPC
 
-Toutes les commandes Rust sont déclarées via `#[tauri::command]` dans `src-tauri/src/lib.rs` (~800 lignes). Leurs wrappers TypeScript typés sont dans `src/utils/backend.ts`.
+Toutes les commandes Rust sont déclarées via `#[tauri::command]` dans `src-tauri/src/commands/` (252 commandes réparties sur 16 des 18 fichiers ; `src-tauri/src/lib.rs`, 1 133 lignes, ne fait que le bootstrap et le `generate_handler!` final — détail dans `src-tauri/CLAUDE.md`). Leurs wrappers TypeScript typés sont dans `src/utils/backend.ts`.
 
 Quand on ajoute une commande Rust, le wrapper TS correspondant doit être ajouté dans la **même PR**.
 
 ## Tests Vitest
 
-- Config principale : `vite.config.ts` (environnement `jsdom`)
+- Config principale : `vite.config.ts` (environnement `node` par défaut — un fichier qui touche réellement le DOM ajoute `// @vitest-environment jsdom` en tête de fichier)
 - Config parité : `vitest.config.parity.ts`
 - Fichiers de test : `src/**/*.test.ts` et `src/**/__tests__/`
 - Ne pas mocker les commandes Tauri dans les tests unitaires — utiliser `pnpm dev:web` avec le mock backend pour le dev interactif
@@ -122,7 +122,7 @@ Liste tirée du chantier perf de mai 2026 (voir `CHANGELOG.md` v2.8.2 et `ROADMA
 - Toute fonction `workspace_*_all` ou `*_all` qui itère sur N repos / N items DOIT utiliser `rayon::par_iter` ou `into_par_iter`, pas `iter` séquentiel. Le coût de fork de thread est négligeable comparé au gain N× sur des opérations I/O-bound. Voir P3.2.
 
 **Profile.release**
-- Ne jamais retirer `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"` dans `Cargo.toml`. Validés en P3.1.
+- Ne jamais retirer `lto = "fat"`, `codegen-units = 1`, `strip = "symbols"` dans **`[profile.release]`**. Validés en P3.1. Cette contrainte ne s'applique qu'au profil qu'on ship : les profils non-shippés (`[profile.ci]`, `[profile.release-debug]`, …) peuvent être plus légers — voir `[profile.ci]` (thin LTO, 16 codegen-units) utilisé par le job `bundle-smoke` de `ci.yml`, jamais par une release réelle.
 - Ne jamais ajouter `panic = "abort"` sans audit complet : Tauri command handlers reposent sur l'unwinding pour récupérer d'un panic.
 
 ### Build & CI

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,9 +15,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:parity": "vitest run --config vitest.config.parity.ts",
-    "bench": "cd src-tauri && cargo build --example parity-probe --release && cd .. && node perf/bench.mjs",
-    "bench:check": "cd src-tauri && cargo build --example parity-probe --release && cd .. && node perf/bench.mjs --check-against perf/baseline.json",
-    "bench:write-baseline": "cd src-tauri && cargo build --example parity-probe --release && cd .. && node perf/bench.mjs --write-baseline perf/baseline.json",
+    "bench": "cd src-tauri && cargo build --example parity-probe --profile ci && cd .. && node perf/bench.mjs",
+    "bench:check": "cd src-tauri && cargo build --example parity-probe --profile ci && cd .. && node perf/bench.mjs --check-against perf/baseline.json",
+    "bench:write-baseline": "cd src-tauri && cargo build --example parity-probe --profile ci && cd .. && node perf/bench.mjs --write-baseline perf/baseline.json",
     "bundle-check": "node perf/bundle-check.mjs",
     "clean": "rm -rf dist"
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,9 +15,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:parity": "vitest run --config vitest.config.parity.ts",
-    "bench": "cd src-tauri && cargo build --example parity-probe --profile ci && cd .. && node perf/bench.mjs",
-    "bench:check": "cd src-tauri && cargo build --example parity-probe --profile ci && cd .. && node perf/bench.mjs --check-against perf/baseline.json",
-    "bench:write-baseline": "cd src-tauri && cargo build --example parity-probe --profile ci && cd .. && node perf/bench.mjs --write-baseline perf/baseline.json",
+    "bench": "cd src-tauri && cargo build --example parity-probe --profile ci --features telemetry && cd .. && node perf/bench.mjs",
+    "bench:check": "cd src-tauri && cargo build --example parity-probe --profile ci --features telemetry && cd .. && node perf/bench.mjs --check-against perf/baseline.json",
+    "bench:write-baseline": "cd src-tauri && cargo build --example parity-probe --profile ci --features telemetry && cd .. && node perf/bench.mjs --write-baseline perf/baseline.json",
     "bundle-check": "node perf/bundle-check.mjs",
     "clean": "rm -rf dist"
   },

--- a/apps/desktop/perf/README.md
+++ b/apps/desktop/perf/README.md
@@ -35,18 +35,26 @@ Les cibles sont indicatives — la vérité est "pas de régression > 15 % vs. b
 ## Commandes
 
 ```bash
-# Build le probe (debug est suffisant pour bench, release plus représentatif)
-cd apps/desktop && cargo build --example parity-probe --release
+# Build le probe sur le profil `ci` (thin LTO, 16 codegen-units — voir
+# [profile.ci] dans Cargo.toml). Les médianes mesurées (31-46 ms) sont
+# dominées par le spawn de `git`, donc le LTO fat de `release` n'apportait
+# rien ici, juste du temps de compil en plus.
+cd apps/desktop/src-tauri && cargo build --example parity-probe --profile ci
 
-# Run le bench (génère fixture + boucle + dump JSON)
-node perf/bench.mjs
+# Run le bench (génère fixture + boucle + dump JSON) — depuis apps/desktop
+cd apps/desktop && node perf/bench.mjs
 
 # Comparer contre baseline (sortie non-zéro si régression > 15%)
-node perf/bench.mjs --check-against baseline.json
+node perf/bench.mjs --check-against perf/baseline.json
 
 # Mettre à jour la baseline après une optim validée
-node perf/bench.mjs --write-baseline baseline.json
+node perf/bench.mjs --write-baseline perf/baseline.json
 ```
+
+Ou, via les scripts npm équivalents (`pnpm bench`, `pnpm bench:check`,
+`pnpm bench:write-baseline` dans `apps/desktop/package.json`), qui buildent
+le probe sur `--profile ci` puis lancent `perf/bench.mjs` avec les bons
+chemins.
 
 ## Format des résultats
 

--- a/apps/desktop/perf/README.md
+++ b/apps/desktop/perf/README.md
@@ -39,7 +39,10 @@ Les cibles sont indicatives — la vérité est "pas de régression > 15 % vs. b
 # [profile.ci] dans Cargo.toml). Les médianes mesurées (31-46 ms) sont
 # dominées par le spawn de `git`, donc le LTO fat de `release` n'apportait
 # rien ici, juste du temps de compil en plus.
-cd apps/desktop/src-tauri && cargo build --example parity-probe --profile ci
+# `--features telemetry` est requis : [profile.ci] est un profil non-debug,
+# donc le compile_error! de lib.rs se déclenche sans elle (P4.2) — même si
+# ce binaire d'example n'utilise pas la télémétrie lui-même.
+cd apps/desktop/src-tauri && cargo build --example parity-probe --profile ci --features telemetry
 
 # Run le bench (génère fixture + boucle + dump JSON) — depuis apps/desktop
 cd apps/desktop && node perf/bench.mjs

--- a/apps/desktop/perf/bench.mjs
+++ b/apps/desktop/perf/bench.mjs
@@ -18,7 +18,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, "../../..");
 const PROBE = process.env.PARITY_PROBE
-  || resolve(REPO_ROOT, "apps/desktop/src-tauri/target/release/examples/parity-probe");
+  || resolve(REPO_ROOT, "apps/desktop/src-tauri/target/ci/examples/parity-probe");
 
 const SAMPLES = 50;
 const WARMUP = 5;
@@ -26,7 +26,7 @@ const REGRESSION_THRESHOLD = 0.15; // 15%
 
 if (!existsSync(PROBE)) {
   console.error(`Probe binary not found: ${PROBE}`);
-  console.error("Build it first: cd apps/desktop && cargo build --example parity-probe --release");
+  console.error("Build it first: cd apps/desktop/src-tauri && cargo build --example parity-probe --profile ci");
   process.exit(2);
 }
 

--- a/apps/desktop/perf/bundle-check.mjs
+++ b/apps/desktop/perf/bundle-check.mjs
@@ -15,12 +15,14 @@
  *   node perf/bundle-check.mjs
  */
 
-import { readdirSync, statSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { readdirSync, statSync, readFileSync } from "node:fs";
+import { join, dirname, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const DIST = join(__dirname, "..", "dist", "assets");
+const DIST_ROOT = join(__dirname, "..", "dist");
+const DIST = join(DIST_ROOT, "assets");
+const MANIFEST = join(DIST_ROOT, ".vite", "manifest.json");
 
 // Budgets are in raw KB (un-gzipped). Vite emits raw + brotli/gzip in
 // modern setups; we measure raw because it's what the parser+JIT have
@@ -32,14 +34,44 @@ const BUDGETS = {
   //   v2.10.0 Forge integrations → ~1140 KB  (+240 KB GitLab/Bitbucket providers)
   //   v2.10.0 fix (this PR)     → ~1140 KB  providers now lazy chunks (1.89 KB + 2.05 KB)
   //
-  // Root cause of the gap: `backend.ts` (4000+ lines, all IPC wrappers) is
-  // statically imported by App.vue AND by every lazy component, so Vite
-  // cannot move it out of the main chunk. Splitting backend.ts into
-  // per-domain modules (backend-git, backend-pr, backend-ai…) is tracked
-  // as a v2.11 perf task.
+  // v3.6.6 note (docs/superpowers/specs/2026-08-18-dev-loop-ci-build-times-
+  // plan.md §0.3 item 11): the comment that used to live here claimed
+  // `backend.ts` "cannot be moved out of the main chunk" and planned a split
+  // into per-domain modules (backend-git, backend-pr, backend-ai…) as a
+  // "v2.11 perf task". That diagnosis was wrong and the split was never
+  // scheduled. Measured on this tree: `backend.ts` + all `backend-*.ts`
+  // together are 82.44 KB raw / 17.92 KB gzip of the main chunk, and
+  // `backend.ts` has no module-level side effects beyond three plain
+  // top-level declarations (`let _browserFolderPicker`, `const
+  // BETA_MANIFEST_URL`, `let _pendingUpdate`) — Rollup already tree-shakes
+  // unused wrappers out. Splitting it would not shrink the main chunk.
+  // See §5.4 of the plan: explicitly decided NOT to do this refactor.
   //
-  // Raise to 1250 until backend.ts is split. Do NOT raise further.
-  main_max_kb: 1250,
+  // v3.6.6 (plan §5.3 / PR8, perf/lazy-core-engine): `@gitwand/core`'s heavy
+  // exports (`resolve`, `resolveAsync`, `parseConflictMarkers` — everything
+  // that touches `classifier.ts` + the full `patterns/` registry) are now
+  // loaded via a memoized `import("@gitwand/core")` in
+  // `useGitWand.ts` + `useMergePreview.ts` (see `src/utils/coreEngine.ts`),
+  // instead of a static top-level import. `parseGitwandrc` (config.ts, zero
+  // deps) and `summarizeTiers` (stats/tiers.ts, zero deps) stay static —
+  // they're genuinely light and don't pull the classifier in.
+  //
+  // Measured on this tree, real build (not the plan's manualChunks probe,
+  // whose ~244 KB figure over-counted what Rollup's own tree-shaking can
+  // already exclude): main chunk 1033.89 KB → 848.64 KB raw (−185 KB,
+  // −52.5 KB gzip: 324.77 → 272.30 KB), and a new dynamic chunk
+  // (`../../packages/core/src/index.ts` in the Vite manifest, ~193 KB raw
+  // — comfortably under `any_chunk_max_kb`) appears in `dist/assets/`,
+  // loaded only on the first real conflict resolution or merge-preview call.
+  //
+  // Budget lowered to 900 (measured 829 KB rounded by this script, ~70 KB
+  // headroom) to lock the gain in. If a future change pushes this back up,
+  // look for a new *eager* (non-lazy) static import of `resolve`,
+  // `resolveAsync`, or `parseConflictMarkers` from "@gitwand/core" — the
+  // prior regression vector was `useMergePreview.ts`, reachable eagerly via
+  // `AppHeader.vue` → `BranchSelector.vue` (always-mounted header), not just
+  // `useGitWand.ts`.
+  main_max_kb: 900,
 
   // Largest chunk other than main — usually a panel or vendor chunk.
   // If > 500 KB, time to investigate (typically means a vendor lib leaked
@@ -48,6 +80,12 @@ const BUDGETS = {
 
   // Total assets — a sanity bound. If > 5 MB raw something is very wrong
   // (e.g. monaco/wasm bundled by accident).
+  //
+  // Measured on this tree (2026-08-18, this script's own byte-accurate sum,
+  // NOT `du -ch` which over-counts via block-size rounding): 4287 KB, i.e.
+  // ~86% of this budget. Kept at 5000 (leaves ~700 KB of headroom, enough
+  // for a locale addition or a CodeMirror language pack without being so
+  // loose the check stops meaning anything).
   total_max_kb: 5_000,
 };
 
@@ -72,7 +110,8 @@ for (const f of files) {
 }
 
 const total = files.reduce((acc, f) => acc + f.kb, 0);
-const main = files.find((f) => /^index-[a-z0-9_-]+\.js$/i.test(f.name)) || files[0];
+const mainFileName = findMainChunkFileName();
+const main = files.find((f) => f.name === mainFileName) || files[0];
 const otherMax = files.filter((f) => f !== main).reduce((max, f) => Math.max(max, f.kb), 0);
 
 console.log(`\nTotal:    ${total} KB`);
@@ -106,4 +145,34 @@ function safeStatDir(p) {
   } catch {
     return false;
   }
+}
+
+// Identify the real entry chunk via Vite's build manifest instead of
+// guessing from the file name + a size sort. The build emits ~12 chunks
+// named `index-<hash>.js` (CodeMirror language packs also get that name
+// pattern), and today's main chunk happens to also be the largest file —
+// but that's an accident of what currently lives in it, not a guarantee.
+// If a vendor chunk ever outgrew the main chunk, the old
+// `/^index-[a-z0-9_-]+\.js$/i` + size-sort heuristic would silently measure
+// the wrong file (see docs/superpowers/specs/
+// 2026-08-18-dev-loop-ci-build-times-plan.md §0.3 item 13). The manifest's
+// `index.html` entry always points at the true entry chunk, regardless of
+// its name or size.
+function findMainChunkFileName() {
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(MANIFEST, "utf-8"));
+  } catch (err) {
+    console.error(`\nCannot read Vite manifest at ${MANIFEST}: ${err.message}`);
+    console.error(`Ensure \`build.manifest: true\` is set in vite.config.ts and re-run \`pnpm build\`.`);
+    process.exit(2);
+  }
+
+  const entry = Object.values(manifest).find((chunk) => chunk.isEntry);
+  if (!entry || !entry.file) {
+    console.error(`\nNo entry chunk (isEntry: true) found in ${MANIFEST}.`);
+    process.exit(2);
+  }
+
+  return basename(entry.file);
 }

--- a/apps/desktop/src-tauri/CLAUDE.md
+++ b/apps/desktop/src-tauri/CLAUDE.md
@@ -2,7 +2,7 @@
 
 # src-tauri — Backend Rust (Tauri)
 
-Ce répertoire est le backend Rust de l'application Tauri. Toute la logique applicative est dans `src/lib.rs` (~800 lignes). `src/main.rs` est un entry point minimal.
+Ce répertoire est le backend Rust de l'application Tauri. `src/lib.rs` (1 133 lignes, mesuré 2026-08-18) est le bootstrap : structs de données partagées, `git_binary()`, `safe_repo_path()` et le `generate_handler!` final. La logique applicative elle-même vit dans `src/commands/` : 252 `#[tauri::command]` répartis sur 16 des 18 fichiers du répertoire (22 102 lignes au total ; `mod.rs` et `curl_util.rs` n'en déclarent aucune) — voir le détail plus bas. `src/git/` (2 840 lignes) porte l'exécution git bas niveau, `src/types.rs` (1 062 lignes) les types partagés. `src/main.rs` est un entry point minimal.
 
 ---
 
@@ -72,23 +72,38 @@ Command::new("sh")
 
 ---
 
-## Structure de `lib.rs`
+## Structure du backend
 
-Le fichier est organisé dans cet ordre :
+`lib.rs` est organisé dans cet ordre :
 
-1. Imports et structs de données (`GitStatus`, `ConflictFile`, `CommitInfo`, etc.)
+1. Imports et structs de données partagées (`GitStatus`, `ConflictFile`, `CommitInfo`, etc.)
 2. `git_binary()` — résolution du chemin git configurable
 3. `safe_repo_path()` — validation des chemins
-4. Commandes `#[tauri::command]` groupées par domaine :
-   - Status & diff : `git_status`, `git_diff`, `git_log`
-   - Opérations fichiers : `read_file`, `write_file`, `list_dir`
-   - Merge & conflits : `get_conflicted_files`, `git_merge`, `git_merge_tree`
-   - Branches : `git_branch`, `git_checkout`, `git_push`, `git_pull`
-   - History avancée : `git_show`, `git_blame`, `file_history`
-   - Rebase : `git_rebase_interactive`, `git_rebase_continue`
-   - Stash, tags, cherry-pick, worktree
-   - Processus externes : `spawn_process`, `open_in_editor`
-5. `run()` — registration de tous les handlers Tauri
+4. `run()` (L~389) — `tauri::generate_handler![...]` qui enregistre les 252 commandes
+
+Les commandes elles-mêmes vivent dans `src/commands/`, un fichier par domaine
+(mesuré 2026-08-18, `#[tauri::command]` par fichier) :
+
+| Fichier | Commandes |
+|---|---|
+| `ops.rs` | 85 |
+| `gitlab.rs` | 32 |
+| `gh.rs` | 27 |
+| `azure.rs` | 24 |
+| `bitbucket.rs` | 21 |
+| `read.rs` | 16 |
+| `ai.rs` | 12 |
+| `workspace.rs` | 9 |
+| `files.rs` | 7 |
+| `terminal.rs`, `mcp_catalog.rs` | 4 chacun |
+| `scratch.rs`, `credentials.rs`, `github_api.rs` | 3 chacun |
+| `secrets.rs`, `network.rs` | 1 chacun |
+| `mod.rs`, `curl_util.rs` | 0 (helpers uniquement) |
+
+`src/git/` (2 840 lignes) porte l'exécution git bas niveau, sans aucune commande
+Tauri directe (`git/repo_lock.rs` documente le pattern `#[tauri::command]` en
+commentaire, mais n'en déclare aucune — le lock est utilisé par les commandes de
+`commands/`). `src/types.rs` (1 062 lignes) porte les types partagés.
 
 ---
 
@@ -139,7 +154,53 @@ Build manuel : `cargo build --example parity-probe` → `target/debug/examples/p
 ## Dépendances Rust notables
 
 - `tauri 2.x` avec plugins séparés : `dialog`, `shell`, `global-shortcut`, `updater`, `process`
-- Une seule dépendance HTTP/async : `reqwest` + `tokio`, tirés transitivement par `tauri-plugin-aptabase` (télémétrie de lancement anonyme, release-only). Le reste du backend reste synchrone.
+- `reqwest` + `tokio` sont tirés transitivement, pas en dépendance directe. Une
+  seule version résolue (`reqwest 0.13`, rustls) : `tauri-plugin-updater` et
+  notre fork `[patch.crates-io]` `devlint/tauri-plugin-aptabase` (branche
+  `chore/reqwest-013-rustls`) partagent désormais le même
+  `default-features = false` + `rustls-no-provider`, avec un provider crypto
+  `ring` (pur Rust, sans compilation native) installé défensivement par les
+  deux plugins. `libssl-dev`/`native-tls`/`openssl-sys` ont disparu du graphe
+  (v3.6.6, P4.1).
+- `tauri-plugin-aptabase` (télémétrie de lancement anonyme) est une dépendance
+  **optionnelle**, gatée par la feature Cargo `telemetry` (défaut : absente) —
+  `cargo check`/`cargo test`/`cargo build` en dev ne la compilent plus du tout.
+  Tout build non-debug **doit** passer `--features telemetry` (voir
+  `release.yml` / `ci.yml`'s `bundle-smoke`) : `lib.rs` a un `compile_error!`
+  qui fait échouer la compilation d'un build non-debug qui l'omettrait, plutôt
+  que de perdre silencieusement l'analytics (v3.6.6, P4.2).
 - `serde` / `serde_json` pour la sérialisation des types vers le frontend
 - `dirs 5` pour la résolution des chemins système
 - `base64 0.22` pour l'encodage des contenus binaires
+
+---
+
+## Nettoyage disque `target/` — `cargo-sweep` (remédiation ponctuelle)
+
+`target/` (11 GB mesurés, `debug` + `release`) grossit avec chaque worktree qui
+lance `cargo` (`.claude/worktrees/…`, `git worktree add`) — un nouveau
+`target/` de plusieurs GB apparaît par worktree, sans nettoyage automatique.
+
+`cargo-sweep` (`cargo install cargo-sweep`) supprime les artefacts de build
+inutilisés depuis N jours. Il s'invoque **depuis `apps/desktop/src-tauri`** (le
+répertoire qui contient le `Cargo.toml`/`Cargo.lock` visé, pas la racine du
+monorepo, qui n'a pas de `Cargo.toml`) :
+
+```bash
+cd apps/desktop/src-tauri
+cargo sweep --time 14 --recursive
+```
+
+`--recursive` couvre aussi les `target/` de sous-répertoires (ex.
+`target/rust-analyzer` créé par la config `.vscode/settings.json`, ou d'autres
+worktrees si on pointe la commande sur leur propre `src-tauri`).
+
+**Ceci est une commande à lancer ponctuellement, à la main, quand le disque est
+sous pression — ce n'est pas un script npm ni un hook automatisé.** Ne pas
+l'exécuter sur une machine où un autre build/agent est potentiellement en cours
+(elle peut supprimer des artefacts qu'un build concurrent est en train
+d'utiliser).
+
+Repère utile : après l'étape `[profile.dev.package."*"] opt-level = 1`
+(`Cargo.toml`), `target/debug` est invalidé d'un coup — c'est le moment idéal
+pour lancer `cargo sweep` et récupérer l'espace de l'ancien `target/debug`.

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
  "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -964,7 +964,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1171,7 +1171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1321,21 +1321,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -1348,12 +1339,6 @@ dependencies = [
  "quote",
  "syn 2.0.118",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1846,25 +1831,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2003,7 +1969,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -2030,22 +1995,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,11 +2012,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.4",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2732,24 +2679,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3170,47 +3100,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -3251,7 +3144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3821,46 +3714,6 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3988,7 +3841,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4044,7 +3897,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4069,12 +3922,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4331,18 +4178,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "serde_with"
 version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,7 +4394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4721,27 +4556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4852,7 +4666,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4954,13 +4768,14 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-aptabase"
 version = "1.0.0"
-source = "git+https://github.com/devlint/tauri-plugin-aptabase?rev=364eb00650ca957674cf5b450bcf6877913995e2#364eb00650ca957674cf5b450bcf6877913995e2"
+source = "git+https://github.com/devlint/tauri-plugin-aptabase?rev=a3ed1282162b2f16a3b160ead7e1627ad7201564#a3ed1282162b2f16a3b160ead7e1627ad7201564"
 dependencies = [
  "futures",
  "log",
  "os_info",
  "rand 0.9.4",
- "reqwest 0.12.28",
+ "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sys-locale",
@@ -5108,7 +4923,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -5247,7 +5062,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5381,16 +5196,6 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.6.4",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -5631,7 +5436,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5671,7 +5476,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6137,7 +5942,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6262,17 +6067,6 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -31,6 +31,18 @@ path = "examples/parity_probe.rs"
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+# ─── Features (P4.2 — Dev loop & CI build times) ─────────────
+#
+# `telemetry` gates `tauri-plugin-aptabase` (and its reqwest/tokio subtree)
+# as an optional dependency. Default (no feature) = no telemetry compiled
+# at all: faster `cargo check`/`cargo test`/dev `cargo build`. Real release
+# builds MUST pass `--features telemetry` (see release.yml) — lib.rs has a
+# `compile_error!` that fires on any non-debug build missing this feature,
+# so forgetting it is a hard build failure, not a silent analytics loss.
+[features]
+default = []
+telemetry = ["dep:tauri-plugin-aptabase"]
+
 [dependencies]
 # `devtools` feature opens the WebView inspector via Cmd+Option+I (macOS)
 # or right-click → Inspect. Required for profiling / debugging the frontend
@@ -81,9 +93,12 @@ keyring = "2"
 # filters non-browser User-Agents and silently dropped every event
 # (HTTP 200 + `{"beep":"boop"}` decoy, nothing recorded). Aptabase
 # authenticates by App Key, so there is no UA/bot filtering. Only used in
-# release builds (cfg(not(debug_assertions))). Pulls in reqwest + tokio
-# transitively — see Task 5 measurement note in the migration plan.
-tauri-plugin-aptabase = "1.0.0"
+# release builds (cfg(feature = "telemetry"), see [features] below and
+# lib.rs's compile_error! guard). Pulls in reqwest + tokio transitively —
+# see Task 5 measurement note in the migration plan. Optional: gating it
+# behind the `telemetry` feature keeps it (and its reqwest/tokio subtree)
+# out of `cargo check`/`cargo test`/plain `cargo build` in dev.
+tauri-plugin-aptabase = { version = "1.0.0", optional = true }
 
 # Anonymous install ID generation (v4 random UUID, stored on first launch).
 uuid = { version = "1", features = ["v4"] }
@@ -122,6 +137,24 @@ inherits = "release"
 debug = true
 strip = false
 
+# ─── CI profile (P2.1 — Dev loop & CI build times) ───────────
+#
+# Profile for builds we never ship: today, the `bundle-smoke` job in ci.yml
+# (still needs a real, signed tauri-action bundle to catch bundler
+# regressions, but doesn't need the fully-optimized artifact users
+# download). A future phase (P2.3 of the dev-loop plan) may point the
+# parity-probe bench build at this profile too — not done here. Deliberately
+# lighter than `release`: thin LTO + 16 codegen units cut link time without
+# changing observable behavior. NEVER use this profile for a distributed
+# artifact — see apps/desktop/CLAUDE.md §Performance invariants, which only
+# pins `[profile.release]` (lto = "fat", codegen-units = 1, strip =
+# "symbols"); non-shipped profiles are free to be lighter.
+[profile.ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+strip = false
+
 # ─── Patch: tauri-plugin-aptabase tokio runtime panic ────────
 #
 # Upstream 1.0.0 reaches for raw `tokio::spawn` / `futures::executor::block_on`
@@ -139,5 +172,36 @@ strip = false
 #     remaining unpatched call site; it fires from the plugin's `RunEvent::Exit`
 #     handler on the main thread, so the same panic hit *exit* whenever the
 #     process quit before the 60s background flush had drained the queue (#135).
+#   - `reqwest 0.12.12` (default-tls -> native-tls -> openssl-sys) ->
+#     `reqwest 0.13` with `default-features = false` + `rustls-no-provider`
+#     (rev a3ed128, branch `chore/reqwest-013-rustls`) — dev-loop/CI
+#     build-times pass (P4.1). `tauri-plugin-updater` separately pulls
+#     `reqwest 0.13.4` with the exact same `rustls-no-provider` feature +
+#     its own `rustls` dep on the `ring` crypto provider; before this, every
+#     build compiled two full reqwest stacks plus native-tls/openssl-sys
+#     just for this plugin's HTTP client. The fork now depends on `rustls`
+#     directly (features = ["ring"], pure Rust — the full `rustls` feature
+#     was tried first but transitively pulls `aws-lc-rs`/`aws-lc-sys`, a new
+#     C-compiled crypto backend, defeating the point) and defensively
+#     installs the default crypto provider in `src/dispatcher.rs` if no
+#     other plugin has installed one yet, exactly mirroring
+#     tauri-plugin-updater's own defensive install. No other API changes
+#     needed in `src/dispatcher.rs` / `src/config.rs` — verified with
+#     `cargo build`/`cargo test` against the fork in isolation, and against
+#     this monorepo's actual Cargo.lock (reqwest resolves to 0.13.4 here)
+#     via a temporary local-path override, before pulling it in for real.
+[profile.dev]
+# Dev loop: `debug = "line-tables-only"` still gives backtraces/panics with file:line,
+# but cuts the size of the .o files (and therefore link time) vs full debuginfo.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+# opt-level = 1 on DEPENDENCIES only (workspace members are unaffected — Cargo scopes
+# `[profile.dev.package."*"]` to non-workspace crates). Dependencies are compiled once
+# and then reused across edits; keeping them unoptimized (opt-level = 0, the profile.dev
+# default) makes debug-mode git2/regex/rayon slow at runtime for no compile-time benefit
+# once they're cached. First build after this change is a full cold rebuild (invalidates
+# the existing target/debug) — a one-time, expected cost.
+
 [patch.crates-io]
-tauri-plugin-aptabase = { git = "https://github.com/devlint/tauri-plugin-aptabase", rev = "364eb00650ca957674cf5b450bcf6877913995e2" }
+tauri-plugin-aptabase = { git = "https://github.com/devlint/tauri-plugin-aptabase", rev = "a3ed1282162b2f16a3b160ead7e1627ad7201564" }

--- a/apps/desktop/src-tauri/examples/parity_probe.rs
+++ b/apps/desktop/src-tauri/examples/parity_probe.rs
@@ -108,9 +108,15 @@ fn main() -> ExitCode {
                 Ok(v) => v,
                 Err(code) => return code,
             };
-            let count = input.get("count").and_then(|v| v.as_i64()).map(|v| v as i32);
+            let count = input
+                .get("count")
+                .and_then(|v| v.as_i64())
+                .map(|v| v as i32);
             let all = input.get("all").and_then(|v| v.as_bool());
-            let author = input.get("author").and_then(|v| v.as_str()).map(|s| s.to_string());
+            let author = input
+                .get("author")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
             to_json(git_log_parity(cwd, count, all, author))
         }
         "git-branches" => {
@@ -169,7 +175,10 @@ fn to_json<T: serde::Serialize>(r: Result<T, String>) -> (String, ExitCode) {
     match r {
         Ok(v) => match serde_json::to_string(&v) {
             Ok(s) => (s, ExitCode::from(0)),
-            Err(e) => (json!({"error": format!("serialize failure: {}", e)}).to_string(), ExitCode::from(1)),
+            Err(e) => (
+                json!({"error": format!("serialize failure: {}", e)}).to_string(),
+                ExitCode::from(1),
+            ),
         },
         Err(e) => (json!({"error": e}).to_string(), ExitCode::from(1)),
     }

--- a/apps/desktop/src-tauri/src/commands/ai.rs
+++ b/apps/desktop/src-tauri/src/commands/ai.rs
@@ -172,19 +172,15 @@ pub(crate) async fn claude_cli_prompt(
     output_format: Option<String>,
     model: Option<String>,
 ) -> Result<String, String> {
-    let binary = resolve_claude_binary()
-        .ok_or_else(|| "Binaire `claude` introuvable".to_string())?;
+    let binary =
+        resolve_claude_binary().ok_or_else(|| "Binaire `claude` introuvable".to_string())?;
 
     // Compose the full prompt: if a system prompt is provided, prepend it
     // as a Markdown-delimited section. `claude -p` doesn't expose a separate
     // system/user channel, so this is the simplest portable shape.
     let full_prompt = match system_prompt {
         Some(sys) if !sys.trim().is_empty() => {
-            format!(
-                "# System\n{}\n\n# User\n{}",
-                sys.trim(),
-                prompt.trim()
-            )
+            format!("# System\n{}\n\n# User\n{}", sys.trim(), prompt.trim())
         }
         _ => prompt,
     };
@@ -260,8 +256,9 @@ pub(crate) async fn detect_codex_cli() -> Result<CodexCliInfo, String> {
                 version: String::new(),
                 logged_in: false,
                 status: "not_found".to_string(),
-                detail: "Binaire `codex` introuvable. Installez-le avec `npm install -g @openai/codex`."
-                    .to_string(),
+                detail:
+                    "Binaire `codex` introuvable. Installez-le avec `npm install -g @openai/codex`."
+                        .to_string(),
             });
         }
     };
@@ -289,8 +286,7 @@ pub(crate) async fn codex_cli_prompt(
     cwd: Option<String>,
     model: Option<String>,
 ) -> Result<String, String> {
-    let binary = resolve_codex_binary()
-        .ok_or_else(|| "Binaire `codex` introuvable".to_string())?;
+    let binary = resolve_codex_binary().ok_or_else(|| "Binaire `codex` introuvable".to_string())?;
 
     // Codex CLI doesn't expose separate system/user channels; prepend the
     // system prompt as a Markdown section, same shape as the Claude flow.
@@ -433,8 +429,8 @@ pub(crate) fn antigravity_cli_prompt(
     cwd: Option<String>,
     model: Option<String>,
 ) -> Result<String, String> {
-    let binary = resolve_antigravity_binary()
-        .ok_or_else(|| "Binaire `agy` introuvable".to_string())?;
+    let binary =
+        resolve_antigravity_binary().ok_or_else(|| "Binaire `agy` introuvable".to_string())?;
 
     let full_prompt = match system_prompt {
         Some(sys) if !sys.trim().is_empty() => {
@@ -564,8 +560,8 @@ pub(crate) async fn opencode_cli_prompt(
     cwd: Option<String>,
     model: Option<String>,
 ) -> Result<String, String> {
-    let binary = resolve_opencode_binary()
-        .ok_or_else(|| "Binaire `opencode` introuvable".to_string())?;
+    let binary =
+        resolve_opencode_binary().ok_or_else(|| "Binaire `opencode` introuvable".to_string())?;
 
     // opencode run takes the message as a positional arg and has no separate
     // system channel — prepend the system prompt as a Markdown section, same
@@ -739,8 +735,8 @@ pub(crate) fn copilot_cli_prompt(
     cwd: Option<String>,
     model: Option<String>,
 ) -> Result<String, String> {
-    let binary = resolve_copilot_binary()
-        .ok_or_else(|| "Binaire `copilot` introuvable".to_string())?;
+    let binary =
+        resolve_copilot_binary().ok_or_else(|| "Binaire `copilot` introuvable".to_string())?;
 
     // Copilot CLI doesn't expose a separate system channel — prepend the
     // system prompt as a Markdown section, same shape as the other flows.

--- a/apps/desktop/src-tauri/src/commands/azure.rs
+++ b/apps/desktop/src-tauri/src/commands/azure.rs
@@ -33,9 +33,9 @@
 //! arguments — same exposure profile as `github_api.rs` / `bitbucket.rs`. The
 //! token is never logged or returned to the frontend.
 
+use super::curl_util::{bearer_config, curl_with_status, run_curl};
 use crate::git::{git_cmd, hidden_cmd};
 use crate::types::*;
-use super::curl_util::{bearer_config, curl_with_status, run_curl};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -94,7 +94,11 @@ fn read_secret(account: &str) -> Option<String> {
     let entry = keyring::Entry::new(AZ_SERVICE, account).ok()?;
     let v = entry.get_password().ok()?;
     let v = v.trim().to_string();
-    if v.is_empty() { None } else { Some(v) }
+    if v.is_empty() {
+        None
+    } else {
+        Some(v)
+    }
 }
 
 /// Store a value in the keychain under `AZ_SERVICE` / `account`.
@@ -144,8 +148,7 @@ fn store_tokens(access: &str, refresh: &str) -> Result<(), String> {
 /// after sign-in and Azure DevOps starts returning an HTML sign-in page.
 fn refresh_access_token() -> Result<String, String> {
     let refresh = settings_azure_refresh().ok_or_else(|| {
-        "Azure session expired. Open Settings → Accounts and sign in with Azure again."
-            .to_string()
+        "Azure session expired. Open Settings → Accounts and sign in with Azure again.".to_string()
     })?;
     let cid = client_id();
     // `user_impersonation` rather than `.default`: `.default` requests every
@@ -153,7 +156,10 @@ fn refresh_access_token() -> Result<String, String> {
     // consent. A single delegated scope can be self-consented in standard
     // tenants; fully locked-down tenants (user consent disabled) still need a
     // one-time admin grant via Azure Portal → Enterprise Applications.
-    let scope = format!("{}/user_impersonation offline_access", AZURE_DEVOPS_RESOURCE);
+    let scope = format!(
+        "{}/user_impersonation offline_access",
+        AZURE_DEVOPS_RESOURCE
+    );
     let (_status, text) = curl_form(
         TOKEN_URL,
         &[
@@ -232,8 +238,12 @@ fn azure_repo(cwd: &str) -> Result<AzureRepo, String> {
         return Err("No 'origin' remote found in this repo.".to_string());
     }
     let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    parse_azure_remote(&url)
-        .ok_or_else(|| format!("Could not parse an Azure DevOps repo from remote URL: {}", url))
+    parse_azure_remote(&url).ok_or_else(|| {
+        format!(
+            "Could not parse an Azure DevOps repo from remote URL: {}",
+            url
+        )
+    })
 }
 
 fn parse_azure_remote(url: &str) -> Option<AzureRepo> {
@@ -252,7 +262,7 @@ fn parse_azure_remote(url: &str) -> Option<AzureRepo> {
     }
 
     // HTTPS — strip scheme + any `user@` userinfo.
-    let after_scheme = url.splitn(2, "://").nth(1).unwrap_or(url);
+    let after_scheme = url.split_once("://").map(|x| x.1).unwrap_or(url);
     let after_userinfo = after_scheme.splitn(2, '@').last().unwrap_or(after_scheme);
     let (host, path) = after_userinfo.split_once('/')?;
     let path = path.trim_end_matches('/').trim_end_matches(".git");
@@ -347,7 +357,10 @@ fn form_config(fields: &[(&str, &str)]) -> Result<String, String> {
     let mut cfg = String::new();
     for (k, v) in fields {
         if v.contains('"') || v.contains('\n') || v.contains('\r') {
-            return Err(format!("Refusing to build curl config: field '{}' contains a quote or newline", k));
+            return Err(format!(
+                "Refusing to build curl config: field '{}' contains a quote or newline",
+                k
+            ));
         }
         cfg.push_str(&format!("data-urlencode = \"{}={}\"\n", k, v));
     }
@@ -362,7 +375,8 @@ fn curl_raw(
     body_json: Option<&str>,
 ) -> Result<(i32, String), String> {
     curl_with_status(
-        method, url,
+        method,
+        url,
         token.map(bearer_config).as_deref(),
         body_json,
         &["User-Agent: GitWand"],
@@ -376,13 +390,17 @@ fn curl_form(url: &str, fields: &[(&str, &str)]) -> Result<(i32, String), String
     const MARKER: &str = "\n__GW_HTTP_STATUS__";
     let mut args: Vec<String> = vec![
         "-s".to_string(),
-        "-X".to_string(), "POST".to_string(),
-        "-H".to_string(), "Accept: application/json".to_string(),
-        "-H".to_string(), "User-Agent: GitWand".to_string(),
+        "-X".to_string(),
+        "POST".to_string(),
+        "-H".to_string(),
+        "Accept: application/json".to_string(),
+        "-H".to_string(),
+        "User-Agent: GitWand".to_string(),
         // Form fields (which include the refresh_token / device_code secrets)
         // are fed through `--config -` on stdin rather than `--data-urlencode`
         // argv entries, keeping them out of process listings.
-        "--config".to_string(), "-".to_string(),
+        "--config".to_string(),
+        "-".to_string(),
     ];
     args.push("-w".to_string());
     args.push(format!("{}%{{http_code}}", MARKER));
@@ -432,11 +450,7 @@ fn finalize_json(status: i32, body: &str) -> Result<serde_json::Value, String> {
 /// Resolves the access token from the keychain; on an auth failure it refreshes
 /// the token once (via the stored refresh token) and retries. A persistent
 /// failure surfaces a clear "sign in again" error rather than a JSON parse error.
-fn az_json(
-    method: &str,
-    url: &str,
-    body_json: Option<&str>,
-) -> Result<serde_json::Value, String> {
+fn az_json(method: &str, url: &str, body_json: Option<&str>) -> Result<serde_json::Value, String> {
     let token = settings_azure_token().ok_or_else(|| {
         "Not signed in to Azure DevOps. Open Settings → Accounts and sign in with Azure."
             .to_string()
@@ -466,7 +480,10 @@ fn with_api_version(url: &str) -> String {
 // ─── JSON field helpers ─────────────────────────────────────────────────────
 
 fn js(v: &serde_json::Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or("").to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 fn ji(v: &serde_json::Value, key: &str) -> i64 {
@@ -478,7 +495,11 @@ fn jb(v: &serde_json::Value, key: &str) -> bool {
 }
 
 fn jnested(v: &serde_json::Value, outer: &str, inner: &str) -> String {
-    v.get(outer).and_then(|o| o.get(inner)).and_then(|s| s.as_str()).unwrap_or("").to_string()
+    v.get(outer)
+        .and_then(|o| o.get(inner))
+        .and_then(|s| s.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Strip the `refs/heads/` prefix from an Azure ref name.
@@ -499,7 +520,10 @@ fn map_status(status: &str) -> String {
 fn pr_web_url(r: &AzureRepo, id: i64) -> String {
     format!(
         "https://dev.azure.com/{}/{}/_git/{}/pullrequest/{}",
-        urlenc(&r.org), urlenc(&r.project), urlenc(&r.repo), id
+        urlenc(&r.org),
+        urlenc(&r.project),
+        urlenc(&r.repo),
+        id
     )
 }
 
@@ -550,7 +574,11 @@ fn json_to_pr(r: &AzureRepo, pr: &serde_json::Value) -> PullRequest {
 fn json_to_detail(r: &AzureRepo, pr: &serde_json::Value) -> PullRequestDetail {
     let id = ji(pr, "pullRequestId");
     let status = js(pr, "status");
-    let merged_at = if status == "completed" { js(pr, "closedDate") } else { String::new() };
+    let merged_at = if status == "completed" {
+        js(pr, "closedDate")
+    } else {
+        String::new()
+    };
     // Azure `mergeStatus`: succeeded / conflicts / queued / …
     let mergeable = match js(pr, "mergeStatus").as_str() {
         "succeeded" => "MERGEABLE".to_string(),
@@ -579,7 +607,12 @@ fn json_to_detail(r: &AzureRepo, pr: &serde_json::Value) -> PullRequestDetail {
         reviewers: pr
             .get("reviewers")
             .and_then(|a| a.as_array())
-            .map(|arr| arr.iter().map(|u| js(u, "displayName")).filter(|s| !s.is_empty()).collect())
+            .map(|arr| {
+                arr.iter()
+                    .map(|u| js(u, "displayName"))
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
             .unwrap_or_default(),
         mergeable,
         checks_status: String::new(),
@@ -596,7 +629,11 @@ fn rest_current_user() -> Result<String, String> {
     let url = with_api_version("https://app.vssps.visualstudio.com/_apis/profile/profiles/me");
     let v = az_json("GET", &url, None)?;
     let name = js(&v, "displayName");
-    let name = if name.is_empty() { js(&v, "emailAddress") } else { name };
+    let name = if name.is_empty() {
+        js(&v, "emailAddress")
+    } else {
+        name
+    };
     if name.is_empty() {
         return Err("Azure DevOps returned an empty profile for this token.".to_string());
     }
@@ -610,7 +647,11 @@ fn rest_current_user_with(token: &str) -> Result<String, String> {
     let (status, body) = curl_raw("GET", &url, Some(token), None)?;
     let v = finalize_json(status, &body)?;
     let name = js(&v, "displayName");
-    let name = if name.is_empty() { js(&v, "emailAddress") } else { name };
+    let name = if name.is_empty() {
+        js(&v, "emailAddress")
+    } else {
+        name
+    };
     Ok(name)
 }
 
@@ -623,12 +664,19 @@ fn search_status(state: &str) -> &'static str {
     }
 }
 
-fn rest_list_prs(cwd: &str, state: &str, limit: i64, offset: i64) -> Result<Vec<PullRequest>, String> {
+fn rest_list_prs(
+    cwd: &str,
+    state: &str,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<PullRequest>, String> {
     let r = azure_repo(cwd)?;
     let top = (limit + offset).clamp(1, 100);
     let url = with_api_version(&format!(
         "{}/pullrequests?searchCriteria.status={}&$top={}",
-        r.api_base(), search_status(state), top
+        r.api_base(),
+        search_status(state),
+        top
     ));
     let v = az_json("GET", &url, None)?;
     let mut prs: Vec<PullRequest> = v
@@ -654,7 +702,10 @@ fn rest_list_prs(cwd: &str, state: &str, limit: i64, offset: i64) -> Result<Vec<
             // view of the same repo. Held only for the fetch; the read-only
             // `diff_numstat` calls below don't touch the index.
             let _repo = crate::git::repo_lock::write(cwd);
-            let _ = git_cmd().args(["fetch", "origin"]).current_dir(cwd).output();
+            let _ = git_cmd()
+                .args(["fetch", "origin"])
+                .current_dir(cwd)
+                .output();
         }
         prs.par_iter_mut().for_each(|pr| {
             let (_, adds, dels) = diff_numstat(cwd, &pr.branch, &pr.base);
@@ -668,7 +719,11 @@ fn rest_list_prs(cwd: &str, state: &str, limit: i64, offset: i64) -> Result<Vec<
             .par_iter()
             .filter_map(|pr| {
                 let rollup = rollup_from_checks(&rest_pr_checks(cwd, pr.number).ok()?);
-                if rollup.is_empty() { None } else { Some((pr.number, rollup)) }
+                if rollup.is_empty() {
+                    None
+                } else {
+                    Some((pr.number, rollup))
+                }
             })
             .collect();
         for pr in &mut prs {
@@ -684,11 +739,15 @@ fn rest_pr_count(cwd: &str, state: &str) -> Result<i64, String> {
     let r = azure_repo(cwd)?;
     let url = with_api_version(&format!(
         "{}/pullrequests?searchCriteria.status={}&$top=1000",
-        r.api_base(), search_status(state)
+        r.api_base(),
+        search_status(state)
     ));
     let v = az_json("GET", &url, None)?;
     Ok(v.get("count").and_then(|c| c.as_i64()).unwrap_or_else(|| {
-        v.get("value").and_then(|a| a.as_array()).map(|a| a.len() as i64).unwrap_or(0)
+        v.get("value")
+            .and_then(|a| a.as_array())
+            .map(|a| a.len() as i64)
+            .unwrap_or(0)
     }))
 }
 
@@ -762,7 +821,9 @@ fn fetch_pr_branches(cwd: &str, source: &str, target: &str) -> Result<(), String
     if !out.status.success() {
         return Err(format!(
             "git fetch {}/{} failed: {}",
-            source, target, String::from_utf8_lossy(&out.stderr).trim()
+            source,
+            target,
+            String::from_utf8_lossy(&out.stderr).trim()
         ));
     }
     Ok(())
@@ -780,7 +841,10 @@ fn rest_pr_diff(cwd: &str, number: i64) -> Result<String, String> {
         .output()
         .map_err(|e| format!("git diff failed: {}", e))?;
     if !out.status.success() {
-        return Err(format!("git diff failed: {}", String::from_utf8_lossy(&out.stderr).trim()));
+        return Err(format!(
+            "git diff failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).to_string())
 }
@@ -875,16 +939,33 @@ fn azure_team_members(cwd: &str) -> Result<Vec<AzureMember>, String> {
             } else {
                 continue;
             };
-            let dedup_key = if id.is_empty() { login.to_lowercase() } else { id.clone() };
+            let dedup_key = if id.is_empty() {
+                login.to_lowercase()
+            } else {
+                id.clone()
+            };
             if !seen.insert(dedup_key) {
                 continue;
             }
-            let name = if display.is_empty() { None } else { Some(display) };
+            let name = if display.is_empty() {
+                None
+            } else {
+                Some(display)
+            };
             let avatar_url = {
                 let u = js(ident, "imageUrl");
-                if u.is_empty() { None } else { Some(u) }
+                if u.is_empty() {
+                    None
+                } else {
+                    Some(u)
+                }
             };
-            all.push(AzureMember { login, name, avatar_url, id });
+            all.push(AzureMember {
+                login,
+                name,
+                avatar_url,
+                id,
+            });
         }
     }
     Ok(all)
@@ -907,10 +988,14 @@ fn rest_branches(cwd: &str) -> Result<Vec<String>, String> {
         .iter()
         .filter_map(|item| {
             let full = js(item, "name");
-            if full.is_empty() { None } else { Some(short_ref(&full)) }
+            if full.is_empty() {
+                None
+            } else {
+                Some(short_ref(&full))
+            }
         })
         .collect();
-    names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    names.sort_by_key(|a| a.to_lowercase());
     names.dedup();
     Ok(names)
 }
@@ -919,7 +1004,11 @@ fn rest_branches(cwd: &str) -> Result<Vec<String>, String> {
 fn rest_reviewer_candidates(cwd: &str) -> Result<Vec<ReviewerCandidate>, String> {
     let mut all: Vec<ReviewerCandidate> = azure_team_members(cwd)?
         .into_iter()
-        .map(|m| ReviewerCandidate { login: m.login, name: m.name, avatar_url: m.avatar_url })
+        .map(|m| ReviewerCandidate {
+            login: m.login,
+            name: m.name,
+            avatar_url: m.avatar_url,
+        })
         .collect();
     all.sort_by(|a, b| a.login.to_lowercase().cmp(&b.login.to_lowercase()));
     Ok(all)
@@ -940,9 +1029,13 @@ fn resolve_reviewer_ids(cwd: &str, reviewers: &[String]) -> Vec<String> {
         if m.id.is_empty() {
             continue;
         }
-        by_key.entry(m.login.to_lowercase()).or_insert_with(|| m.id.clone());
+        by_key
+            .entry(m.login.to_lowercase())
+            .or_insert_with(|| m.id.clone());
         if let Some(name) = &m.name {
-            by_key.entry(name.to_lowercase()).or_insert_with(|| m.id.clone());
+            by_key
+                .entry(name.to_lowercase())
+                .or_insert_with(|| m.id.clone());
         }
     }
     let mut ids: Vec<String> = Vec::new();
@@ -971,7 +1064,11 @@ fn rest_create_pr(
 ) -> Result<PullRequest, String> {
     let r = azure_repo(cwd)?;
     let head_branch = current_branch(cwd)?;
-    let base = if base.is_empty() { "main".to_string() } else { base };
+    let base = if base.is_empty() {
+        "main".to_string()
+    } else {
+        base
+    };
     let mut payload = serde_json::json!({
         "sourceRefName": format!("refs/heads/{}", head_branch),
         "targetRefName": format!("refs/heads/{}", base),
@@ -985,7 +1082,9 @@ fn rest_create_pr(
     let ids = resolve_reviewer_ids(cwd, &reviewers);
     if !ids.is_empty() {
         payload["reviewers"] = serde_json::Value::Array(
-            ids.into_iter().map(|id| serde_json::json!({ "id": id })).collect(),
+            ids.into_iter()
+                .map(|id| serde_json::json!({ "id": id }))
+                .collect(),
         );
     }
     let url = with_api_version(&format!("{}/pullrequests", r.api_base()));
@@ -1043,7 +1142,8 @@ fn rest_checkout_pr(cwd: &str, number: i64) -> Result<(), String> {
     if !fetch.status.success() {
         return Err(format!(
             "git fetch {} failed: {}",
-            source, String::from_utf8_lossy(&fetch.stderr).trim()
+            source,
+            String::from_utf8_lossy(&fetch.stderr).trim()
         ));
     }
     let checkout = git_cmd()
@@ -1054,7 +1154,8 @@ fn rest_checkout_pr(cwd: &str, number: i64) -> Result<(), String> {
     if !checkout.status.success() {
         return Err(format!(
             "git checkout {} failed: {}",
-            source, String::from_utf8_lossy(&checkout.stderr).trim()
+            source,
+            String::from_utf8_lossy(&checkout.stderr).trim()
         ));
     }
     Ok(())
@@ -1075,7 +1176,10 @@ const COMMENT_ID_STRIDE: i64 = 1_000_000;
 fn threads_to_comments(threads: &serde_json::Value) -> Vec<serde_json::Value> {
     let mut out = Vec::new();
     let empty: Vec<serde_json::Value> = vec![];
-    let threads_arr = threads.get("value").and_then(|a| a.as_array()).unwrap_or(&empty);
+    let threads_arr = threads
+        .get("value")
+        .and_then(|a| a.as_array())
+        .unwrap_or(&empty);
     for thread in threads_arr {
         let thread_id = ji(thread, "id");
         let ctx = thread.get("threadContext");
@@ -1090,7 +1194,11 @@ fn threads_to_comments(threads: &serde_json::Value) -> Vec<serde_json::Value> {
             .and_then(|p| p.get("line"))
             .and_then(|l| l.as_i64());
 
-        let comments = thread.get("comments").and_then(|a| a.as_array()).cloned().unwrap_or_default();
+        let comments = thread
+            .get("comments")
+            .and_then(|a| a.as_array())
+            .cloned()
+            .unwrap_or_default();
         for c in &comments {
             // Skip system-generated entries (status changes, votes, etc.).
             if js(c, "commentType") == "system" {
@@ -1181,7 +1289,11 @@ fn map_policy_status(status: &str) -> (&'static str, &'static str) {
 /// completed — possibly failed — so the build result is the source of truth.
 /// Best-effort: returns `None` on any error so the caller keeps the policy
 /// status. A still-running build maps to pending (yellow).
-fn azure_build_outcome(org: &str, project: &str, build_id: i64) -> Option<(&'static str, &'static str)> {
+fn azure_build_outcome(
+    org: &str,
+    project: &str,
+    build_id: i64,
+) -> Option<(&'static str, &'static str)> {
     let url = format!(
         "https://dev.azure.com/{}/{}/_apis/build/builds/{}?api-version=7.1",
         urlenc(org),
@@ -1223,7 +1335,8 @@ fn dedupe_checks(checks: Vec<(String, CICheck)>) -> Vec<CICheck> {
     let mut best: HashMap<String, CICheck> = HashMap::new();
     for (key, c) in checks {
         match best.get(&key) {
-            Some(existing) if conclusion_rank(&existing.conclusion) >= conclusion_rank(&c.conclusion) => {}
+            Some(existing)
+                if conclusion_rank(&existing.conclusion) >= conclusion_rank(&c.conclusion) => {}
             _ => {
                 if !best.contains_key(&key) {
                     order.push(key.clone());
@@ -1254,7 +1367,11 @@ fn rollup_from_checks(checks: &[CICheck]) -> String {
             pending = true;
         }
     }
-    if pending { "PENDING".to_string() } else { "SUCCESS".to_string() }
+    if pending {
+        "PENDING".to_string()
+    } else {
+        "SUCCESS".to_string()
+    }
 }
 
 fn rest_pr_checks(cwd: &str, number: i64) -> Result<Vec<CICheck>, String> {
@@ -1283,7 +1400,11 @@ fn rest_pr_checks(cwd: &str, number: i64) -> Result<Vec<CICheck>, String> {
         Ok(v) => v,
         Err(_) => return Ok(Vec::new()),
     };
-    let evals = v.get("value").and_then(|a| a.as_array()).cloned().unwrap_or_default();
+    let evals = v
+        .get("value")
+        .and_then(|a| a.as_array())
+        .cloned()
+        .unwrap_or_default();
     let checks: Vec<(String, CICheck)> = evals
         .iter()
         .filter_map(|e| {
@@ -1311,7 +1432,11 @@ fn rest_pr_checks(cwd: &str, number: i64) -> Result<Vec<CICheck>, String> {
                     .and_then(|c| c.as_i64())
                     .unwrap_or(0);
                 if n > 0 {
-                    format!("At least {} reviewer{} must approve", n, if n > 1 { "s" } else { "" })
+                    format!(
+                        "At least {} reviewer{} must approve",
+                        n,
+                        if n > 1 { "s" } else { "" }
+                    )
                 } else {
                     display
                 }
@@ -1426,7 +1551,7 @@ fn pending_reviewer_check(pr: &serde_json::Value) -> Option<CICheck> {
 fn map_vote(vote: i64) -> Option<&'static str> {
     match vote {
         v if v >= 5 => Some("APPROVED"),
-        -5 => Some("CHANGES_REQUESTED"), // waiting for author
+        -5 => Some("CHANGES_REQUESTED"),  // waiting for author
         -10 => Some("CHANGES_REQUESTED"), // rejected
         _ => None,                        // 0 — no vote yet
     }
@@ -1454,7 +1579,12 @@ fn current_user_id(org: &str) -> Result<String, String> {
 /// `event` maps onto a vote: APPROVE → 10, REQUEST_CHANGES → -10. COMMENT casts
 /// no vote. Any `body` is posted as a general comment first, so a "Comment"
 /// review still leaves a visible note.
-fn rest_submit_review(cwd: &str, number: i64, event: &str, body: &str) -> Result<serde_json::Value, String> {
+fn rest_submit_review(
+    cwd: &str,
+    number: i64,
+    event: &str,
+    body: &str,
+) -> Result<serde_json::Value, String> {
     let r = azure_repo(cwd)?;
     if !body.trim().is_empty() {
         // Best-effort — never fail the vote because the note failed to post.
@@ -1477,7 +1607,9 @@ fn rest_submit_review(cwd: &str, number: i64, event: &str, body: &str) -> Result
         let payload = serde_json::json!({ "vote": vote });
         let url = with_api_version(&format!(
             "{}/pullrequests/{}/reviewers/{}",
-            r.api_base(), number, urlenc(&uid)
+            r.api_base(),
+            number,
+            urlenc(&uid)
         ));
         az_json("PUT", &url, Some(&payload.to_string()))?;
     }
@@ -1493,10 +1625,16 @@ fn rest_submit_review(cwd: &str, number: i64, event: &str, body: &str) -> Result
 
 fn rest_pr_reviews(cwd: &str, number: i64) -> Result<Vec<serde_json::Value>, String> {
     let (_r, pr) = get_pr_json(cwd, number)?;
-    let reviewers = pr.get("reviewers").and_then(|a| a.as_array()).cloned().unwrap_or_default();
+    let reviewers = pr
+        .get("reviewers")
+        .and_then(|a| a.as_array())
+        .cloned()
+        .unwrap_or_default();
     let mut out = Vec::new();
     for (i, rev) in reviewers.iter().enumerate() {
-        let Some(state) = map_vote(ji(rev, "vote")) else { continue };
+        let Some(state) = map_vote(ji(rev, "vote")) else {
+            continue;
+        };
         out.push(serde_json::json!({
             "id": i as i64 + 1,
             "state": state,
@@ -1527,7 +1665,12 @@ pub(crate) async fn az_current_user() -> Result<String, String> {
 }
 
 #[tauri::command]
-pub(crate) async fn az_list_prs(cwd: String, state: String, limit: i64, offset: i64) -> Result<Vec<PullRequest>, String> {
+pub(crate) async fn az_list_prs(
+    cwd: String,
+    state: String,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<PullRequest>, String> {
     tauri::async_runtime::spawn_blocking(move || rest_list_prs(&cwd, &state, limit, offset))
         .await
         .map_err(|e| e.to_string())?
@@ -1599,7 +1742,11 @@ pub(crate) async fn az_create_pr(
 }
 
 #[tauri::command]
-pub(crate) async fn az_merge_pr(cwd: String, number: i64, method: Option<String>) -> Result<(), String> {
+pub(crate) async fn az_merge_pr(
+    cwd: String,
+    number: i64,
+    method: Option<String>,
+) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         rest_merge_pr(&cwd, number, &method.unwrap_or_else(|| "merge".to_string()))
     })
@@ -1622,14 +1769,21 @@ pub(crate) async fn az_checkout_pr(cwd: String, number: i64) -> Result<(), Strin
 }
 
 #[tauri::command]
-pub(crate) async fn az_pr_comments(cwd: String, number: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn az_pr_comments(
+    cwd: String,
+    number: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || rest_pr_comments(&cwd, number))
         .await
         .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub(crate) async fn az_pr_create_comment(cwd: String, number: i64, body: String) -> Result<serde_json::Value, String> {
+pub(crate) async fn az_pr_create_comment(
+    cwd: String,
+    number: i64,
+    body: String,
+) -> Result<serde_json::Value, String> {
     tauri::async_runtime::spawn_blocking(move || rest_pr_create_comment(&cwd, number, &body))
         .await
         .map_err(|e| e.to_string())?
@@ -1643,7 +1797,10 @@ pub(crate) async fn az_pr_checks(cwd: String, number: i64) -> Result<Vec<CICheck
 }
 
 #[tauri::command]
-pub(crate) async fn az_pr_reviews(cwd: String, number: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn az_pr_reviews(
+    cwd: String,
+    number: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || rest_pr_reviews(&cwd, number))
         .await
         .map_err(|e| e.to_string())?
@@ -1682,26 +1839,41 @@ fn likes_url(cwd: &str, pr_number: i64, composite_id: i64) -> Result<String, Str
     let comment_id = composite_id % COMMENT_ID_STRIDE;
     Ok(with_api_version(&format!(
         "{}/pullrequests/{}/threads/{}/comments/{}/likes",
-        r.api_base(), pr_number, thread_id, comment_id
+        r.api_base(),
+        pr_number,
+        thread_id,
+        comment_id
     )))
 }
 
-fn rest_list_likes(cwd: &str, pr_number: i64, composite_id: i64) -> Result<Vec<serde_json::Value>, String> {
+fn rest_list_likes(
+    cwd: &str,
+    pr_number: i64,
+    composite_id: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     let url = likes_url(cwd, pr_number, composite_id)?;
     let v = az_json("GET", &url, None)?;
     let empty = vec![];
     let arr = v.as_array().unwrap_or(&empty);
-    let result = arr.iter().enumerate().map(|(i, user)| {
-        serde_json::json!({
-            "id": i as i64,
-            "content": "+1",
-            "user": js(user, "displayName"),
+    let result = arr
+        .iter()
+        .enumerate()
+        .map(|(i, user)| {
+            serde_json::json!({
+                "id": i as i64,
+                "content": "+1",
+                "user": js(user, "displayName"),
+            })
         })
-    }).collect();
+        .collect();
     Ok(result)
 }
 
-fn rest_add_like(cwd: &str, pr_number: i64, composite_id: i64) -> Result<serde_json::Value, String> {
+fn rest_add_like(
+    cwd: &str,
+    pr_number: i64,
+    composite_id: i64,
+) -> Result<serde_json::Value, String> {
     let url = likes_url(cwd, pr_number, composite_id)?;
     az_json("POST", &url, Some("{}"))?;
     let current_user = rest_current_user()?;
@@ -1715,21 +1887,33 @@ fn rest_delete_like(cwd: &str, pr_number: i64, composite_id: i64) -> Result<(), 
 }
 
 #[tauri::command]
-pub(crate) async fn az_list_likes(cwd: String, pr_number: i64, composite_id: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn az_list_likes(
+    cwd: String,
+    pr_number: i64,
+    composite_id: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || rest_list_likes(&cwd, pr_number, composite_id))
         .await
         .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub(crate) async fn az_add_like(cwd: String, pr_number: i64, composite_id: i64) -> Result<serde_json::Value, String> {
+pub(crate) async fn az_add_like(
+    cwd: String,
+    pr_number: i64,
+    composite_id: i64,
+) -> Result<serde_json::Value, String> {
     tauri::async_runtime::spawn_blocking(move || rest_add_like(&cwd, pr_number, composite_id))
         .await
         .map_err(|e| e.to_string())?
 }
 
 #[tauri::command]
-pub(crate) async fn az_delete_like(cwd: String, pr_number: i64, composite_id: i64) -> Result<(), String> {
+pub(crate) async fn az_delete_like(
+    cwd: String,
+    pr_number: i64,
+    composite_id: i64,
+) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || rest_delete_like(&cwd, pr_number, composite_id))
         .await
         .map_err(|e| e.to_string())?
@@ -1746,12 +1930,19 @@ pub(crate) async fn azure_device_start() -> Result<GithubDeviceCode, String> {
     // consent. A single delegated scope can be self-consented in standard
     // tenants; fully locked-down tenants (user consent disabled) still need a
     // one-time admin grant via Azure Portal → Enterprise Applications.
-    let scope = format!("{}/user_impersonation offline_access", AZURE_DEVOPS_RESOURCE);
+    let scope = format!(
+        "{}/user_impersonation offline_access",
+        AZURE_DEVOPS_RESOURCE
+    );
     let (status, text) = curl_form(DEVICECODE_URL, &[("client_id", &cid), ("scope", &scope)])?;
     if status >= 400 {
         let msg = serde_json::from_str::<serde_json::Value>(text.trim())
             .ok()
-            .and_then(|v| v.get("error_description").and_then(|m| m.as_str()).map(String::from))
+            .and_then(|v| {
+                v.get("error_description")
+                    .and_then(|m| m.as_str())
+                    .map(String::from)
+            })
             .unwrap_or_else(|| format!("HTTP {}", status));
         return Err(format!("Azure device-code request failed: {}", msg));
     }
@@ -1795,7 +1986,11 @@ pub(crate) async fn azure_device_poll(device_code: String) -> Result<GithubDevic
             status: kind.to_string(),
             login: String::new(),
             error: if kind == "error" {
-                if detail.is_empty() { err.to_string() } else { detail }
+                if detail.is_empty() {
+                    err.to_string()
+                } else {
+                    detail
+                }
             } else {
                 String::new()
             },
@@ -1912,8 +2107,14 @@ mod tests {
 
     #[test]
     fn with_api_version_picks_right_separator() {
-        assert_eq!(with_api_version("https://x/y"), "https://x/y?api-version=7.1");
-        assert_eq!(with_api_version("https://x/y?a=1"), "https://x/y?a=1&api-version=7.1");
+        assert_eq!(
+            with_api_version("https://x/y"),
+            "https://x/y?api-version=7.1"
+        );
+        assert_eq!(
+            with_api_version("https://x/y?a=1"),
+            "https://x/y?a=1&api-version=7.1"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/azure.rs
+++ b/apps/desktop/src-tauri/src/commands/azure.rs
@@ -1010,7 +1010,7 @@ fn rest_reviewer_candidates(cwd: &str) -> Result<Vec<ReviewerCandidate>, String>
             avatar_url: m.avatar_url,
         })
         .collect();
-    all.sort_by(|a, b| a.login.to_lowercase().cmp(&b.login.to_lowercase()));
+    all.sort_by_key(|a| a.login.to_lowercase());
     Ok(all)
 }
 

--- a/apps/desktop/src-tauri/src/commands/bitbucket.rs
+++ b/apps/desktop/src-tauri/src/commands/bitbucket.rs
@@ -19,10 +19,10 @@
 //! **Security note**: credentials are injected via `curl --config -` (stdin),
 //! keeping the `Authorization: Basic` header off the process argv.
 
-use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+use super::curl_util::{auth_header_config, curl_with_status};
 use crate::git::hidden_cmd;
 use crate::types::*;
-use super::curl_util::{auth_header_config, curl_with_status};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
 use rayon::prelude::*;
 use std::collections::HashMap;
 
@@ -38,8 +38,8 @@ fn get_bb_creds(cwd: &str) -> Result<(String, String), String> {
     let (workspace, _) = parse_workspace_slug(cwd)?;
     // Try workspace-scoped entry first; fall back to generic workspace key.
     let account_key = workspace.clone();
-    let entry = keyring::Entry::new(BB_SERVICE, &account_key)
-        .map_err(|e| format!("keyring: {}", e))?;
+    let entry =
+        keyring::Entry::new(BB_SERVICE, &account_key).map_err(|e| format!("keyring: {}", e))?;
     let stored = entry.get_password().map_err(|_| {
         format!(
             "No Bitbucket credentials found for workspace '{workspace}'. \
@@ -85,8 +85,8 @@ fn parse_workspace_slug(cwd: &str) -> Result<(String, String), String> {
 
     let path = if url.starts_with("git@") {
         // git@bitbucket.org:workspace/repo.git  →  workspace/repo
-        url.splitn(2, ':')
-            .nth(1)
+        url.split_once(':')
+            .map(|x| x.1)
             .unwrap_or("")
             .trim_end_matches(".git")
             .to_string()
@@ -94,8 +94,8 @@ fn parse_workspace_slug(cwd: &str) -> Result<(String, String), String> {
         // https://bitbucket.org/workspace/repo.git  →  workspace/repo
         url.trim_end_matches('/')
             .trim_end_matches(".git")
-            .splitn(2, "bitbucket.org/")
-            .nth(1)
+            .split_once("bitbucket.org/")
+            .map(|x| x.1)
             .unwrap_or("")
             .to_string()
     };
@@ -162,8 +162,13 @@ fn bb_curl(
     if body.trim().is_empty() {
         return Ok(serde_json::Value::Null);
     }
-    let json: serde_json::Value = serde_json::from_str(body.trim())
-        .map_err(|e| format!("Failed to parse Bitbucket response: {} — raw: {}", e, &body[..body.len().min(300)]))?;
+    let json: serde_json::Value = serde_json::from_str(body.trim()).map_err(|e| {
+        format!(
+            "Failed to parse Bitbucket response: {} — raw: {}",
+            e,
+            &body[..body.len().min(300)]
+        )
+    })?;
     // Secondary check: Bitbucket sometimes returns 2xx with an error envelope.
     if let Some(error) = json.get("error") {
         let msg = error
@@ -178,13 +183,20 @@ fn bb_curl(
 // ─── JSON field helpers ────────────────────────────────────────────────────────
 
 fn js(v: &serde_json::Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or("").to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 fn ji(v: &serde_json::Value, key: &str) -> i64 {
     v.get(key)
         .and_then(|x| x.as_i64())
-        .or_else(|| v.get(key).and_then(|x| x.as_str()).and_then(|s| s.parse().ok()))
+        .or_else(|| {
+            v.get(key)
+                .and_then(|x| x.as_str())
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap_or(0)
 }
 
@@ -353,8 +365,7 @@ fn bb_pr_to_detail(pr: &serde_json::Value) -> PullRequestDetail {
         .unwrap_or_default();
 
     // merge_commit is present on merged PRs.
-    let merged_at = jnested(pr, "merge_commit", "date")
-        .or_else_empty(|| js(pr, "updated_on")); // fallback if unavailable
+    let merged_at = jnested(pr, "merge_commit", "date").or_else_empty(|| js(pr, "updated_on")); // fallback if unavailable
 
     PullRequestDetail {
         number: ji(pr, "id"),
@@ -376,7 +387,7 @@ fn bb_pr_to_detail(pr: &serde_json::Value) -> PullRequestDetail {
         review_comments: 0,
         labels: jlabels(pr, "labels"),
         reviewers,
-        mergeable: String::new(), // Not directly available in v2.10
+        mergeable: String::new(),     // Not directly available in v2.10
         checks_status: String::new(), // Bitbucket Pipelines needs a separate call
         // Bitbucket merge permission needs a separate privileges call —
         // unknown ⇒ UI gates on errors only.
@@ -391,7 +402,11 @@ trait OrElseEmpty {
 }
 impl OrElseEmpty for String {
     fn or_else_empty(self, f: impl FnOnce() -> String) -> String {
-        if self.is_empty() { f() } else { self }
+        if self.is_empty() {
+            f()
+        } else {
+            self
+        }
     }
 }
 
@@ -460,7 +475,11 @@ pub(crate) async fn bb_list_prs(
         .iter()
         .filter_map(|pr| {
             let hash = jdeep(pr, "source", "commit", "hash");
-            if hash.is_empty() { None } else { Some((ji(pr, "id"), hash)) }
+            if hash.is_empty() {
+                None
+            } else {
+                Some((ji(pr, "id"), hash))
+            }
         })
         .collect();
     let rollups: HashMap<i64, String> = prs
@@ -468,7 +487,11 @@ pub(crate) async fn bb_list_prs(
         .filter_map(|pr| {
             let sha = sha_by_num.get(&pr.number)?;
             let rollup = bb_rollup_for_sha(&workspace, &slug, sha, &auth_config);
-            if rollup.is_empty() { None } else { Some((pr.number, rollup)) }
+            if rollup.is_empty() {
+                None
+            } else {
+                Some((pr.number, rollup))
+            }
         })
         .collect();
     for pr in &mut prs {
@@ -527,10 +550,18 @@ pub(crate) async fn bb_pr_diff(cwd: String, pr_id: i64) -> Result<String, String
     let auth_config = basic_auth_config(&username, &app_password);
 
     // Bitbucket /diff endpoint returns plain-text unified diff — not JSON.
-    let url = format!("{}/pullrequests/{}/diff", repo_api(&workspace, &slug), pr_id);
+    let url = format!(
+        "{}/pullrequests/{}/diff",
+        repo_api(&workspace, &slug),
+        pr_id
+    );
     let (status, body) = bb_curl_raw("GET", &url, None, &auth_config, "*/*")?;
     if status >= 400 {
-        return Err(format!("Bitbucket diff failed (HTTP {}): {}", status, body.trim()));
+        return Err(format!(
+            "Bitbucket diff failed (HTTP {}): {}",
+            status,
+            body.trim()
+        ));
     }
     Ok(body)
 }
@@ -604,7 +635,11 @@ pub(crate) async fn bb_merge_pr(cwd: String, pr_id: i64, method: String) -> Resu
         "close_source_branch": true
     });
 
-    let url = format!("{}/pullrequests/{}/merge", repo_api(&workspace, &slug), pr_id);
+    let url = format!(
+        "{}/pullrequests/{}/merge",
+        repo_api(&workspace, &slug),
+        pr_id
+    );
     bb_curl("POST", &url, Some(&payload.to_string()), &auth_config)?;
     Ok(())
 }
@@ -625,7 +660,10 @@ pub(crate) async fn bb_checkout_pr(cwd: String, pr_id: i64) -> Result<(), String
     let pr = bb_curl("GET", &url, None, &auth_config)?;
     let branch = jdeep(&pr, "source", "branch", "name");
     if branch.is_empty() {
-        return Err(format!("Could not determine source branch for PR #{}", pr_id));
+        return Err(format!(
+            "Could not determine source branch for PR #{}",
+            pr_id
+        ));
     }
 
     // Write guard: fetch + switch mutate refs and the worktree, colliding on
@@ -684,7 +722,10 @@ pub(crate) async fn bb_pr_comments(cwd: String, pr_id: i64) -> Result<serde_json
         pr_id
     );
     let resp = bb_curl("GET", &url, None, &auth_config)?;
-    Ok(resp.get("values").cloned().unwrap_or(serde_json::Value::Array(vec![])))
+    Ok(resp
+        .get("values")
+        .cloned()
+        .unwrap_or(serde_json::Value::Array(vec![])))
 }
 
 /// Create a comment on a PR.
@@ -882,7 +923,12 @@ pub(crate) async fn bb_current_user(cwd: String) -> Result<String, String> {
     let (username, app_password) = get_bb_creds(&cwd)?;
     let auth_config = basic_auth_config(&username, &app_password);
 
-    let resp = bb_curl("GET", "https://api.bitbucket.org/2.0/user", None, &auth_config)?;
+    let resp = bb_curl(
+        "GET",
+        "https://api.bitbucket.org/2.0/user",
+        None,
+        &auth_config,
+    )?;
     Ok(resp
         .get("nickname")
         .or_else(|| resp.get("display_name"))
@@ -902,8 +948,7 @@ pub(crate) async fn bb_reviewer_candidates(cwd: String) -> Result<Vec<ReviewerCa
         "https://api.bitbucket.org/2.0/repositories/{}/{}/permissions-config/users",
         workspace, slug
     );
-    let resp = bb_curl("GET", &url, None, &auth_config)
-        .unwrap_or(serde_json::Value::Null);
+    let resp = bb_curl("GET", &url, None, &auth_config).unwrap_or(serde_json::Value::Null);
 
     let values = resp
         .get("values")
@@ -924,7 +969,10 @@ pub(crate) async fn bb_reviewer_candidates(cwd: String) -> Result<Vec<ReviewerCa
             }
             Some(ReviewerCandidate {
                 login: login.to_string(),
-                name: user.get("display_name").and_then(|v| v.as_str()).map(String::from),
+                name: user
+                    .get("display_name")
+                    .and_then(|v| v.as_str())
+                    .map(String::from),
                 avatar_url: user
                     .get("links")
                     .and_then(|l| l.get("avatar"))
@@ -977,7 +1025,7 @@ pub(crate) async fn bb_branches(cwd: String) -> Result<Vec<String>, String> {
             _ => break,
         }
     }
-    names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    names.sort_by_key(|a| a.to_lowercase());
     Ok(names)
 }
 
@@ -997,7 +1045,11 @@ fn bb_rollup_from_statuses(values: &[serde_json::Value]) -> String {
             _ => pending = true, // INPROGRESS / anything unknown → still running
         }
     }
-    if pending { "PENDING".to_string() } else { "SUCCESS".to_string() }
+    if pending {
+        "PENDING".to_string()
+    } else {
+        "SUCCESS".to_string()
+    }
 }
 
 /// Fetch + aggregate the build statuses of commit `sha`. Sync, best-effort
@@ -1011,7 +1063,11 @@ fn bb_rollup_for_sha(workspace: &str, slug: &str, sha: &str, auth_config: &str) 
         workspace, slug, sha
     );
     let resp = bb_curl("GET", &url, None, auth_config).unwrap_or(serde_json::Value::Null);
-    let values = resp.get("values").and_then(|v| v.as_array()).cloned().unwrap_or_default();
+    let values = resp
+        .get("values")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default();
     bb_rollup_from_statuses(&values)
 }
 
@@ -1052,9 +1108,9 @@ pub(crate) async fn bb_pr_ci_checks(cwd: String, pr_id: i64) -> Result<Vec<CIChe
             let bb_state = js(s, "state");
             let conclusion = match bb_state.as_str() {
                 "SUCCESSFUL" => "success".to_string(),
-                "FAILED"     => "failure".to_string(),
-                "STOPPED"    => "cancelled".to_string(),
-                _            => "pending".to_string(),
+                "FAILED" => "failure".to_string(),
+                "STOPPED" => "cancelled".to_string(),
+                _ => "pending".to_string(),
             };
             let status = if bb_state == "INPROGRESS" {
                 "in_progress".to_string()
@@ -1067,7 +1123,11 @@ pub(crate) async fn bb_pr_ci_checks(cwd: String, pr_id: i64) -> Result<Vec<CIChe
                 conclusion,
                 details_url: {
                     let u = jnested(s, "url", "href");
-                    if u.is_empty() { js(s, "url") } else { u }
+                    if u.is_empty() {
+                        js(s, "url")
+                    } else {
+                        u
+                    }
                 },
             }
         })
@@ -1156,7 +1216,11 @@ pub(crate) fn bb_pr_annotations(cwd: String, pr_id: i64) -> Result<Vec<CIAnnotat
                 title: js(a, "summary"),
                 message: {
                     let d = js(a, "details");
-                    if d.is_empty() { js(a, "summary") } else { d }
+                    if d.is_empty() {
+                        js(a, "summary")
+                    } else {
+                        d
+                    }
                 },
             });
         }
@@ -1183,7 +1247,11 @@ pub(crate) fn bb_pr_annotations(cwd: String, pr_id: i64) -> Result<Vec<CIAnnotat
 /// Bitbucket issues have no labels array or milestone in the same shape as GitHub.
 fn bb_issue_to_issue(v: &serde_json::Value) -> crate::types::Issue {
     let assignee = jnested(v, "assignee", "nickname");
-    let assignees = if assignee.is_empty() { vec![] } else { vec![assignee] };
+    let assignees = if assignee.is_empty() {
+        vec![]
+    } else {
+        vec![assignee]
+    };
     // links.html is {"href": "..."} — extract the nested href string explicitly.
     let url = v
         .get("links")
@@ -1347,14 +1415,17 @@ mod bb_list_issues_tests {
 
     #[test]
     fn maps_bitbucket_issue_json_to_issue() {
-        let v: serde_json::Value = serde_json::from_str(r#"{
+        let v: serde_json::Value = serde_json::from_str(
+            r#"{
             "id": 5, "title": "Broken", "state": "new",
             "reporter": {"nickname": "alice"},
             "assignee": {"nickname": "bob"},
             "created_on": "2026-01-01T00:00:00Z",
             "updated_on": "2026-01-02T00:00:00Z",
             "links": {"html": {"href": "https://bitbucket.org/o/r/issues/5"}}
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
         let i = bb_issue_to_issue(&v);
         assert_eq!(i.number, 5);
         assert_eq!(i.state, "new");

--- a/apps/desktop/src-tauri/src/commands/bitbucket.rs
+++ b/apps/desktop/src-tauri/src/commands/bitbucket.rs
@@ -983,7 +983,7 @@ pub(crate) async fn bb_reviewer_candidates(cwd: String) -> Result<Vec<ReviewerCa
         })
         .collect();
 
-    candidates.sort_by(|a, b| a.login.to_lowercase().cmp(&b.login.to_lowercase()));
+    candidates.sort_by_key(|a| a.login.to_lowercase());
     Ok(candidates)
 }
 

--- a/apps/desktop/src-tauri/src/commands/credentials.rs
+++ b/apps/desktop/src-tauri/src/commands/credentials.rs
@@ -33,7 +33,11 @@
 /// `account` — sub-key within the service, e.g. `"workspace:username"`.
 /// `value`   — the secret (PAT, app-password, etc.).
 #[tauri::command]
-pub(crate) async fn set_credential(service: String, account: String, value: String) -> Result<(), String> {
+pub(crate) async fn set_credential(
+    service: String,
+    account: String,
+    value: String,
+) -> Result<(), String> {
     let entry = keyring::Entry::new(&service, &account)
         .map_err(|e| format!("keyring init failed for {}/{}: {}", service, account, e))?;
     entry
@@ -50,12 +54,12 @@ pub(crate) async fn set_credential(service: String, account: String, value: Stri
 pub(crate) async fn get_credential(service: String, account: String) -> Result<String, String> {
     let entry = keyring::Entry::new(&service, &account)
         .map_err(|e| format!("keyring init failed for {}/{}: {}", service, account, e))?;
-    entry
-        .get_password()
-        .map_err(|_| format!(
+    entry.get_password().map_err(|_| {
+        format!(
             "No credential found for {}/{}. Please configure your account in Settings > Accounts.",
             service, account
-        ))
+        )
+    })
 }
 
 /// Delete a credential from the OS keychain.
@@ -70,6 +74,9 @@ pub(crate) async fn delete_credential(service: String, account: String) -> Resul
     match entry.delete_password() {
         Ok(()) => Ok(()),
         Err(keyring::Error::NoEntry) => Ok(()), // Already gone — idempotent
-        Err(e) => Err(format!("Failed to delete credential {}/{}: {}", service, account, e)),
+        Err(e) => Err(format!(
+            "Failed to delete credential {}/{}: {}",
+            service, account, e
+        )),
     }
 }

--- a/apps/desktop/src-tauri/src/commands/curl_util.rs
+++ b/apps/desktop/src-tauri/src/commands/curl_util.rs
@@ -31,7 +31,7 @@ pub(crate) fn run_curl(
         .stderr(Stdio::piped())
         .stdin(match stdin_config {
             Some(_) => Stdio::piped(),
-            None    => Stdio::null(),
+            None => Stdio::null(),
         });
     let mut child = cmd
         .spawn()
@@ -66,7 +66,9 @@ fn curl_transport_check(success: bool, code: Option<i32>, stderr: &str) -> Resul
     if success {
         return Ok(());
     }
-    let code_str = code.map(|c| c.to_string()).unwrap_or_else(|| "signal".to_string());
+    let code_str = code
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "signal".to_string());
     let detail = stderr.trim();
     if detail.is_empty() {
         Err(format!(
@@ -97,8 +99,10 @@ pub(crate) fn curl_with_status(
     let mut args: Vec<String> = vec![
         "-s".to_string(),
         "-S".to_string(), // --show-error: keep stderr diagnostics under -s
-        "-X".to_string(), method.to_string(),
-        "-H".to_string(), format!("Accept: {}", accept),
+        "-X".to_string(),
+        method.to_string(),
+        "-H".to_string(),
+        format!("Accept: {}", accept),
     ];
     for h in extra_headers {
         args.push("-H".to_string());
@@ -157,9 +161,12 @@ pub(crate) fn curl_with_headers(
     let mut args: Vec<String> = vec![
         "-s".to_string(),
         "-S".to_string(),
-        "-D".to_string(), "-".to_string(), // dump response headers to stdout
-        "-X".to_string(), method.to_string(),
-        "-H".to_string(), format!("Accept: {}", accept),
+        "-D".to_string(),
+        "-".to_string(), // dump response headers to stdout
+        "-X".to_string(),
+        method.to_string(),
+        "-H".to_string(),
+        format!("Accept: {}", accept),
     ];
     for h in extra_headers {
         args.push("-H".to_string());
@@ -225,7 +232,10 @@ mod tests {
         let raw = "HTTP/2 200\r\nETag: \"abc123\"\r\nContent-Type: application/json";
         let h = parse_response_headers(raw);
         assert_eq!(h.get("etag").map(String::as_str), Some("\"abc123\""));
-        assert_eq!(h.get("content-type").map(String::as_str), Some("application/json"));
+        assert_eq!(
+            h.get("content-type").map(String::as_str),
+            Some("application/json")
+        );
         assert!(!h.contains_key("http/2 200"));
     }
 

--- a/apps/desktop/src-tauri/src/commands/files.rs
+++ b/apps/desktop/src-tauri/src/commands/files.rs
@@ -296,7 +296,7 @@ pub(crate) async fn list_dir(path: Option<String>) -> Result<ListDirResult, Stri
         });
     }
 
-    dirs.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    dirs.sort_by_key(|a| a.name.to_lowercase());
 
     let parent = dir_path
         .parent()

--- a/apps/desktop/src-tauri/src/commands/files.rs
+++ b/apps/desktop/src-tauri/src/commands/files.rs
@@ -136,7 +136,11 @@ pub(crate) async fn read_file_at_revision(
 }
 
 #[tauri::command]
-pub(crate) async fn folder_diff(cwd: String, ref_a: String, ref_b: String) -> Result<FolderDiffNode, String> {
+pub(crate) async fn folder_diff(
+    cwd: String,
+    ref_a: String,
+    ref_b: String,
+) -> Result<FolderDiffNode, String> {
     if cwd.trim().is_empty() {
         return Err("cwd must not be empty".to_string());
     }
@@ -186,10 +190,8 @@ pub(crate) async fn folder_diff(cwd: String, ref_a: String, ref_b: String) -> Re
     // --- Merge into raw changes (key = new_path) ---
     let mut changes: Vec<RawFileChange> = Vec::with_capacity(name_status.len());
     for (new_path, status, old_path) in name_status.into_iter() {
-        let (additions, deletions, binary) = numstat
-            .get(&new_path)
-            .copied()
-            .unwrap_or((0, 0, false));
+        let (additions, deletions, binary) =
+            numstat.get(&new_path).copied().unwrap_or((0, 0, false));
         changes.push(RawFileChange {
             new_path,
             old_path,
@@ -243,8 +245,8 @@ pub(crate) async fn list_dir(path: Option<String>) -> Result<ListDirResult, Stri
         .canonicalize()
         .map_err(|e| format!("Cannot resolve path: {}", e))?;
 
-    let entries = std::fs::read_dir(&dir_path)
-        .map_err(|e| format!("Cannot read directory: {}", e))?;
+    let entries =
+        std::fs::read_dir(&dir_path).map_err(|e| format!("Cannot read directory: {}", e))?;
 
     // Is this the home directory? If so, we want to avoid probing
     // inside TCC-protected subfolders on macOS (Documents/Desktop/...)
@@ -326,7 +328,13 @@ fn build_repo_tree(cwd: &str) -> Result<RepoTreeResult, String> {
     }
 
     let output = git_cmd()
-        .args(["ls-files", "-z", "--cached", "--others", "--exclude-standard"])
+        .args([
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+        ])
         .current_dir(cwd)
         .output()
         .map_err(|e| format!("Failed to run git ls-files: {}", e))?;
@@ -390,8 +398,10 @@ mod list_repo_tree_tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let dir = std::env::temp_dir()
-                .join(format!("gitwand-tree-test-{}-{}-{}-{}", label, pid, n, nanos));
+            let dir = std::env::temp_dir().join(format!(
+                "gitwand-tree-test-{}-{}-{}-{}",
+                label, pid, n, nanos
+            ));
             std::fs::create_dir_all(&dir).unwrap();
             let repo = TempRepo { path: dir };
             repo.git(&["init", "-q"]);
@@ -435,13 +445,23 @@ mod list_repo_tree_tests {
         let result = build_repo_tree(&repo.cwd()).unwrap();
 
         assert!(!result.truncated);
-        let names: Vec<&str> = result.root.children.iter().map(|c| c.name.as_str()).collect();
+        let names: Vec<&str> = result
+            .root
+            .children
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
         assert!(names.contains(&"src"));
         assert!(names.contains(&"untracked.md"));
         assert!(names.contains(&".gitignore"));
         assert!(!names.contains(&"ignored_dir"));
 
-        let src_folder = result.root.children.iter().find(|c| c.name == "src").unwrap();
+        let src_folder = result
+            .root
+            .children
+            .iter()
+            .find(|c| c.name == "src")
+            .unwrap();
         assert_eq!(src_folder.kind, "folder");
         assert_eq!(src_folder.children.len(), 1);
         assert_eq!(src_folder.children[0].name, "main.rs");

--- a/apps/desktop/src-tauri/src/commands/gh.rs
+++ b/apps/desktop/src-tauri/src/commands/gh.rs
@@ -566,7 +566,7 @@ fn gh_list_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidat
         }
     }
     // Sort alphabetically by login for stable UX.
-    all.sort_by(|a, b| a.login.to_lowercase().cmp(&b.login.to_lowercase()));
+    all.sort_by_key(|a| a.login.to_lowercase());
     Ok(all)
 }
 

--- a/apps/desktop/src-tauri/src/commands/gh.rs
+++ b/apps/desktop/src-tauri/src/commands/gh.rs
@@ -20,10 +20,9 @@
 //! `spawn_blocking` — matching `azure.rs` — so the Tokio executor thread is
 //! never held by a synchronous wait.
 
+use crate::commands::github_api;
 use crate::git::*;
 use crate::types::*;
-use crate::commands::github_api;
-use serde_json;
 
 // ─── Inner (sync) implementations ───────────────────────────────────────────
 //
@@ -91,7 +90,10 @@ fn gh_list_prs_inner(
         // race the single-repo view of the same repo on `index.lock`. Held only
         // around the fetch — the numstat diffs below are read-only.
         let _repo = repo_lock::write(&cwd);
-        let _ = hidden_cmd("git").args(["fetch", "origin"]).current_dir(&cwd).output();
+        let _ = hidden_cmd("git")
+            .args(["fetch", "origin"])
+            .current_dir(&cwd)
+            .output();
     }
     for pr in &mut prs {
         let (adds, dels) = github_api::diff_numstat(&cwd, &pr.branch, &pr.base);
@@ -144,8 +146,8 @@ fn gh_pr_count_inner(cwd: String, state: String) -> Result<i64, String> {
     let states_expr = match st.as_str() {
         "closed" => "[CLOSED]",
         "merged" => "[MERGED]",
-        "all"    => "[OPEN, CLOSED, MERGED]",
-        _        => "[OPEN]",
+        "all" => "[OPEN, CLOSED, MERGED]",
+        _ => "[OPEN]",
     };
 
     // Resolve owner/name once via `gh repo view`. `nameWithOwner` is the
@@ -169,14 +171,24 @@ fn gh_pr_count_inner(cwd: String, state: String) -> Result<i64, String> {
     let nwo = if is_fork {
         v.get("parent")
             .and_then(|p| {
-                let owner = p.get("owner").and_then(|o| o.get("login")).and_then(|s| s.as_str())?;
+                let owner = p
+                    .get("owner")
+                    .and_then(|o| o.get("login"))
+                    .and_then(|s| s.as_str())?;
                 let name = p.get("name").and_then(|s| s.as_str())?;
                 Some(format!("{}/{}", owner, name))
             })
-            .or_else(|| v.get("nameWithOwner").and_then(|s| s.as_str()).map(|s| s.to_string()))
+            .or_else(|| {
+                v.get("nameWithOwner")
+                    .and_then(|s| s.as_str())
+                    .map(|s| s.to_string())
+            })
             .unwrap_or_default()
     } else {
-        v.get("nameWithOwner").and_then(|s| s.as_str()).unwrap_or("").to_string()
+        v.get("nameWithOwner")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string()
     };
 
     let (owner, name) = match nwo.split_once('/') {
@@ -191,10 +203,14 @@ fn gh_pr_count_inner(cwd: String, state: String) -> Result<i64, String> {
     );
     let out = hidden_cmd("gh")
         .args([
-            "api", "graphql",
-            "-F", &format!("owner={}", owner),
-            "-F", &format!("name={}", name),
-            "-f", &format!("query={}", query),
+            "api",
+            "graphql",
+            "-F",
+            &format!("owner={}", owner),
+            "-F",
+            &format!("name={}", name),
+            "-f",
+            &format!("query={}", query),
         ])
         .current_dir(&cwd)
         .output()
@@ -211,12 +227,17 @@ fn gh_pr_count_inner(cwd: String, state: String) -> Result<i64, String> {
     // above: no serde_json import just for one integer. The response
     // shape is fixed by GitHub's schema so the substring lookup is safe.
     let key = "\"totalCount\"";
-    let start = stdout.find(key)
+    let start = stdout
+        .find(key)
         .ok_or_else(|| format!("totalCount missing from response: {}", stdout))?;
     let after = &stdout[start + key.len()..];
-    let colon = after.find(':').ok_or_else(|| "malformed totalCount".to_string())?;
+    let colon = after
+        .find(':')
+        .ok_or_else(|| "malformed totalCount".to_string())?;
     let tail = after[colon + 1..].trim_start();
-    let end = tail.find(|c: char| !c.is_ascii_digit()).unwrap_or(tail.len());
+    let end = tail
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(tail.len());
     if end == 0 {
         return Err(format!("totalCount has no digits: {}", tail));
     }
@@ -270,11 +291,16 @@ fn gh_pr_freshness_signal_inner(cwd: String) -> Result<Option<PrFreshnessSignal>
     let target_repo = gh_fork_upstream(&cwd);
     let mut cmd = hidden_cmd("gh");
     cmd.args([
-        "pr", "list",
-        "--state", "open",
-        "--json", "number,updatedAt",
-        "--limit", "1",
-        "-S", "sort:updated-desc",
+        "pr",
+        "list",
+        "--state",
+        "open",
+        "--json",
+        "number,updatedAt",
+        "--limit",
+        "1",
+        "-S",
+        "sort:updated-desc",
     ]);
     if let Some(ref nwo) = target_repo {
         cmd.args(["--repo", nwo]);
@@ -295,14 +321,20 @@ fn gh_pr_freshness_signal_inner(cwd: String) -> Result<Option<PrFreshnessSignal>
         None => return Ok(None),
     };
     let open_count = gh_pr_count_inner(cwd, "open".to_string())?;
-    Ok(Some(PrFreshnessSignal { number, updated_at, open_count }))
+    Ok(Some(PrFreshnessSignal {
+        number,
+        updated_at,
+        open_count,
+    }))
 }
 
 /// Cheap "has the open-PR list changed?" probe for the branch-badge
 /// background-drain cache (`usePrPanel.ts`'s `PR_LIST_CACHE`). See
 /// `PrFreshnessSignal`'s doc comment for why two facts are needed.
 #[tauri::command]
-pub(crate) async fn gh_pr_freshness_signal(cwd: String) -> Result<Option<PrFreshnessSignal>, String> {
+pub(crate) async fn gh_pr_freshness_signal(
+    cwd: String,
+) -> Result<Option<PrFreshnessSignal>, String> {
     tauri::async_runtime::spawn_blocking(move || gh_pr_freshness_signal_inner(cwd))
         .await
         .map_err(|e| e.to_string())?
@@ -318,7 +350,9 @@ fn gh_create_pr_inner(
     reviewers: Option<Vec<String>>,
 ) -> Result<PullRequest, String> {
     if let Some(tok) = github_api::settings_github_token() {
-        return github_api::rest_create_pr(&cwd, title, body, base, base_repo, draft, reviewers, &tok);
+        return github_api::rest_create_pr(
+            &cwd, title, body, base, base_repo, draft, reviewers, &tok,
+        );
     }
     let mut args = vec![
         "pr".to_string(),
@@ -462,9 +496,14 @@ fn gh_list_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidat
         ));
     }
     #[derive(serde::Deserialize)]
-    struct OwnerLogin { login: String }
+    struct OwnerLogin {
+        login: String,
+    }
     #[derive(serde::Deserialize)]
-    struct RepoView { owner: OwnerLogin, name: String }
+    struct RepoView {
+        owner: OwnerLogin,
+        name: String,
+    }
     let repo: RepoView = serde_json::from_slice(&view.stdout)
         .map_err(|e| format!("Failed to parse repo view: {}", e))?;
     let endpoint = format!("/repos/{}/{}/assignees", repo.owner.login, repo.name);
@@ -474,9 +513,11 @@ fn gh_list_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidat
         .args([
             "api",
             "--paginate",
-            "-H", "Accept: application/vnd.github+json",
+            "-H",
+            "Accept: application/vnd.github+json",
             &endpoint,
-            "--jq", "[.[] | {login: .login, name: .name, avatar_url: .avatar_url}]",
+            "--jq",
+            "[.[] | {login: .login, name: .name, avatar_url: .avatar_url}]",
         ])
         .current_dir(&cwd)
         .output()
@@ -495,7 +536,9 @@ fn gh_list_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidat
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for chunk in raw.split('\n') {
         let trimmed = chunk.trim();
-        if trimmed.is_empty() { continue; }
+        if trimmed.is_empty() {
+            continue;
+        }
         // gh might return either a single array per chunk (--jq with array wrapper)
         // or NDJSON of arrays. Try to parse as Value and walk.
         let value: serde_json::Value = match serde_json::from_str(trimmed) {
@@ -505,11 +548,19 @@ fn gh_list_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidat
         if let Some(arr) = value.as_array() {
             for item in arr {
                 let login = item.get("login").and_then(|v| v.as_str()).unwrap_or("");
-                if login.is_empty() || !seen.insert(login.to_string()) { continue; }
+                if login.is_empty() || !seen.insert(login.to_string()) {
+                    continue;
+                }
                 all.push(ReviewerCandidate {
                     login: login.to_string(),
-                    name: item.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
-                    avatar_url: item.get("avatar_url").and_then(|v| v.as_str()).map(|s| s.to_string()),
+                    name: item
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
+                    avatar_url: item
+                        .get("avatar_url")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string()),
                 });
             }
         }
@@ -524,7 +575,9 @@ fn gh_list_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidat
 /// Calls `gh api /repos/:owner/:repo/assignees` (paginated) which returns
 /// users with push access — exactly the set GitHub allows as reviewers.
 #[tauri::command]
-pub(crate) async fn gh_list_reviewer_candidates(cwd: String) -> Result<Vec<ReviewerCandidate>, String> {
+pub(crate) async fn gh_list_reviewer_candidates(
+    cwd: String,
+) -> Result<Vec<ReviewerCandidate>, String> {
     tauri::async_runtime::spawn_blocking(move || gh_list_reviewer_candidates_inner(cwd))
         .await
         .map_err(|e| e.to_string())?
@@ -548,9 +601,14 @@ fn gh_branches_inner(cwd: String) -> Result<Vec<String>, String> {
         ));
     }
     #[derive(serde::Deserialize)]
-    struct OwnerLogin { login: String }
+    struct OwnerLogin {
+        login: String,
+    }
     #[derive(serde::Deserialize)]
-    struct RepoView { owner: OwnerLogin, name: String }
+    struct RepoView {
+        owner: OwnerLogin,
+        name: String,
+    }
     let repo: RepoView = serde_json::from_slice(&view.stdout)
         .map_err(|e| format!("Failed to parse repo view: {}", e))?;
     let endpoint = format!("/repos/{}/{}/branches", repo.owner.login, repo.name);
@@ -559,9 +617,11 @@ fn gh_branches_inner(cwd: String) -> Result<Vec<String>, String> {
         .args([
             "api",
             "--paginate",
-            "-H", "Accept: application/vnd.github+json",
+            "-H",
+            "Accept: application/vnd.github+json",
             &endpoint,
-            "--jq", "[.[] | .name]",
+            "--jq",
+            "[.[] | .name]",
         ])
         .current_dir(&cwd)
         .output()
@@ -579,7 +639,9 @@ fn gh_branches_inner(cwd: String) -> Result<Vec<String>, String> {
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
     for chunk in raw.split('\n') {
         let trimmed = chunk.trim();
-        if trimmed.is_empty() { continue; }
+        if trimmed.is_empty() {
+            continue;
+        }
         let value: serde_json::Value = match serde_json::from_str(trimmed) {
             Ok(v) => v,
             Err(_) => continue,
@@ -587,13 +649,15 @@ fn gh_branches_inner(cwd: String) -> Result<Vec<String>, String> {
         if let Some(arr) = value.as_array() {
             for item in arr {
                 if let Some(name) = item.as_str() {
-                    if name.is_empty() || !seen.insert(name.to_string()) { continue; }
+                    if name.is_empty() || !seen.insert(name.to_string()) {
+                        continue;
+                    }
                     names.push(name.to_string());
                 }
             }
         }
     }
-    names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    names.sort_by_key(|a| a.to_lowercase());
     Ok(names)
 }
 
@@ -648,7 +712,13 @@ fn gh_merge_pr_inner(cwd: String, number: i64, method: String) -> Result<(), Str
     };
 
     let output = hidden_cmd("gh")
-        .args(["pr", "merge", &number.to_string(), merge_flag, "--delete-branch"])
+        .args([
+            "pr",
+            "merge",
+            &number.to_string(),
+            merge_flag,
+            "--delete-branch",
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to merge PR: {}", e))?;
@@ -698,22 +768,42 @@ pub(crate) async fn gh_pr_ready(cwd: String, number: i64) -> Result<(), String> 
         .map_err(|e| e.to_string())?
 }
 
-fn gh_dismiss_review_inner(cwd: String, number: i64, review_id: i64, message: String) -> Result<(), String> {
+fn gh_dismiss_review_inner(
+    cwd: String,
+    number: i64,
+    review_id: i64,
+    message: String,
+) -> Result<(), String> {
     if let Some(tok) = github_api::settings_github_token() {
         return github_api::rest_dismiss_review(&cwd, number, review_id, &message, &tok);
     }
     let nwo = gh_fork_upstream(&cwd).unwrap_or_else(|| "{owner}/{repo}".to_string());
-    let path = format!("repos/{}/pulls/{}/reviews/{}/dismissals", nwo, number, review_id);
-    gh_api_write(&cwd, "PUT", &path, &[("message", message.as_str()), ("event", "DISMISS")])?;
+    let path = format!(
+        "repos/{}/pulls/{}/reviews/{}/dismissals",
+        nwo, number, review_id
+    );
+    gh_api_write(
+        &cwd,
+        "PUT",
+        &path,
+        &[("message", message.as_str()), ("event", "DISMISS")],
+    )?;
     Ok(())
 }
 
 /// Dismiss a submitted review (B4, v3.6.0).
 #[tauri::command]
-pub(crate) async fn gh_dismiss_review(cwd: String, number: i64, review_id: i64, message: String) -> Result<(), String> {
-    tauri::async_runtime::spawn_blocking(move || gh_dismiss_review_inner(cwd, number, review_id, message))
-        .await
-        .map_err(|e| e.to_string())?
+pub(crate) async fn gh_dismiss_review(
+    cwd: String,
+    number: i64,
+    review_id: i64,
+    message: String,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        gh_dismiss_review_inner(cwd, number, review_id, message)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 fn gh_request_reviewers_inner(cwd: String, number: i64, logins: Vec<String>) -> Result<(), String> {
@@ -742,7 +832,11 @@ fn gh_request_reviewers_inner(cwd: String, number: i64, logins: Vec<String>) -> 
 
 /// Request reviewers on an existing PR (B4, v3.6.0).
 #[tauri::command]
-pub(crate) async fn gh_request_reviewers(cwd: String, number: i64, logins: Vec<String>) -> Result<(), String> {
+pub(crate) async fn gh_request_reviewers(
+    cwd: String,
+    number: i64,
+    logins: Vec<String>,
+) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || gh_request_reviewers_inner(cwd, number, logins))
         .await
         .map_err(|e| e.to_string())?
@@ -768,7 +862,10 @@ fn gh_pr_detail_inner(cwd: String, number: i64) -> Result<PullRequestDetail, Str
         .map_err(|e| format!("gh pr view: {}", e))?;
 
     if !output.status.success() {
-        return Err(format!("gh pr view failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh pr view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -809,7 +906,10 @@ fn gh_issue_detail_inner(cwd: String, number: i64) -> Result<IssueDetail, String
         .output()
         .map_err(|e| format!("gh issue view: {}", e))?;
     if !output.status.success() {
-        return Err(format!("gh issue view failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh issue view failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let raw: GhIssueDetailRaw = serde_json::from_str(stdout.trim())
@@ -850,7 +950,10 @@ fn gh_issue_comments_inner(cwd: String, number: i64) -> Result<Vec<serde_json::V
         .output()
         .map_err(|e| format!("gh api issue comments: {}", e))?;
     if !output.status.success() {
-        return Err(format!("gh api issue comments failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh api issue comments failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let v: serde_json::Value = serde_json::from_slice(&output.stdout)
         .map_err(|e| format!("parse issue comments: {}", e))?;
@@ -859,13 +962,20 @@ fn gh_issue_comments_inner(cwd: String, number: i64) -> Result<Vec<serde_json::V
 
 /// List conversation comments on an issue.
 #[tauri::command]
-pub(crate) async fn gh_issue_comments(cwd: String, number: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn gh_issue_comments(
+    cwd: String,
+    number: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || gh_issue_comments_inner(cwd, number))
         .await
         .map_err(|e| e.to_string())?
 }
 
-fn gh_issue_add_comment_inner(cwd: String, number: i64, body: String) -> Result<serde_json::Value, String> {
+fn gh_issue_add_comment_inner(
+    cwd: String,
+    number: i64,
+    body: String,
+) -> Result<serde_json::Value, String> {
     if let Some(tok) = github_api::settings_github_token() {
         return github_api::rest_issue_add_comment(&cwd, number, &body, &tok);
     }
@@ -878,7 +988,10 @@ fn gh_issue_add_comment_inner(cwd: String, number: i64, body: String) -> Result<
         .output()
         .map_err(|e| format!("gh api add comment: {}", e))?;
     if !output.status.success() {
-        return Err(format!("gh api add comment failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh api add comment failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let v: serde_json::Value = serde_json::from_slice(&output.stdout)
         .map_err(|e| format!("parse created comment: {}", e))?;
@@ -887,7 +1000,11 @@ fn gh_issue_add_comment_inner(cwd: String, number: i64, body: String) -> Result<
 
 /// Add a comment to an issue. Returns the created comment (mapped shape).
 #[tauri::command]
-pub(crate) async fn gh_issue_add_comment(cwd: String, number: i64, body: String) -> Result<serde_json::Value, String> {
+pub(crate) async fn gh_issue_add_comment(
+    cwd: String,
+    number: i64,
+    body: String,
+) -> Result<serde_json::Value, String> {
     tauri::async_runtime::spawn_blocking(move || gh_issue_add_comment_inner(cwd, number, body))
         .await
         .map_err(|e| e.to_string())?
@@ -906,14 +1023,22 @@ fn gh_issue_set_state_inner(cwd: String, number: i64, state: String) -> Result<(
         .output()
         .map_err(|e| format!("gh issue {}: {}", sub, e))?;
     if !output.status.success() {
-        return Err(format!("gh issue {} failed: {}", sub, String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh issue {} failed: {}",
+            sub,
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     Ok(())
 }
 
 /// Close (`state="closed"`) or reopen (`state="open"`) an issue.
 #[tauri::command]
-pub(crate) async fn gh_issue_set_state(cwd: String, number: i64, state: String) -> Result<(), String> {
+pub(crate) async fn gh_issue_set_state(
+    cwd: String,
+    number: i64,
+    state: String,
+) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || gh_issue_set_state_inner(cwd, number, state))
         .await
         .map_err(|e| e.to_string())?
@@ -936,7 +1061,10 @@ fn gh_fork_upstream(cwd: &str) -> Option<String> {
         return None;
     }
     v.get("parent").and_then(|p| {
-        let owner = p.get("owner").and_then(|o| o.get("login")).and_then(|s| s.as_str())?;
+        let owner = p
+            .get("owner")
+            .and_then(|o| o.get("login"))
+            .and_then(|s| s.as_str())?;
         let name = p.get("name").and_then(|s| s.as_str())?;
         Some(format!("{}/{}", owner, name))
     })
@@ -949,13 +1077,24 @@ fn gh_fork_upstream(cwd: &str) -> Option<String> {
 /// reads like unfinished code. Returns `None` on any failure.
 fn gh_current_nwo(cwd: &str) -> Option<String> {
     let out = hidden_cmd("gh")
-        .args(["repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"])
+        .args([
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner",
+            "--jq",
+            ".nameWithOwner",
+        ])
         .current_dir(cwd)
         .output()
         .ok()
         .filter(|o| o.status.success())?;
     let nwo = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if nwo.is_empty() { None } else { Some(nwo) }
+    if nwo.is_empty() {
+        None
+    } else {
+        Some(nwo)
+    }
 }
 
 /// Resolve whether the current viewer can merge this PR. A PR merges into its
@@ -969,7 +1108,12 @@ fn gh_current_nwo(cwd: &str) -> Option<String> {
 fn gh_viewer_can_merge(cwd: &str, pr_url: &str) -> Option<bool> {
     let nwo = github_nwo_from_pr_url(pr_url)?;
     let output = hidden_cmd("gh")
-        .args(["api", &format!("repos/{}", nwo), "--jq", ".permissions.push"])
+        .args([
+            "api",
+            &format!("repos/{}", nwo),
+            "--jq",
+            ".permissions.push",
+        ])
         .current_dir(cwd)
         .output()
         .ok()?;
@@ -1010,7 +1154,10 @@ fn gh_pr_diff_inner(cwd: String, number: i64) -> Result<String, String> {
         .map_err(|e| format!("gh pr diff: {}", e))?;
 
     if !output.status.success() {
-        return Err(format!("gh pr diff failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh pr diff failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
@@ -1035,7 +1182,12 @@ fn gh_pr_checks_inner(cwd: String, number: i64) -> Result<Vec<CICheck>, String> 
 
     // Step 1 — head commit SHA for this PR.
     let pr_out = hidden_cmd("gh")
-        .args(["api", &format!("repos/{}/pulls/{}", nwo, number), "--jq", ".head.sha"])
+        .args([
+            "api",
+            &format!("repos/{}/pulls/{}", nwo, number),
+            "--jq",
+            ".head.sha",
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("gh api pr head sha: {}", e))?;
@@ -1052,7 +1204,10 @@ fn gh_pr_checks_inner(cwd: String, number: i64) -> Result<Vec<CICheck>, String> 
 
     // Step 2 — check-runs for that commit.
     let runs_out = hidden_cmd("gh")
-        .args(["api", &format!("repos/{}/commits/{}/check-runs?per_page=100", nwo, sha)])
+        .args([
+            "api",
+            &format!("repos/{}/commits/{}/check-runs?per_page=100", nwo, sha),
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("gh api check-runs: {}", e))?;
@@ -1063,18 +1218,34 @@ fn gh_pr_checks_inner(cwd: String, number: i64) -> Result<Vec<CICheck>, String> 
         Ok(v) => v,
         Err(_) => return Ok(Vec::new()),
     };
-    let runs = v.get("check_runs").and_then(|r| r.as_array()).cloned().unwrap_or_default();
-    let checks = runs.iter().map(|run| {
-        let js = |k: &str| run.get(k).and_then(|s| s.as_str()).unwrap_or("").to_string();
-        let status = js("status").to_uppercase();
-        let conclusion = js("conclusion");
-        CICheck {
-            name: js("name"),
-            state: if status == "COMPLETED" { conclusion.clone() } else { status },
-            conclusion,
-            details_url: js("html_url"),
-        }
-    }).collect();
+    let runs = v
+        .get("check_runs")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default();
+    let checks = runs
+        .iter()
+        .map(|run| {
+            let js = |k: &str| {
+                run.get(k)
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_string()
+            };
+            let status = js("status").to_uppercase();
+            let conclusion = js("conclusion");
+            CICheck {
+                name: js("name"),
+                state: if status == "COMPLETED" {
+                    conclusion.clone()
+                } else {
+                    status
+                },
+                conclusion,
+                details_url: js("html_url"),
+            }
+        })
+        .collect();
     Ok(checks)
 }
 
@@ -1108,7 +1279,10 @@ fn gh_pr_comments_inner(cwd: String, number: i64) -> Result<Vec<serde_json::Valu
 /// List inline review comments (anchored to diff lines) for a PR.
 /// Token present → REST; otherwise `gh api`.
 #[tauri::command]
-pub(crate) async fn gh_pr_comments(cwd: String, number: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn gh_pr_comments(
+    cwd: String,
+    number: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || gh_pr_comments_inner(cwd, number))
         .await
         .map_err(|e| e.to_string())?
@@ -1131,7 +1305,10 @@ fn gh_pr_issue_comments_inner(cwd: String, number: i64) -> Result<Vec<serde_json
 /// List issue-level (conversation) comments for a PR.
 /// Token present → REST; otherwise `gh api`.
 #[tauri::command]
-pub(crate) async fn gh_pr_issue_comments(cwd: String, number: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn gh_pr_issue_comments(
+    cwd: String,
+    number: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || gh_pr_issue_comments_inner(cwd, number))
         .await
         .map_err(|e| e.to_string())?
@@ -1154,7 +1331,10 @@ fn gh_pr_reviews_inner(cwd: String, number: i64) -> Result<Vec<serde_json::Value
 /// List submitted reviews (Approve / Request changes / Comment verdicts) for a PR.
 /// Token present → REST; otherwise `gh api`.
 #[tauri::command]
-pub(crate) async fn gh_pr_reviews(cwd: String, number: i64) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) async fn gh_pr_reviews(
+    cwd: String,
+    number: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     tauri::async_runtime::spawn_blocking(move || gh_pr_reviews_inner(cwd, number))
         .await
         .map_err(|e| e.to_string())?
@@ -1169,7 +1349,10 @@ fn gh_api_json(cwd: &str, path: &str) -> Result<serde_json::Value, String> {
         .output()
         .map_err(|e| format!("gh api: {}", e))?;
     if !output.status.success() {
-        return Err(format!("gh api failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh api failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let trimmed = stdout.trim();
@@ -1181,19 +1364,33 @@ fn gh_api_json(cwd: &str, path: &str) -> Result<serde_json::Value, String> {
 
 /// Run a mutating `gh api` call (`POST`/`DELETE`) with optional `-f key=value` fields.
 /// Returns the parsed JSON body, or `Null` for 204 No Content responses.
-fn gh_api_write(cwd: &str, method: &str, path: &str, fields: &[(&str, &str)]) -> Result<serde_json::Value, String> {
+fn gh_api_write(
+    cwd: &str,
+    method: &str,
+    path: &str,
+    fields: &[(&str, &str)],
+) -> Result<serde_json::Value, String> {
     let mut cmd = hidden_cmd("gh");
     cmd.args(["api", "-X", method, path]);
     for (k, v) in fields {
         cmd.args(["-f", &format!("{}={}", k, v)]);
     }
-    let output = cmd.current_dir(cwd).output().map_err(|e| format!("gh api write: {}", e))?;
+    let output = cmd
+        .current_dir(cwd)
+        .output()
+        .map_err(|e| format!("gh api write: {}", e))?;
     if !output.status.success() {
-        return Err(format!("gh api {}: {}", method, String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "gh api {}: {}",
+            method,
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let trimmed = stdout.trim();
-    if trimmed.is_empty() { return Ok(serde_json::Value::Null); }
+    if trimmed.is_empty() {
+        return Ok(serde_json::Value::Null);
+    }
     serde_json::from_str(trimmed).map_err(|e| format!("parse gh api write response: {}", e))
 }
 
@@ -1213,39 +1410,72 @@ fn gh_auth_token() -> Option<String> {
         return None;
     }
     let tok = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if tok.is_empty() { None } else { Some(tok) }
+    if tok.is_empty() {
+        None
+    } else {
+        Some(tok)
+    }
 }
 
 /// Token for reaction calls: the GitWand token if configured, else (only for the
 /// GraphQL-only `"review"` target) the gh CLI's own token. Other targets fall
 /// back to the plain `gh api` path below when this returns `None`.
 fn reaction_token(target_type: &str) -> Option<String> {
-    github_api::settings_github_token().or_else(|| (target_type == "review").then(gh_auth_token).flatten())
+    github_api::settings_github_token()
+        .or_else(|| (target_type == "review").then(gh_auth_token).flatten())
 }
 
-fn gh_list_reactions_inner(cwd: String, number: i64, target_type: String, target_id: i64) -> Result<Vec<serde_json::Value>, String> {
+fn gh_list_reactions_inner(
+    cwd: String,
+    number: i64,
+    target_type: String,
+    target_id: i64,
+) -> Result<Vec<serde_json::Value>, String> {
     if let Some(tok) = reaction_token(&target_type) {
         return github_api::rest_list_reactions(&cwd, number, &target_type, target_id, &tok);
     }
     let nwo = gh_fork_upstream(&cwd).unwrap_or_else(|| "{owner}/{repo}".to_string());
     let path = reactions_api_path(&nwo, &target_type, target_id);
     let json = gh_api_json(&cwd, &path)?;
-    Ok(json.as_array().map(|a| a.iter().map(|r| github_api::map_reaction(r)).collect()).unwrap_or_default())
+    Ok(json
+        .as_array()
+        .map(|a| a.iter().map(github_api::map_reaction).collect())
+        .unwrap_or_default())
 }
 
 /// List reactions on a PR or one of its comments.
 /// `target_type`: `"pr"` | `"review_comment"` | `"issue_comment"`.
 /// `target_id`: PR number for `"pr"`, comment id otherwise.
 #[tauri::command]
-pub(crate) async fn gh_list_reactions(cwd: String, number: i64, target_type: String, target_id: i64) -> Result<Vec<serde_json::Value>, String> {
-    tauri::async_runtime::spawn_blocking(move || gh_list_reactions_inner(cwd, number, target_type, target_id))
-        .await
-        .map_err(|e| e.to_string())?
+pub(crate) async fn gh_list_reactions(
+    cwd: String,
+    number: i64,
+    target_type: String,
+    target_id: i64,
+) -> Result<Vec<serde_json::Value>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        gh_list_reactions_inner(cwd, number, target_type, target_id)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
-fn gh_add_reaction_inner(cwd: String, number: i64, target_type: String, target_id: i64, content: String) -> Result<serde_json::Value, String> {
+fn gh_add_reaction_inner(
+    cwd: String,
+    number: i64,
+    target_type: String,
+    target_id: i64,
+    content: String,
+) -> Result<serde_json::Value, String> {
     if let Some(tok) = reaction_token(&target_type) {
-        return github_api::rest_add_reaction(&cwd, number, &target_type, target_id, &content, &tok);
+        return github_api::rest_add_reaction(
+            &cwd,
+            number,
+            &target_type,
+            target_id,
+            &content,
+            &tok,
+        );
     }
     let nwo = gh_fork_upstream(&cwd).unwrap_or_else(|| "{owner}/{repo}".to_string());
     let path = reactions_api_path(&nwo, &target_type, target_id);
@@ -1254,28 +1484,61 @@ fn gh_add_reaction_inner(cwd: String, number: i64, target_type: String, target_i
 
 /// Add a reaction to a PR or comment.
 #[tauri::command]
-pub(crate) async fn gh_add_reaction(cwd: String, number: i64, target_type: String, target_id: i64, content: String) -> Result<serde_json::Value, String> {
-    tauri::async_runtime::spawn_blocking(move || gh_add_reaction_inner(cwd, number, target_type, target_id, content))
-        .await
-        .map_err(|e| e.to_string())?
+pub(crate) async fn gh_add_reaction(
+    cwd: String,
+    number: i64,
+    target_type: String,
+    target_id: i64,
+    content: String,
+) -> Result<serde_json::Value, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        gh_add_reaction_inner(cwd, number, target_type, target_id, content)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
-fn gh_delete_reaction_inner(cwd: String, number: i64, target_type: String, target_id: i64, reaction_id: i64) -> Result<(), String> {
+fn gh_delete_reaction_inner(
+    cwd: String,
+    number: i64,
+    target_type: String,
+    target_id: i64,
+    reaction_id: i64,
+) -> Result<(), String> {
     if let Some(tok) = reaction_token(&target_type) {
-        return github_api::rest_delete_reaction(&cwd, number, &target_type, target_id, reaction_id, &tok);
+        return github_api::rest_delete_reaction(
+            &cwd,
+            number,
+            &target_type,
+            target_id,
+            reaction_id,
+            &tok,
+        );
     }
     let nwo = gh_fork_upstream(&cwd).unwrap_or_else(|| "{owner}/{repo}".to_string());
-    let path = format!("{}/{}", reactions_api_path(&nwo, &target_type, target_id), reaction_id);
+    let path = format!(
+        "{}/{}",
+        reactions_api_path(&nwo, &target_type, target_id),
+        reaction_id
+    );
     gh_api_write(&cwd, "DELETE", &path, &[])?;
     Ok(())
 }
 
 /// Delete a reaction from a PR or comment.
 #[tauri::command]
-pub(crate) async fn gh_delete_reaction(cwd: String, number: i64, target_type: String, target_id: i64, reaction_id: i64) -> Result<(), String> {
-    tauri::async_runtime::spawn_blocking(move || gh_delete_reaction_inner(cwd, number, target_type, target_id, reaction_id))
-        .await
-        .map_err(|e| e.to_string())?
+pub(crate) async fn gh_delete_reaction(
+    cwd: String,
+    number: i64,
+    target_type: String,
+    target_id: i64,
+    reaction_id: i64,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        gh_delete_reaction_inner(cwd, number, target_type, target_id, reaction_id)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 fn gh_fork_info_inner(cwd: String) -> Result<ForkInfo, String> {
@@ -1293,19 +1556,29 @@ fn gh_fork_info_inner(cwd: String) -> Result<ForkInfo, String> {
             String::from_utf8_lossy(&output.stderr)
         ));
     }
-    let v: serde_json::Value =
-        serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
-    let origin = v.get("nameWithOwner").and_then(|s| s.as_str()).unwrap_or("").to_string();
+    let v: serde_json::Value = serde_json::from_slice(&output.stdout).map_err(|e| e.to_string())?;
+    let origin = v
+        .get("nameWithOwner")
+        .and_then(|s| s.as_str())
+        .unwrap_or("")
+        .to_string();
     let is_fork = v.get("isFork").and_then(|b| b.as_bool()).unwrap_or(false);
     let parent = v
         .get("parent")
         .and_then(|p| {
-            let owner = p.get("owner").and_then(|o| o.get("login")).and_then(|s| s.as_str())?;
+            let owner = p
+                .get("owner")
+                .and_then(|o| o.get("login"))
+                .and_then(|s| s.as_str())?;
             let name = p.get("name").and_then(|s| s.as_str())?;
             Some(format!("{}/{}", owner, name))
         })
         .unwrap_or_default();
-    Ok(ForkInfo { is_fork, origin, parent })
+    Ok(ForkInfo {
+        is_fork,
+        origin,
+        parent,
+    })
 }
 
 /// Report the current repo's fork relationship so the PR create view can offer
@@ -1347,7 +1620,10 @@ pub(crate) fn gh_check_annotations(cwd: String, number: i64) -> Result<Vec<CIAnn
     let output = hidden_cmd("gh")
         .args([
             "api",
-            &format!("repos/{{owner}}/{{repo}}/commits/{}/check-runs?per_page=100", sha),
+            &format!(
+                "repos/{{owner}}/{{repo}}/commits/{}/check-runs?per_page=100",
+                sha
+            ),
         ])
         .current_dir(&cwd)
         .output()
@@ -1392,7 +1668,10 @@ pub(crate) fn gh_check_annotations(cwd: String, number: i64) -> Result<Vec<CIAnn
         let output = hidden_cmd("gh")
             .args([
                 "api",
-                &format!("repos/{{owner}}/{{repo}}/check-runs/{}/annotations?per_page=100", run_id),
+                &format!(
+                    "repos/{{owner}}/{{repo}}/check-runs/{}/annotations?per_page=100",
+                    run_id
+                ),
             ])
             .current_dir(&cwd)
             .output();
@@ -1403,7 +1682,9 @@ pub(crate) fn gh_check_annotations(cwd: String, number: i64) -> Result<Vec<CIAnn
         let stdout = String::from_utf8_lossy(&output.stdout);
         let arr: serde_json::Value =
             serde_json::from_str(stdout.trim()).unwrap_or(serde_json::Value::Array(vec![]));
-        let Some(items) = arr.as_array() else { continue };
+        let Some(items) = arr.as_array() else {
+            continue;
+        };
 
         for a in items {
             let s = |k: &str| a.get(k).and_then(|v| v.as_str()).unwrap_or("").to_string();
@@ -1450,15 +1731,25 @@ fn gh_list_issues_inner(
     // Fallback: shell `gh issue list` (mirrors workspace_issues_all gh path).
     let mut cmd = hidden_cmd("gh");
     cmd.args([
-        "issue", "list",
-        "--state", "open",
-        "--json", "number,title,state,author,assignees,labels,url,createdAt,updatedAt,milestone",
-        "--limit", &lim.to_string(),
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--json",
+        "number,title,state,author,assignees,labels,url,createdAt,updatedAt,milestone",
+        "--limit",
+        &lim.to_string(),
     ]);
     match filter.as_str() {
-        "assigned" => { cmd.args(["--assignee", "@me"]); }
-        "created" => { cmd.args(["--author", "@me"]); }
-        "mentioned" => { cmd.args(["--search", "mentions:@me"]); }
+        "assigned" => {
+            cmd.args(["--assignee", "@me"]);
+        }
+        "created" => {
+            cmd.args(["--author", "@me"]);
+        }
+        "mentioned" => {
+            cmd.args(["--search", "mentions:@me"]);
+        }
         _ => {}
     }
     let output = cmd

--- a/apps/desktop/src-tauri/src/commands/github_api.rs
+++ b/apps/desktop/src-tauri/src/commands/github_api.rs
@@ -36,9 +36,9 @@
 //! harden via `curl --config -` stdin piping in a follow-up). The token is
 //! never logged or included in error messages.
 
+use super::curl_util::{bearer_config, curl_with_headers, curl_with_status};
 use crate::git::{git_cmd, hidden_cmd};
 use crate::types::*;
-use super::curl_util::{bearer_config, curl_with_headers, curl_with_status};
 use rayon::prelude::*;
 use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
@@ -89,7 +89,11 @@ pub(crate) fn settings_github_token() -> Option<String> {
     let entry = keyring::Entry::new(GH_SERVICE, GH_ACCOUNT).ok()?;
     let tok = entry.get_password().ok()?;
     let tok = tok.trim().to_string();
-    if tok.is_empty() { None } else { Some(tok) }
+    if tok.is_empty() {
+        None
+    } else {
+        Some(tok)
+    }
 }
 
 // ─── Owner/repo resolution ──────────────────────────────────────────────────
@@ -110,8 +114,8 @@ fn owner_repo(cwd: &str) -> Result<(String, String), String> {
 
     let path = if url.starts_with("git@") || url.contains("@github.com:") {
         // git@github.com:owner/repo.git → owner/repo
-        url.splitn(2, ':')
-            .nth(1)
+        url.split_once(':')
+            .map(|x| x.1)
             .unwrap_or("")
             .trim_end_matches(".git")
             .to_string()
@@ -119,8 +123,8 @@ fn owner_repo(cwd: &str) -> Result<(String, String), String> {
         // https://github.com/owner/repo.git → owner/repo
         url.trim_end_matches('/')
             .trim_end_matches(".git")
-            .splitn(2, "github.com/")
-            .nth(1)
+            .split_once("github.com/")
+            .map(|x| x.1)
             .unwrap_or("")
             .to_string()
     };
@@ -129,7 +133,10 @@ fn owner_repo(cwd: &str) -> Result<(String, String), String> {
     let owner = parts.next().unwrap_or("").to_string();
     let repo = parts.next().unwrap_or("").to_string();
     if owner.is_empty() || repo.is_empty() {
-        return Err(format!("Could not parse GitHub owner/repo from remote URL: {}", url));
+        return Err(format!(
+            "Could not parse GitHub owner/repo from remote URL: {}",
+            url
+        ));
     }
     Ok((owner, repo))
 }
@@ -161,7 +168,8 @@ fn curl_raw(
     accept: &str,
 ) -> Result<(i32, String), String> {
     curl_with_status(
-        method, url,
+        method,
+        url,
         token.map(bearer_config).as_deref(),
         body_json,
         &["User-Agent: GitWand", "X-GitHub-Api-Version: 2022-11-28"],
@@ -197,7 +205,13 @@ fn api_json(
     token: &str,
     body_json: Option<&str>,
 ) -> Result<serde_json::Value, String> {
-    let (status, body) = curl_raw(method, url, Some(token), body_json, "application/vnd.github+json")?;
+    let (status, body) = curl_raw(
+        method,
+        url,
+        Some(token),
+        body_json,
+        "application/vnd.github+json",
+    )?;
     if status >= 400 {
         return Err(map_api_error(status, &body));
     }
@@ -224,7 +238,9 @@ fn api_json_cached(url: &str, token: &str) -> Result<serde_json::Value, String> 
     let cached = cache.lock().unwrap().get(url).cloned();
 
     let auth = bearer_config(token);
-    let inm = cached.as_ref().map(|(etag, _)| format!("If-None-Match: {}", etag));
+    let inm = cached
+        .as_ref()
+        .map(|(etag, _)| format!("If-None-Match: {}", etag));
     let mut headers: Vec<&str> = vec!["User-Agent: GitWand", "X-GitHub-Api-Version: 2022-11-28"];
     if let Some(h) = &inm {
         headers.push(h);
@@ -245,7 +261,9 @@ fn api_json_cached(url: &str, token: &str) -> Result<serde_json::Value, String> 
         // fail loudly rather than silently parsing an empty body as data.
         return match cached {
             Some((_, cached_body)) => parse_json_body(&cached_body),
-            None => Err(format!("304 Not Modified received for {url} with no cached body")),
+            None => Err(format!(
+                "304 Not Modified received for {url} with no cached body"
+            )),
         };
     }
     if status >= 400 {
@@ -265,7 +283,10 @@ fn api_json_cached(url: &str, token: &str) -> Result<serde_json::Value, String> 
 // ─── JSON field helpers ─────────────────────────────────────────────────────
 
 fn js(v: &serde_json::Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or("").to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Percent-encode an `owner/repo` slug for use inside a search query value,
@@ -295,7 +316,11 @@ fn jb(v: &serde_json::Value, key: &str) -> bool {
 
 /// `obj[outer][inner]` as a string.
 fn jnested(v: &serde_json::Value, outer: &str, inner: &str) -> String {
-    v.get(outer).and_then(|o| o.get(inner)).and_then(|s| s.as_str()).unwrap_or("").to_string()
+    v.get(outer)
+        .and_then(|o| o.get(inner))
+        .and_then(|s| s.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Collect `[{ key: "..." }]` string fields into a Vec.
@@ -315,7 +340,11 @@ fn jlogins(v: &serde_json::Value, arr_key: &str, field: &str) -> Vec<String> {
 /// Map a GitHub REST pull-request object to `PullRequest`.
 fn json_to_pr(pr: &serde_json::Value) -> PullRequest {
     let merged = pr.get("merged_at").map(|m| !m.is_null()).unwrap_or(false);
-    let state = if merged { "merged".to_string() } else { js(pr, "state") };
+    let state = if merged {
+        "merged".to_string()
+    } else {
+        js(pr, "state")
+    };
     let review_requested = jlogins(pr, "requested_reviewers", "login");
     // REST has no review-decision field (that's GraphQL). Use the requested
     // reviewers as a cheap proxy: GitHub removes a reviewer from this list once
@@ -351,9 +380,17 @@ fn json_to_pr(pr: &serde_json::Value) -> PullRequest {
 
 /// Map a GitHub REST pull-request object to `PullRequestDetail`.
 fn json_to_detail(pr: &serde_json::Value) -> PullRequestDetail {
-    let merged_at = pr.get("merged_at").and_then(|m| m.as_str()).unwrap_or("").to_string();
+    let merged_at = pr
+        .get("merged_at")
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
     let merged = !merged_at.is_empty();
-    let state = if merged { "merged".to_string() } else { js(pr, "state") };
+    let state = if merged {
+        "merged".to_string()
+    } else {
+        js(pr, "state")
+    };
     // GitHub `mergeable`: true / false / null (still computing).
     let mergeable = match pr.get("mergeable").and_then(|m| m.as_bool()) {
         Some(true) => "MERGEABLE".to_string(),
@@ -393,7 +430,11 @@ fn json_to_detail(pr: &serde_json::Value) -> PullRequestDetail {
 
 pub(crate) fn rest_current_user(token: &str) -> Result<String, String> {
     let v = api_json("GET", &format!("{}/user", API_BASE), token, None)?;
-    let login = v.get("login").and_then(|l| l.as_str()).unwrap_or("").to_string();
+    let login = v
+        .get("login")
+        .and_then(|l| l.as_str())
+        .unwrap_or("")
+        .to_string();
     if login.is_empty() {
         return Err("GitHub returned an empty login for this token.".to_string());
     }
@@ -488,7 +529,11 @@ pub(crate) fn rest_list_prs(
                 let (adds, dels, merge_state) = rest_pr_detail_enrich(&base, pr.number, token)
                     .unwrap_or((pr.additions, pr.deletions, String::new()));
                 let sha = sha_by_num.get(&pr.number).map(|s| s.as_str()).unwrap_or("");
-                let rollup = if sha.is_empty() { String::new() } else { rest_rollup_for_sha(&base, sha, token) };
+                let rollup = if sha.is_empty() {
+                    String::new()
+                } else {
+                    rest_rollup_for_sha(&base, sha, token)
+                };
                 (pr.number, (adds, dels, rollup, merge_state))
             })
             .collect();
@@ -496,8 +541,12 @@ pub(crate) fn rest_list_prs(
             if let Some((adds, dels, rollup, merge_state)) = enrich.get(&pr.number) {
                 pr.additions = *adds;
                 pr.deletions = *dels;
-                if !rollup.is_empty() { pr.checks_rollup = rollup.clone(); }
-                if !merge_state.is_empty() { pr.merge_state_status = merge_state.clone(); }
+                if !rollup.is_empty() {
+                    pr.checks_rollup = rollup.clone();
+                }
+                if !merge_state.is_empty() {
+                    pr.merge_state_status = merge_state.clone();
+                }
             }
         }
     }
@@ -523,7 +572,10 @@ fn top_pr_from_rest_json(raw: &[serde_json::Value]) -> Option<(i64, String)> {
 /// endpoints) plus the open PR count (`rest_pr_count`, already a single
 /// `/search/issues` call). `Ok(None)` means the repo currently has zero open
 /// PRs.
-pub(crate) fn rest_pr_freshness_signal(cwd: &str, token: &str) -> Result<Option<PrFreshnessSignal>, String> {
+pub(crate) fn rest_pr_freshness_signal(
+    cwd: &str,
+    token: &str,
+) -> Result<Option<PrFreshnessSignal>, String> {
     let base = base_owner_repo(cwd, token).unwrap_or_else(|_| {
         let (o, r) = owner_repo(cwd).unwrap_or_default();
         format!("{}/{}", o, r)
@@ -543,7 +595,11 @@ pub(crate) fn rest_pr_freshness_signal(cwd: &str, token: &str) -> Result<Option<
         None => return Ok(None),
     };
     let open_count = rest_pr_count(cwd, "open", token)?;
-    Ok(Some(PrFreshnessSignal { number, updated_at, open_count }))
+    Ok(Some(PrFreshnessSignal {
+        number,
+        updated_at,
+        open_count,
+    }))
 }
 
 /// Aggregate the check-runs of commit `sha` in `repo` ("owner/name") into a
@@ -562,7 +618,11 @@ fn rest_rollup_for_sha(repo: &str, sha: &str, token: &str) -> String {
         Ok(v) => v,
         Err(_) => return String::new(),
     };
-    let runs = v.get("check_runs").and_then(|r| r.as_array()).cloned().unwrap_or_default();
+    let runs = v
+        .get("check_runs")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default();
     rollup_from_check_runs(&runs)
 }
 
@@ -579,7 +639,11 @@ fn rest_pr_detail_enrich(repo: &str, number: i64, token: &str) -> Option<(i64, i
     let url = format!("{}/repos/{}/pulls/{}", API_BASE, repo, number);
     let v = api_json_cached(&url, token).ok()?;
     let state = js(&v, "mergeable_state").to_uppercase();
-    let merge_state = if state.is_empty() || state == "UNKNOWN" { String::new() } else { state };
+    let merge_state = if state.is_empty() || state == "UNKNOWN" {
+        String::new()
+    } else {
+        state
+    };
     Some((ji(&v, "additions"), ji(&v, "deletions"), merge_state))
 }
 
@@ -605,7 +669,11 @@ fn rollup_from_check_runs(runs: &[serde_json::Value]) -> String {
             _ => pending = true,
         }
     }
-    if pending { "PENDING".to_string() } else { "SUCCESS".to_string() }
+    if pending {
+        "PENDING".to_string()
+    } else {
+        "SUCCESS".to_string()
+    }
 }
 
 /// `git diff --numstat origin/base...origin/head` → (additions, deletions).
@@ -661,7 +729,8 @@ fn get_pr_json(cwd: &str, number: i64, token: &str) -> Result<(String, serde_jso
                 "application/vnd.github+json",
             )?;
             if st2 < 400 {
-                let v = serde_json::from_str(body2.trim()).map_err(|e| format!("parse PR: {}", e))?;
+                let v =
+                    serde_json::from_str(body2.trim()).map_err(|e| format!("parse PR: {}", e))?;
                 return Ok((parent, v));
             }
         }
@@ -683,13 +752,19 @@ pub(crate) fn rest_pr_count(cwd: &str, state: &str, token: &str) -> Result<i64, 
     // /search/issues returns total_count without expanding every item.
     let url = format!(
         "{}/search/issues?q=repo:{}+type:pr{}&per_page=1",
-        API_BASE, enc_nwo(&base), qualifier
+        API_BASE,
+        enc_nwo(&base),
+        qualifier
     );
     let v = api_json("GET", &url, token, None)?;
     Ok(v.get("total_count").and_then(|c| c.as_i64()).unwrap_or(0))
 }
 
-pub(crate) fn rest_pr_detail(cwd: &str, number: i64, token: &str) -> Result<PullRequestDetail, String> {
+pub(crate) fn rest_pr_detail(
+    cwd: &str,
+    number: i64,
+    token: &str,
+) -> Result<PullRequestDetail, String> {
     let (repo, v) = get_pr_json(cwd, number, token)?;
     let mut detail = json_to_detail(&v);
     // The REST PR object carries no CI status; aggregate the head commit's
@@ -721,7 +796,13 @@ pub(crate) fn rest_pr_diff(cwd: &str, number: i64, token: &str) -> Result<String
     // its diff from there.
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
     let url = format!("{}/repos/{}/pulls/{}", API_BASE, repo, number);
-    let (status, body) = curl_raw("GET", &url, Some(token), None, "application/vnd.github.v3.diff")?;
+    let (status, body) = curl_raw(
+        "GET",
+        &url,
+        Some(token),
+        None,
+        "application/vnd.github.v3.diff",
+    )?;
     if status >= 400 {
         return Err(format!("GitHub diff failed (HTTP {})", status));
     }
@@ -740,7 +821,11 @@ pub(crate) fn rest_pr_checks(cwd: &str, number: i64, token: &str) -> Result<Vec<
         Ok(v) => v,
         Err(_) => return Ok(Vec::new()), // no checks configured — not fatal
     };
-    let runs = v.get("check_runs").and_then(|r| r.as_array()).cloned().unwrap_or_default();
+    let runs = v
+        .get("check_runs")
+        .and_then(|r| r.as_array())
+        .cloned()
+        .unwrap_or_default();
     let checks = runs
         .iter()
         .map(|run| CICheck {
@@ -755,11 +840,19 @@ pub(crate) fn rest_pr_checks(cwd: &str, number: i64, token: &str) -> Result<Vec<
 
 pub(crate) fn rest_pr_files(cwd: &str, number: i64, token: &str) -> Result<Vec<String>, String> {
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
-    let url = format!("{}/repos/{}/pulls/{}/files?per_page=100", API_BASE, repo, number);
+    let url = format!(
+        "{}/repos/{}/pulls/{}/files?per_page=100",
+        API_BASE, repo, number
+    );
     let v = api_json("GET", &url, token, None)?;
     let files = v
         .as_array()
-        .map(|arr| arr.iter().map(|f| js(f, "filename")).filter(|s| !s.is_empty()).collect())
+        .map(|arr| {
+            arr.iter()
+                .map(|f| js(f, "filename"))
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
         .unwrap_or_default();
     Ok(files)
 }
@@ -770,7 +863,10 @@ pub(crate) fn rest_pr_files(cwd: &str, number: i64, token: &str) -> Result<Vec<S
 /// Fetches up to 3 pages of 100 (same ceiling as the CLI path). The assignees
 /// list carries `login` and `avatar_url` but not the display `name` (that needs
 /// a per-user lookup), so `name` is left null — matching the CLI path.
-pub(crate) fn rest_reviewer_candidates(cwd: &str, token: &str) -> Result<Vec<ReviewerCandidate>, String> {
+pub(crate) fn rest_reviewer_candidates(
+    cwd: &str,
+    token: &str,
+) -> Result<Vec<ReviewerCandidate>, String> {
     let (owner, repo) = owner_repo(cwd)?;
     let mut all: Vec<ReviewerCandidate> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -791,8 +887,15 @@ pub(crate) fn rest_reviewer_candidates(cwd: &str, token: &str) -> Result<Vec<Rev
                 continue;
             }
             let name = u.get("name").and_then(|n| n.as_str()).map(String::from);
-            let avatar_url = u.get("avatar_url").and_then(|a| a.as_str()).map(String::from);
-            all.push(ReviewerCandidate { login, name, avatar_url });
+            let avatar_url = u
+                .get("avatar_url")
+                .and_then(|a| a.as_str())
+                .map(String::from);
+            all.push(ReviewerCandidate {
+                login,
+                name,
+                avatar_url,
+            });
         }
         if count < 100 {
             break;
@@ -830,7 +933,7 @@ pub(crate) fn rest_branches(cwd: &str, token: &str) -> Result<Vec<String>, Strin
             break;
         }
     }
-    names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    names.sort_by_key(|a| a.to_lowercase());
     Ok(names)
 }
 
@@ -841,7 +944,11 @@ pub(crate) fn map_comment(c: &serde_json::Value, issue_level: bool) -> serde_jso
     use serde_json::Value;
     let side = {
         let s = js(c, "side");
-        if s.is_empty() { "RIGHT".to_string() } else { s }
+        if s.is_empty() {
+            "RIGHT".to_string()
+        } else {
+            s
+        }
     };
     serde_json::json!({
         "id": ji(c, "id"),
@@ -869,17 +976,31 @@ pub(crate) fn map_comments(v: &serde_json::Value, issue_level: bool) -> Vec<serd
 }
 
 /// List inline review comments (anchored to diff lines) for a PR (REST).
-pub(crate) fn rest_pr_comments(cwd: &str, number: i64, token: &str) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) fn rest_pr_comments(
+    cwd: &str,
+    number: i64,
+    token: &str,
+) -> Result<Vec<serde_json::Value>, String> {
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
-    let url = format!("{}/repos/{}/pulls/{}/comments?per_page=100", API_BASE, repo, number);
+    let url = format!(
+        "{}/repos/{}/pulls/{}/comments?per_page=100",
+        API_BASE, repo, number
+    );
     let v = api_json("GET", &url, token, None)?;
     Ok(map_comments(&v, false))
 }
 
 /// List issue-level (conversation) comments for a PR (REST).
-pub(crate) fn rest_pr_issue_comments(cwd: &str, number: i64, token: &str) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) fn rest_pr_issue_comments(
+    cwd: &str,
+    number: i64,
+    token: &str,
+) -> Result<Vec<serde_json::Value>, String> {
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
-    let url = format!("{}/repos/{}/issues/{}/comments?per_page=100", API_BASE, repo, number);
+    let url = format!(
+        "{}/repos/{}/issues/{}/comments?per_page=100",
+        API_BASE, repo, number
+    );
     let v = api_json("GET", &url, token, None)?;
     Ok(map_comments(&v, true))
 }
@@ -894,15 +1015,28 @@ fn json_to_issue_detail(v: &serde_json::Value) -> IssueDetail {
     let assignees = v
         .get("assignees")
         .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().map(|u| js(u, "login")).filter(|s| !s.is_empty()).collect())
+        .map(|arr| {
+            arr.iter()
+                .map(|u| js(u, "login"))
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
         .unwrap_or_default();
     let labels = v
         .get("labels")
         .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().map(|l| js(l, "name")).filter(|s| !s.is_empty()).collect())
+        .map(|arr| {
+            arr.iter()
+                .map(|l| js(l, "name"))
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
         .unwrap_or_default();
     // `milestone` is null when unset — js() on a non-object yields "".
-    let milestone = v.get("milestone").map(|m| js(m, "title")).unwrap_or_default();
+    let milestone = v
+        .get("milestone")
+        .map(|m| js(m, "title"))
+        .unwrap_or_default();
     IssueDetail {
         number: ji(v, "number"),
         title: js(v, "title"),
@@ -920,7 +1054,11 @@ fn json_to_issue_detail(v: &serde_json::Value) -> IssueDetail {
 }
 
 /// Fetch a single issue's detail (REST).
-pub(crate) fn rest_issue_detail(cwd: &str, number: i64, token: &str) -> Result<IssueDetail, String> {
+pub(crate) fn rest_issue_detail(
+    cwd: &str,
+    number: i64,
+    token: &str,
+) -> Result<IssueDetail, String> {
     let (owner, repo) = owner_repo(cwd)?;
     let url = format!("{}/repos/{}/{}/issues/{}", API_BASE, owner, repo, number);
     let v = api_json("GET", &url, token, None)?;
@@ -933,14 +1071,27 @@ fn json_to_issue(v: &serde_json::Value) -> Issue {
     let assignees = v
         .get("assignees")
         .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().map(|u| js(u, "login")).filter(|s| !s.is_empty()).collect())
+        .map(|arr| {
+            arr.iter()
+                .map(|u| js(u, "login"))
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
         .unwrap_or_default();
     let labels = v
         .get("labels")
         .and_then(|a| a.as_array())
-        .map(|arr| arr.iter().map(|l| js(l, "name")).filter(|s| !s.is_empty()).collect())
+        .map(|arr| {
+            arr.iter()
+                .map(|l| js(l, "name"))
+                .filter(|s| !s.is_empty())
+                .collect()
+        })
         .unwrap_or_default();
-    let milestone = v.get("milestone").map(|m| js(m, "title")).unwrap_or_default();
+    let milestone = v
+        .get("milestone")
+        .map(|m| js(m, "title"))
+        .unwrap_or_default();
     Issue {
         number: ji(v, "number"),
         title: js(v, "title"),
@@ -999,24 +1150,44 @@ pub(crate) fn rest_list_issues(
 }
 
 /// List conversation comments for an issue (REST).
-pub(crate) fn rest_issue_comments(cwd: &str, number: i64, token: &str) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) fn rest_issue_comments(
+    cwd: &str,
+    number: i64,
+    token: &str,
+) -> Result<Vec<serde_json::Value>, String> {
     let (owner, repo) = owner_repo(cwd)?;
-    let url = format!("{}/repos/{}/{}/issues/{}/comments?per_page=100", API_BASE, owner, repo, number);
+    let url = format!(
+        "{}/repos/{}/{}/issues/{}/comments?per_page=100",
+        API_BASE, owner, repo, number
+    );
     let v = api_json("GET", &url, token, None)?;
     Ok(map_comments(&v, true))
 }
 
 /// Add a comment to an issue (REST). Returns the created comment, mapped.
-pub(crate) fn rest_issue_add_comment(cwd: &str, number: i64, body: &str, token: &str) -> Result<serde_json::Value, String> {
+pub(crate) fn rest_issue_add_comment(
+    cwd: &str,
+    number: i64,
+    body: &str,
+    token: &str,
+) -> Result<serde_json::Value, String> {
     let (owner, repo) = owner_repo(cwd)?;
-    let url = format!("{}/repos/{}/{}/issues/{}/comments", API_BASE, owner, repo, number);
+    let url = format!(
+        "{}/repos/{}/{}/issues/{}/comments",
+        API_BASE, owner, repo, number
+    );
     let payload = serde_json::json!({ "body": body });
     let v = api_json("POST", &url, token, Some(&payload.to_string()))?;
     Ok(map_comment(&v, true))
 }
 
 /// Close or reopen an issue (REST). `state` is "closed" or "open".
-pub(crate) fn rest_issue_set_state(cwd: &str, number: i64, state: &str, token: &str) -> Result<(), String> {
+pub(crate) fn rest_issue_set_state(
+    cwd: &str,
+    number: i64,
+    state: &str,
+    token: &str,
+) -> Result<(), String> {
     let (owner, repo) = owner_repo(cwd)?;
     let url = format!("{}/repos/{}/{}/issues/{}", API_BASE, owner, repo, number);
     let payload = serde_json::json!({ "state": state });
@@ -1048,9 +1219,16 @@ pub(crate) fn map_reviews(v: &serde_json::Value) -> Vec<serde_json::Value> {
 }
 
 /// List submitted reviews for a PR (REST).
-pub(crate) fn rest_pr_reviews(cwd: &str, number: i64, token: &str) -> Result<Vec<serde_json::Value>, String> {
+pub(crate) fn rest_pr_reviews(
+    cwd: &str,
+    number: i64,
+    token: &str,
+) -> Result<Vec<serde_json::Value>, String> {
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
-    let url = format!("{}/repos/{}/pulls/{}/reviews?per_page=100", API_BASE, repo, number);
+    let url = format!(
+        "{}/repos/{}/pulls/{}/reviews?per_page=100",
+        API_BASE, repo, number
+    );
     let v = api_json("GET", &url, token, None)?;
     Ok(map_reviews(&v))
 }
@@ -1072,7 +1250,12 @@ pub(crate) fn rest_fork_info(cwd: &str, token: &str) -> Result<ForkInfo, String>
         return Ok(cached.clone());
     }
 
-    let info = api_json("GET", &format!("{}/repos/{}/{}", API_BASE, owner, repo), token, None)?;
+    let info = api_json(
+        "GET",
+        &format!("{}/repos/{}/{}", API_BASE, owner, repo),
+        token,
+        None,
+    )?;
     let is_fork = info.get("fork").and_then(|f| f.as_bool()).unwrap_or(false);
     let parent = info
         .get("parent")
@@ -1080,7 +1263,11 @@ pub(crate) fn rest_fork_info(cwd: &str, token: &str) -> Result<ForkInfo, String>
         .and_then(|n| n.as_str())
         .unwrap_or("")
         .to_string();
-    let fi = ForkInfo { is_fork, origin: origin.clone(), parent };
+    let fi = ForkInfo {
+        is_fork,
+        origin: origin.clone(),
+        parent,
+    };
     cache.lock().unwrap().insert(origin, fi.clone());
     Ok(fi)
 }
@@ -1104,6 +1291,11 @@ fn base_owner_repo(cwd: &str, token: &str) -> Result<String, String> {
     }
 }
 
+// Bundling these into a params struct is a real API-shape decision (one
+// caller today, but the sibling `azure.rs`/`bitbucket.rs` "create PR"
+// helpers share this exact parameter list) — deferred rather than done as
+// a drive-by in a chore(ci) PR. See PR1 clippy cleanup notes.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn rest_create_pr(
     cwd: &str,
     title: String,
@@ -1133,9 +1325,18 @@ pub(crate) fn rest_create_pr(
 
     // Resolve base from the *target* repo's default branch when left empty.
     let base = if base.is_empty() {
-        let repo_info = api_json("GET", &format!("{}/repos/{}", API_BASE, target), token, None)?;
+        let repo_info = api_json(
+            "GET",
+            &format!("{}/repos/{}", API_BASE, target),
+            token,
+            None,
+        )?;
         let default = js(&repo_info, "default_branch");
-        if default.is_empty() { "main".to_string() } else { default }
+        if default.is_empty() {
+            "main".to_string()
+        } else {
+            default
+        }
     } else {
         base
     };
@@ -1171,7 +1372,12 @@ pub(crate) fn rest_create_pr(
     Ok(json_to_pr(&created))
 }
 
-pub(crate) fn rest_merge_pr(cwd: &str, number: i64, method: &str, token: &str) -> Result<(), String> {
+pub(crate) fn rest_merge_pr(
+    cwd: &str,
+    number: i64,
+    method: &str,
+    token: &str,
+) -> Result<(), String> {
     let merge_method = match method {
         "squash" => "squash",
         "rebase" => "rebase",
@@ -1202,7 +1408,10 @@ pub(crate) fn rest_dismiss_review(
     token: &str,
 ) -> Result<(), String> {
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
-    let url = format!("{}/repos/{}/pulls/{}/reviews/{}/dismissals", API_BASE, repo, number, review_id);
+    let url = format!(
+        "{}/repos/{}/pulls/{}/reviews/{}/dismissals",
+        API_BASE, repo, number, review_id
+    );
     let payload = serde_json::json!({ "message": message, "event": "DISMISS" });
     api_json("PUT", &url, token, Some(&payload.to_string()))?;
     Ok(())
@@ -1216,7 +1425,10 @@ pub(crate) fn rest_request_reviewers(
     token: &str,
 ) -> Result<(), String> {
     let (repo, _pr) = get_pr_json(cwd, number, token)?;
-    let url = format!("{}/repos/{}/pulls/{}/requested_reviewers", API_BASE, repo, number);
+    let url = format!(
+        "{}/repos/{}/pulls/{}/requested_reviewers",
+        API_BASE, repo, number
+    );
     let payload = serde_json::json!({ "reviewers": logins });
     api_json("POST", &url, token, Some(&payload.to_string()))?;
     Ok(())
@@ -1299,13 +1511,23 @@ pub(crate) fn map_reaction(r: &serde_json::Value) -> serde_json::Value {
 fn reactions_url(repo: &str, target_type: &str, target_id: i64) -> String {
     match target_type {
         "pr" => format!("{}/repos/{}/issues/{}/reactions", API_BASE, repo, target_id),
-        "review_comment" => format!("{}/repos/{}/pulls/comments/{}/reactions", API_BASE, repo, target_id),
-        _ => format!("{}/repos/{}/issues/comments/{}/reactions", API_BASE, repo, target_id),
+        "review_comment" => format!(
+            "{}/repos/{}/pulls/comments/{}/reactions",
+            API_BASE, repo, target_id
+        ),
+        _ => format!(
+            "{}/repos/{}/issues/comments/{}/reactions",
+            API_BASE, repo, target_id
+        ),
     }
 }
 
 fn reaction_delete_url(repo: &str, target_type: &str, target_id: i64, reaction_id: i64) -> String {
-    format!("{}/{}", reactions_url(repo, target_type, target_id), reaction_id)
+    format!(
+        "{}/{}",
+        reactions_url(repo, target_type, target_id),
+        reaction_id
+    )
 }
 
 // ── Review-summary reactions (GraphQL) ──────────────────────────────────────
@@ -1357,12 +1579,24 @@ fn map_gql_reaction(r: &serde_json::Value) -> serde_json::Value {
 }
 
 /// Run a GraphQL operation and surface the first `errors[]` entry as an `Err`.
-fn graphql(token: &str, query: &str, variables: serde_json::Value) -> Result<serde_json::Value, String> {
+fn graphql(
+    token: &str,
+    query: &str,
+    variables: serde_json::Value,
+) -> Result<serde_json::Value, String> {
     let payload = serde_json::json!({ "query": query, "variables": variables });
-    let v = api_json("POST", &format!("{}/graphql", API_BASE), token, Some(&payload.to_string()))?;
+    let v = api_json(
+        "POST",
+        &format!("{}/graphql", API_BASE),
+        token,
+        Some(&payload.to_string()),
+    )?;
     if let Some(errors) = v.get("errors").and_then(|e| e.as_array()) {
         if let Some(first) = errors.first() {
-            let msg = first.get("message").and_then(|m| m.as_str()).unwrap_or("GraphQL error");
+            let msg = first
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("GraphQL error");
             return Err(format!("GraphQL error: {}", msg));
         }
     }
@@ -1371,7 +1605,10 @@ fn graphql(token: &str, query: &str, variables: serde_json::Value) -> Result<ser
 
 /// Resolve a review's opaque GraphQL node id from its REST numeric id.
 fn review_node_id(repo: &str, number: i64, review_id: i64, token: &str) -> Result<String, String> {
-    let url = format!("{}/repos/{}/pulls/{}/reviews/{}", API_BASE, repo, number, review_id);
+    let url = format!(
+        "{}/repos/{}/pulls/{}/reviews/{}",
+        API_BASE, repo, number, review_id
+    );
     let v = api_json("GET", &url, token, None)?;
     let id = js(&v, "node_id");
     if id.is_empty() {
@@ -1393,33 +1630,66 @@ fn gql_reactions_for_node(node: &str, token: &str) -> Result<Vec<serde_json::Val
     Ok(nodes.iter().map(map_gql_reaction).collect())
 }
 
-fn gql_list_review_reactions(repo: &str, number: i64, review_id: i64, token: &str) -> Result<Vec<serde_json::Value>, String> {
+fn gql_list_review_reactions(
+    repo: &str,
+    number: i64,
+    review_id: i64,
+    token: &str,
+) -> Result<Vec<serde_json::Value>, String> {
     let node = review_node_id(repo, number, review_id, token)?;
     gql_reactions_for_node(&node, token)
 }
 
-fn gql_add_review_reaction(repo: &str, number: i64, review_id: i64, content: &str, token: &str) -> Result<serde_json::Value, String> {
-    let gql_content = reaction_content_to_gql(content).ok_or_else(|| format!("Unsupported reaction: {}", content))?;
+fn gql_add_review_reaction(
+    repo: &str,
+    number: i64,
+    review_id: i64,
+    content: &str,
+    token: &str,
+) -> Result<serde_json::Value, String> {
+    let gql_content = reaction_content_to_gql(content)
+        .ok_or_else(|| format!("Unsupported reaction: {}", content))?;
     let node = review_node_id(repo, number, review_id, token)?;
     let query = "mutation($id: ID!, $c: ReactionContent!) { addReaction(input: { subjectId: $id, content: $c }) { reaction { databaseId content user { login } } } }";
-    let v = graphql(token, query, serde_json::json!({ "id": node, "c": gql_content }))?;
-    let reaction = v.pointer("/data/addReaction/reaction").cloned().unwrap_or(serde_json::Value::Null);
+    let v = graphql(
+        token,
+        query,
+        serde_json::json!({ "id": node, "c": gql_content }),
+    )?;
+    let reaction = v
+        .pointer("/data/addReaction/reaction")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
     Ok(map_gql_reaction(&reaction))
 }
 
-fn gql_delete_review_reaction(repo: &str, number: i64, review_id: i64, reaction_id: i64, token: &str) -> Result<(), String> {
+fn gql_delete_review_reaction(
+    repo: &str,
+    number: i64,
+    review_id: i64,
+    reaction_id: i64,
+    token: &str,
+) -> Result<(), String> {
     // GraphQL's removeReaction keys off content, not the reaction id, so look up
     // the content of the reaction being removed first. Resolve the node once and
     // reuse it for both the lookup and the mutation.
     let node = review_node_id(repo, number, review_id, token)?;
     let existing = gql_reactions_for_node(&node, token)?;
-    let Some(target) = existing.iter().find(|r| r.get("id").and_then(|x| x.as_i64()) == Some(reaction_id)) else {
+    let Some(target) = existing
+        .iter()
+        .find(|r| r.get("id").and_then(|x| x.as_i64()) == Some(reaction_id))
+    else {
         return Ok(()); // already gone
     };
     let rest_content = target.get("content").and_then(|c| c.as_str()).unwrap_or("");
-    let gql_content = reaction_content_to_gql(rest_content).ok_or_else(|| format!("Unsupported reaction: {}", rest_content))?;
+    let gql_content = reaction_content_to_gql(rest_content)
+        .ok_or_else(|| format!("Unsupported reaction: {}", rest_content))?;
     let query = "mutation($id: ID!, $c: ReactionContent!) { removeReaction(input: { subjectId: $id, content: $c }) { reaction { databaseId } } }";
-    graphql(token, query, serde_json::json!({ "id": node, "c": gql_content }))?;
+    graphql(
+        token,
+        query,
+        serde_json::json!({ "id": node, "c": gql_content }),
+    )?;
     Ok(())
 }
 
@@ -1440,7 +1710,9 @@ pub(crate) fn rest_list_reactions(
     }
     let url = reactions_url(&repo, target_type, target_id);
     let v = api_json("GET", &url, token, None)?;
-    Ok(v.as_array().map(|a| a.iter().map(|r| map_reaction(r)).collect()).unwrap_or_default())
+    Ok(v.as_array()
+        .map(|a| a.iter().map(map_reaction).collect())
+        .unwrap_or_default())
 }
 
 pub(crate) fn rest_add_reaction(
@@ -1493,7 +1765,10 @@ fn github_device_start_inner() -> Result<GithubDeviceCode, String> {
         "application/json",
     )?;
     if status >= 400 {
-        return Err(format!("GitHub device-code request failed (HTTP {})", status));
+        return Err(format!(
+            "GitHub device-code request failed (HTTP {})",
+            status
+        ));
     }
     let v: serde_json::Value = serde_json::from_str(text.trim())
         .map_err(|e| format!("Failed to parse device-code response: {}", e))?;
@@ -1548,7 +1823,11 @@ fn github_device_poll_inner(device_code: String) -> Result<GithubDevicePoll, Str
         return Ok(GithubDevicePoll {
             status: kind.to_string(),
             login: String::new(),
-            error: if kind == "error" { err.to_string() } else { String::new() },
+            error: if kind == "error" {
+                err.to_string()
+            } else {
+                String::new()
+            },
         });
     }
 
@@ -1661,7 +1940,10 @@ mod tests {
             "requested_reviewers": [{"login": "bob"}],
         });
         assert_eq!(json_to_pr(&pending).review_decision, "REVIEW_REQUIRED");
-        assert_eq!(json_to_pr(&pending).review_requested, vec!["bob".to_string()]);
+        assert_eq!(
+            json_to_pr(&pending).review_requested,
+            vec!["bob".to_string()]
+        );
 
         let cleared = json!({"number": 2, "state": "open", "requested_reviewers": []});
         assert_eq!(json_to_pr(&cleared).review_decision, "");

--- a/apps/desktop/src-tauri/src/commands/github_api.rs
+++ b/apps/desktop/src-tauri/src/commands/github_api.rs
@@ -901,7 +901,7 @@ pub(crate) fn rest_reviewer_candidates(
             break;
         }
     }
-    all.sort_by(|a, b| a.login.to_lowercase().cmp(&b.login.to_lowercase()));
+    all.sort_by_key(|a| a.login.to_lowercase());
     Ok(all)
 }
 

--- a/apps/desktop/src-tauri/src/commands/gitlab.rs
+++ b/apps/desktop/src-tauri/src/commands/gitlab.rs
@@ -44,14 +44,21 @@ const ROLLUP_BUDGET: Duration = Duration::from_secs(5);
 
 /// Extract a string field from a serde_json::Value object.
 fn js(v: &serde_json::Value, key: &str) -> String {
-    v.get(key).and_then(|x| x.as_str()).unwrap_or("").to_string()
+    v.get(key)
+        .and_then(|x| x.as_str())
+        .unwrap_or("")
+        .to_string()
 }
 
 /// Extract an i64 field. Also handles string-encoded numbers (GitLab quirk).
 fn ji(v: &serde_json::Value, key: &str) -> i64 {
     v.get(key)
         .and_then(|x| x.as_i64())
-        .or_else(|| v.get(key).and_then(|x| x.as_str()).and_then(|s| s.parse().ok()))
+        .or_else(|| {
+            v.get(key)
+                .and_then(|x| x.as_str())
+                .and_then(|s| s.parse().ok())
+        })
         .unwrap_or(0)
 }
 
@@ -134,9 +141,7 @@ fn gl_mr_to_pr(mr: &serde_json::Value) -> PullRequest {
     let state = js(mr, "state");
     // Draft MRs: `draft` boolean (GitLab 14+) or legacy title prefix "Draft:"/"WIP:".
     let title = js(mr, "title");
-    let is_draft = jb(mr, "draft")
-        || title.starts_with("Draft:")
-        || title.starts_with("WIP:");
+    let is_draft = jb(mr, "draft") || title.starts_with("Draft:") || title.starts_with("WIP:");
 
     // diff_stats is present on `gl_get_mr` (detail) responses.
     let (additions, deletions) = mr
@@ -204,9 +209,7 @@ fn gl_mergeable_state(mr: &serde_json::Value) -> String {
 fn gl_mr_to_detail(mr: &serde_json::Value) -> PullRequestDetail {
     let state = js(mr, "state");
     let title = js(mr, "title");
-    let is_draft = jb(mr, "draft")
-        || title.starts_with("Draft:")
-        || title.starts_with("WIP:");
+    let is_draft = jb(mr, "draft") || title.starts_with("Draft:") || title.starts_with("WIP:");
 
     let (additions, deletions) = mr
         .get("diff_stats")
@@ -308,13 +311,8 @@ fn gl_list_mrs_inner(
     let total = gl_mr_list_per_page(limit, offset).to_string();
 
     let mut cmd = hidden_cmd("glab");
-    cmd.args([
-        "mr", "list",
-        flag,
-        "--per-page", &total,
-        "--output", "json",
-    ])
-    .current_dir(&cwd);
+    cmd.args(["mr", "list", flag, "--per-page", &total, "--output", "json"])
+        .current_dir(&cwd);
     let output = output_with_timeout(cmd, GLAB_TIMEOUT)
         .map_err(|e| format!("Failed to run glab mr list (is glab installed?): {}", e))?;
 
@@ -327,9 +325,12 @@ fn gl_list_mrs_inner(
     let raw: serde_json::Value = serde_json::from_str(stdout.trim())
         .map_err(|e| format!("Failed to parse glab mr list output: {}", e))?;
 
-    let arr = raw
-        .as_array()
-        .ok_or_else(|| format!("Expected JSON array from glab mr list, got: {}", &stdout[..stdout.len().min(200)]))?;
+    let arr = raw.as_array().ok_or_else(|| {
+        format!(
+            "Expected JSON array from glab mr list, got: {}",
+            &stdout[..stdout.len().min(200)]
+        )
+    })?;
 
     let mut mrs: Vec<PullRequest> = arr.iter().map(gl_mr_to_pr).collect();
 
@@ -346,7 +347,10 @@ fn gl_list_mrs_inner(
         .iter()
         .filter_map(|mr| {
             let iid = ji(mr, "iid");
-            let status = mr.get("head_pipeline").or_else(|| mr.get("pipeline")).map(|p| js(p, "status"))?;
+            let status = mr
+                .get("head_pipeline")
+                .or_else(|| mr.get("pipeline"))
+                .map(|p| js(p, "status"))?;
             Some((iid, status))
         })
         .collect();
@@ -362,7 +366,11 @@ fn gl_list_mrs_inner(
                 None if Instant::now() < rollup_deadline => gl_pipeline_rollup(&cwd, mr.number),
                 None => String::new(),
             };
-            if rollup.is_empty() { None } else { Some((mr.number, rollup)) }
+            if rollup.is_empty() {
+                None
+            } else {
+                Some((mr.number, rollup))
+            }
         })
         .collect();
     for mr in &mut mrs {
@@ -481,7 +489,8 @@ fn gl_get_mr_inner(cwd: String, iid: i64) -> Result<PullRequestDetail, String> {
     let mut cmd = hidden_cmd("glab");
     cmd.args(["mr", "view", &iid.to_string(), "--output", "json"])
         .current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr view: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr view: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -544,7 +553,10 @@ fn gl_diff_stats_from_files(files: &[serde_json::Value]) -> (i64, i64) {
 /// since a stats miss shouldn't block the rest of the MR detail from
 /// rendering.
 fn gl_mr_diff_stats(cwd: &str, iid: i64) -> (i64, i64) {
-    let endpoint = format!("projects/:fullpath/merge_requests/{}/diffs?per_page=100", iid);
+    let endpoint = format!(
+        "projects/:fullpath/merge_requests/{}/diffs?per_page=100",
+        iid
+    );
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", &endpoint]).current_dir(cwd);
     let out = match output_with_timeout(cmd, GLAB_API_TIMEOUT) {
@@ -575,7 +587,8 @@ fn gl_mr_diff_refs_inner(cwd: String, iid: i64) -> Result<MrDiffRefs, String> {
     let mut cmd = hidden_cmd("glab");
     cmd.args(["mr", "view", &iid.to_string(), "--output", "json"])
         .current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr view: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr view: {}", e))?;
     if !output.status.success() {
         return Err(format!(
             "glab mr view failed: {}",
@@ -585,14 +598,25 @@ fn gl_mr_diff_refs_inner(cwd: String, iid: i64) -> Result<MrDiffRefs, String> {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mr: serde_json::Value = serde_json::from_str(stdout.trim())
         .map_err(|e| format!("Failed to parse glab mr view output: {}", e))?;
-    let refs = mr.get("diff_refs").cloned().unwrap_or(serde_json::Value::Null);
+    let refs = mr
+        .get("diff_refs")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
     let base_sha = js(&refs, "base_sha");
     let start_sha = js(&refs, "start_sha");
     let head_sha = js(&refs, "head_sha");
     Ok(MrDiffRefs {
         base_sha: base_sha.clone(),
-        start_sha: if start_sha.is_empty() { base_sha } else { start_sha },
-        head_sha: if head_sha.is_empty() { js(&mr, "sha") } else { head_sha },
+        start_sha: if start_sha.is_empty() {
+            base_sha
+        } else {
+            start_sha
+        },
+        head_sha: if head_sha.is_empty() {
+            js(&mr, "sha")
+        } else {
+            head_sha
+        },
     })
 }
 
@@ -612,14 +636,20 @@ pub(crate) async fn gl_mr_diff_refs(cwd: String, iid: i64) -> Result<MrDiffRefs,
 /// parsers silently see zero files — no error, just an empty result — and
 /// the UI renders "no diff available" regardless of what the MR contains.
 fn gl_mr_diff_args(iid: i64) -> Vec<String> {
-    vec!["mr".to_string(), "diff".to_string(), iid.to_string(), "--raw".to_string()]
+    vec![
+        "mr".to_string(),
+        "diff".to_string(),
+        iid.to_string(),
+        "--raw".to_string(),
+    ]
 }
 
 /// Get the unified diff of a MR using `glab mr diff`.
 fn gl_mr_diff_inner(cwd: String, iid: i64) -> Result<String, String> {
     let mut cmd = hidden_cmd("glab");
     cmd.args(gl_mr_diff_args(iid)).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr diff: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr diff: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -643,14 +673,11 @@ pub(crate) async fn gl_mr_diff(cwd: String, iid: i64) -> Result<String, String> 
 /// Returns the most-recent pipeline as a single-entry list (GitLab only has
 /// one "active" pipeline per MR at a time). Each job maps to a CICheck entry.
 fn gl_mr_pipelines_inner(cwd: String, iid: i64) -> Result<Vec<CICheck>, String> {
-    let endpoint = format!(
-        "projects/:fullpath/merge_requests/{}/pipelines",
-        iid
-    );
+    let endpoint = format!("projects/:fullpath/merge_requests/{}/pipelines", iid);
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", &endpoint]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT)
-        .map_err(|e| format!("glab api pipelines: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api pipelines: {}", e))?;
 
     if !output.status.success() {
         return Ok(Vec::new()); // Non-fatal — no CI configured is common
@@ -768,7 +795,11 @@ fn gl_mr_annotations_inner(cwd: String, iid: i64) -> Result<Vec<CIAnnotation>, S
         Some(v) => v,
         None => return Ok(Vec::new()),
     };
-    let pipeline_id = match pipelines.as_array().and_then(|a| a.first()).map(|p| ji(p, "id")) {
+    let pipeline_id = match pipelines
+        .as_array()
+        .and_then(|a| a.first())
+        .map(|p| ji(p, "id"))
+    {
         Some(id) if id > 0 => id,
         _ => return Ok(Vec::new()),
     };
@@ -776,7 +807,10 @@ fn gl_mr_annotations_inner(cwd: String, iid: i64) -> Result<Vec<CIAnnotation>, S
     // 2. Jobs of that pipeline, keep those with a codequality report artifact.
     let jobs = match glab_api_json(
         &cwd,
-        &format!("projects/:fullpath/pipelines/{}/jobs?per_page=100", pipeline_id),
+        &format!(
+            "projects/:fullpath/pipelines/{}/jobs?per_page=100",
+            pipeline_id
+        ),
     ) {
         Some(v) => v,
         None => return Ok(Vec::new()),
@@ -808,7 +842,9 @@ fn gl_mr_annotations_inner(cwd: String, iid: i64) -> Result<Vec<CIAnnotation>, S
             Some(v) => v,
             None => continue, // report expired or custom filename — skip
         };
-        let Some(entries) = report.as_array() else { continue };
+        let Some(entries) = report.as_array() else {
+            continue;
+        };
 
         // 4. Code Climate format:
         //    { description, check_name, severity, location: { path, lines: { begin, end? } } }
@@ -877,9 +913,16 @@ fn gl_issue_to_issue(v: &serde_json::Value) -> crate::types::Issue {
     let labels = v
         .get("labels")
         .and_then(|l| l.as_array())
-        .map(|arr| arr.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|x| x.as_str().map(String::from))
+                .collect()
+        })
         .unwrap_or_default();
-    let milestone = v.get("milestone").map(|m| js(m, "title")).unwrap_or_default();
+    let milestone = v
+        .get("milestone")
+        .map(|m| js(m, "title"))
+        .unwrap_or_default();
     crate::types::Issue {
         number: ji(v, "iid"),
         title: js(v, "title"),
@@ -906,22 +949,32 @@ fn gl_list_issues_inner(
     // GitLab caps --per-page at 100; clamp so an over-large limit doesn't error.
     let lim = limit.unwrap_or(100).clamp(1, 100).to_string();
     let mut args: Vec<String> = vec![
-        "issue".into(), "list".into(),
-        "--state".into(), "opened".into(),
-        "--per-page".into(), lim,
-        "--output".into(), "json".into(),
+        "issue".into(),
+        "list".into(),
+        "--state".into(),
+        "opened".into(),
+        "--per-page".into(),
+        lim,
+        "--output".into(),
+        "json".into(),
     ];
     // glab filter flags: --assignee / --author accept usernames or "@me".
     match filter.as_str() {
-        "assigned" => { args.push("--assignee".into()); args.push("@me".into()); }
-        "created"  => { args.push("--author".into());   args.push("@me".into()); }
+        "assigned" => {
+            args.push("--assignee".into());
+            args.push("@me".into());
+        }
+        "created" => {
+            args.push("--author".into());
+            args.push("@me".into());
+        }
         // "mentioned" has no native glab flag → fall back to all-open.
         _ => {}
     }
     let mut cmd = hidden_cmd("glab");
     cmd.args(&args).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT)
-        .map_err(|e| format!("glab not available: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab not available: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("glab issue list failed: {}", stderr.trim()));
@@ -965,7 +1018,7 @@ fn gl_create_mr_inner(
         source_branch,
         "--target-branch".to_string(),
         target_branch,
-        "--yes".to_string(),     // Skip interactive prompts
+        "--yes".to_string(), // Skip interactive prompts
         "--output".to_string(),
         "json".to_string(),
     ];
@@ -1014,7 +1067,15 @@ pub(crate) async fn gl_create_mr(
     reviewers: Option<Vec<String>>,
 ) -> Result<PullRequest, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        gl_create_mr_inner(cwd, title, body, source_branch, target_branch, draft, reviewers)
+        gl_create_mr_inner(
+            cwd,
+            title,
+            body,
+            source_branch,
+            target_branch,
+            draft,
+            reviewers,
+        )
     })
     .await
     .map_err(|e| e.to_string())?
@@ -1038,7 +1099,8 @@ fn gl_merge_mr_inner(cwd: String, iid: i64, method: String) -> Result<(), String
 
     let mut cmd = hidden_cmd("glab");
     cmd.args(&args).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr merge: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr merge: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -1060,8 +1122,10 @@ pub(crate) async fn gl_merge_mr(cwd: String, iid: i64, method: String) -> Result
 #[tauri::command]
 fn gl_checkout_mr_inner(cwd: String, iid: i64) -> Result<(), String> {
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["mr", "checkout", &iid.to_string()]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr checkout: {}", e))?;
+    cmd.args(["mr", "checkout", &iid.to_string()])
+        .current_dir(&cwd);
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr checkout: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -1082,7 +1146,8 @@ pub(crate) async fn gl_checkout_mr(cwd: String, iid: i64) -> Result<(), String> 
 /// Convert a draft MR to ready-for-review using `glab mr update --draft=false`.
 fn gl_convert_draft_to_ready_inner(cwd: String, iid: i64) -> Result<(), String> {
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["mr", "update", &iid.to_string(), "--draft=false"]).current_dir(&cwd);
+    cmd.args(["mr", "update", &iid.to_string(), "--draft=false"])
+        .current_dir(&cwd);
     let output = output_with_timeout(cmd, GLAB_TIMEOUT)
         .map_err(|e| format!("glab mr update (draft→ready): {}", e))?;
 
@@ -1134,7 +1199,8 @@ fn gl_mr_notes_inner(cwd: String, iid: i64) -> Result<serde_json::Value, String>
     );
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", &endpoint]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api discussions: {}", e))?;
+    let output = output_with_timeout(cmd, GLAB_TIMEOUT)
+        .map_err(|e| format!("glab api discussions: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -1146,7 +1212,9 @@ fn gl_mr_notes_inner(cwd: String, iid: i64) -> Result<serde_json::Value, String>
     let stdout = String::from_utf8_lossy(&output.stdout);
     let discussions: Vec<serde_json::Value> =
         serde_json::from_str(stdout.trim()).map_err(|e| format!("Parse discussions: {}", e))?;
-    Ok(serde_json::Value::Array(gl_flatten_discussions(&discussions)))
+    Ok(serde_json::Value::Array(gl_flatten_discussions(
+        &discussions,
+    )))
 }
 
 #[tauri::command]
@@ -1159,11 +1227,22 @@ pub(crate) async fn gl_mr_notes(cwd: String, iid: i64) -> Result<serde_json::Val
 /// Create a note (comment) on a MR via `glab api`.
 ///
 /// Returns the created note as raw JSON — parsed TypeScript-side.
-fn gl_mr_create_note_inner(cwd: String, iid: i64, body: String) -> Result<serde_json::Value, String> {
+fn gl_mr_create_note_inner(
+    cwd: String,
+    iid: i64,
+    body: String,
+) -> Result<serde_json::Value, String> {
     let endpoint = format!("projects/:fullpath/merge_requests/{}/notes", iid);
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["api", "-X", "POST", &endpoint, "-f", &format!("body={}", body)])
-        .current_dir(&cwd);
+    cmd.args([
+        "api",
+        "-X",
+        "POST",
+        &endpoint,
+        "-f",
+        &format!("body={}", body),
+    ])
+    .current_dir(&cwd);
     let output = output_with_timeout(cmd, GLAB_TIMEOUT)
         .map_err(|e| format!("glab api create note: {}", e))?;
 
@@ -1190,14 +1269,26 @@ pub(crate) async fn gl_mr_create_note(
 }
 
 /// Update a note on a MR via `glab api`.
-fn gl_mr_update_note_inner(cwd: String, iid: i64, note_id: i64, body: String) -> Result<(), String> {
+fn gl_mr_update_note_inner(
+    cwd: String,
+    iid: i64,
+    note_id: i64,
+    body: String,
+) -> Result<(), String> {
     let endpoint = format!(
         "projects/:fullpath/merge_requests/{}/notes/{}",
         iid, note_id
     );
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["api", "-X", "PUT", &endpoint, "-f", &format!("body={}", body)])
-        .current_dir(&cwd);
+    cmd.args([
+        "api",
+        "-X",
+        "PUT",
+        &endpoint,
+        "-f",
+        &format!("body={}", body),
+    ])
+    .current_dir(&cwd);
     let output = output_with_timeout(cmd, GLAB_TIMEOUT)
         .map_err(|e| format!("glab api update note: {}", e))?;
 
@@ -1229,7 +1320,8 @@ fn gl_mr_delete_note_inner(cwd: String, iid: i64, note_id: i64) -> Result<(), St
         iid, note_id
     );
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["api", "-X", "DELETE", &endpoint]).current_dir(&cwd);
+    cmd.args(["api", "-X", "DELETE", &endpoint])
+        .current_dir(&cwd);
     let output = output_with_timeout(cmd, GLAB_TIMEOUT)
         .map_err(|e| format!("glab api delete note: {}", e))?;
 
@@ -1243,11 +1335,7 @@ fn gl_mr_delete_note_inner(cwd: String, iid: i64, note_id: i64) -> Result<(), St
 }
 
 #[tauri::command]
-pub(crate) async fn gl_mr_delete_note(
-    cwd: String,
-    iid: i64,
-    note_id: i64,
-) -> Result<(), String> {
+pub(crate) async fn gl_mr_delete_note(cwd: String, iid: i64, note_id: i64) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || gl_mr_delete_note_inner(cwd, iid, note_id))
         .await
         .map_err(|e| e.to_string())?
@@ -1257,8 +1345,10 @@ pub(crate) async fn gl_mr_delete_note(
 #[tauri::command]
 fn gl_approve_mr_inner(cwd: String, iid: i64) -> Result<(), String> {
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["mr", "approve", &iid.to_string()]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr approve: {}", e))?;
+    cmd.args(["mr", "approve", &iid.to_string()])
+        .current_dir(&cwd);
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab mr approve: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -1280,13 +1370,11 @@ pub(crate) async fn gl_approve_mr(cwd: String, iid: i64) -> Result<(), String> {
 ///
 /// Returns raw JSON — parsed TypeScript-side into PrReview[].
 fn gl_list_reviews_inner(cwd: String, iid: i64) -> Result<serde_json::Value, String> {
-    let endpoint = format!(
-        "projects/:fullpath/merge_requests/{}/approvals",
-        iid
-    );
+    let endpoint = format!("projects/:fullpath/merge_requests/{}/approvals", iid);
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", &endpoint]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api approvals: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api approvals: {}", e))?;
 
     if !output.status.success() {
         // Not all GitLab tiers have the approvals API — return empty gracefully.
@@ -1308,7 +1396,8 @@ pub(crate) async fn gl_list_reviews(cwd: String, iid: i64) -> Result<serde_json:
 fn gl_current_user_inner(cwd: String) -> Result<String, String> {
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", "/user"]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api /user: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api /user: {}", e))?;
 
     if !output.status.success() {
         return Err(format!(
@@ -1318,8 +1407,8 @@ fn gl_current_user_inner(cwd: String) -> Result<String, String> {
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let user: serde_json::Value = serde_json::from_str(stdout.trim())
-        .map_err(|e| format!("Parse user: {}", e))?;
+    let user: serde_json::Value =
+        serde_json::from_str(stdout.trim()).map_err(|e| format!("Parse user: {}", e))?;
 
     Ok(user
         .get("username")
@@ -1338,8 +1427,10 @@ pub(crate) async fn gl_current_user(cwd: String) -> Result<String, String> {
 /// List reviewer candidates (project members with push access) via `glab api`.
 fn gl_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidate>, String> {
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["api", "projects/:fullpath/members/all?per_page=100"]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api members: {}", e))?;
+    cmd.args(["api", "projects/:fullpath/members/all?per_page=100"])
+        .current_dir(&cwd);
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api members: {}", e))?;
 
     if !output.status.success() {
         return Ok(Vec::new()); // Non-fatal
@@ -1363,10 +1454,7 @@ fn gl_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidate>, S
             }
             Some(ReviewerCandidate {
                 login: login.to_string(),
-                name: m
-                    .get("name")
-                    .and_then(|v| v.as_str())
-                    .map(String::from),
+                name: m.get("name").and_then(|v| v.as_str()).map(String::from),
                 avatar_url: m
                     .get("avatar_url")
                     .and_then(|v| v.as_str())
@@ -1391,8 +1479,11 @@ pub(crate) async fn gl_reviewer_candidates(cwd: String) -> Result<Vec<ReviewerCa
 /// (numeric), not usernames.
 fn gl_resolve_member_id(cwd: &str, username: &str) -> Option<i64> {
     let mut cmd = hidden_cmd("glab");
-    cmd.args(["api", &format!("projects/:fullpath/members/all?query={}", username)])
-        .current_dir(cwd);
+    cmd.args([
+        "api",
+        &format!("projects/:fullpath/members/all?query={}", username),
+    ])
+    .current_dir(cwd);
     let output = output_with_timeout(cmd, GLAB_API_TIMEOUT).ok()?;
     if !output.status.success() {
         return None;
@@ -1409,14 +1500,20 @@ fn gl_resolve_member_id(cwd: &str, username: &str) -> Option<i64> {
 /// Request reviewers on an existing MR (B4, v3.6.0) — `PUT
 /// /merge_requests/:iid` with `reviewer_ids[]=<id>` per resolved username.
 #[tauri::command]
-pub(crate) async fn gl_request_reviewers(cwd: String, iid: i64, usernames: Vec<String>) -> Result<(), String> {
+pub(crate) async fn gl_request_reviewers(
+    cwd: String,
+    iid: i64,
+    usernames: Vec<String>,
+) -> Result<(), String> {
     tauri::async_runtime::spawn_blocking(move || {
         let ids: Vec<i64> = usernames
             .iter()
             .filter_map(|u| gl_resolve_member_id(&cwd, u))
             .collect();
         if ids.is_empty() {
-            return Err("Could not resolve any reviewer username to a GitLab project member.".to_string());
+            return Err(
+                "Could not resolve any reviewer username to a GitLab project member.".to_string(),
+            );
         }
         let endpoint = format!("projects/:fullpath/merge_requests/{}", iid);
         let mut cmd = hidden_cmd("glab");
@@ -1476,7 +1573,7 @@ fn gl_branches_inner(cwd: String) -> Result<Vec<String>, String> {
             break;
         }
     }
-    names.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+    names.sort_by_key(|a| a.to_lowercase());
     Ok(names)
 }
 
@@ -1495,8 +1592,8 @@ fn gl_mr_files_inner(cwd: String, iid: i64) -> Result<Vec<String>, String> {
     );
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", &endpoint]).current_dir(&cwd);
-    let output = output_with_timeout(cmd, GLAB_TIMEOUT)
-        .map_err(|e| format!("glab api mr diffs: {}", e))?;
+    let output =
+        output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api mr diffs: {}", e))?;
 
     if !output.status.success() {
         return Ok(Vec::new());
@@ -1535,6 +1632,11 @@ pub(crate) async fn gl_mr_files(cwd: String, iid: i64) -> Result<Vec<String>, St
 ///   POST /projects/:fullpath/merge_requests/:iid/discussions
 ///   Body: { body, position: { base_sha, start_sha, head_sha, position_type,
 ///            new_path, new_line, old_path, old_line } }
+// Mirrors the `#[tauri::command]` wrapper below 1:1 — its param list is the
+// IPC contract with the frontend (see `backend.ts`). Regrouping fields into
+// a params struct would be a real API-shape change, not a mechanical clippy
+// fix; deferred out of this chore(ci) PR. See PR1 clippy cleanup notes.
+#[allow(clippy::too_many_arguments)]
 fn gl_mr_create_discussion_inner(
     cwd: String,
     iid: i64,
@@ -1551,21 +1653,29 @@ fn gl_mr_create_discussion_inner(
     // Build args for `glab api -X POST`.
     let mut args: Vec<String> = vec![
         "api".to_string(),
-        "-X".to_string(), "POST".to_string(),
+        "-X".to_string(),
+        "POST".to_string(),
         endpoint.clone(),
-        "-f".to_string(), format!("body={}", body),
+        "-f".to_string(),
+        format!("body={}", body),
     ];
 
     // Attach diff-line position when we have enough context.
     let has_position = !base_sha.is_empty() && !head_sha.is_empty() && !path.is_empty();
     if has_position {
         args.extend([
-            "-f".to_string(), format!("position[base_sha]={}", base_sha),
-            "-f".to_string(), format!("position[start_sha]={}", start_sha),
-            "-f".to_string(), format!("position[head_sha]={}", head_sha),
-            "-f".to_string(), "position[position_type]=text".to_string(),
-            "-f".to_string(), format!("position[new_path]={}", path),
-            "-f".to_string(), format!("position[old_path]={}", path),
+            "-f".to_string(),
+            format!("position[base_sha]={}", base_sha),
+            "-f".to_string(),
+            format!("position[start_sha]={}", start_sha),
+            "-f".to_string(),
+            format!("position[head_sha]={}", head_sha),
+            "-f".to_string(),
+            "position[position_type]=text".to_string(),
+            "-f".to_string(),
+            format!("position[new_path]={}", path),
+            "-f".to_string(),
+            format!("position[old_path]={}", path),
         ]);
         if let Some(nl) = new_line {
             args.extend(["-f".to_string(), format!("position[new_line]={}", nl)]);
@@ -1591,6 +1701,11 @@ fn gl_mr_create_discussion_inner(
     serde_json::from_str(stdout.trim()).map_err(|e| format!("Parse discussion: {}", e))
 }
 
+// This signature is the Tauri IPC contract (see `backend.ts`); regrouping
+// its fields into a params struct is a frontend+backend API-shape change,
+// not a mechanical clippy fix. Deferred out of this chore(ci) PR — see PR1
+// clippy cleanup notes.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub(crate) async fn gl_mr_create_discussion(
     cwd: String,
@@ -1604,7 +1719,9 @@ pub(crate) async fn gl_mr_create_discussion(
     path: String,
 ) -> Result<serde_json::Value, String> {
     tauri::async_runtime::spawn_blocking(move || {
-        gl_mr_create_discussion_inner(cwd, iid, body, base_sha, start_sha, head_sha, old_line, new_line, path)
+        gl_mr_create_discussion_inner(
+            cwd, iid, body, base_sha, start_sha, head_sha, old_line, new_line, path,
+        )
     })
     .await
     .map_err(|e| e.to_string())?
@@ -1615,23 +1732,23 @@ pub(crate) async fn gl_mr_create_discussion(
 /// Map a GitLab emoji name to the equivalent GitHub reaction content string.
 fn gl_emoji_to_gh(name: &str) -> &str {
     match name {
-        "thumbsup"   => "+1",
+        "thumbsup" => "+1",
         "thumbsdown" => "-1",
-        "laughing"   => "laugh",
-        "tada"       => "hooray",
+        "laughing" => "laugh",
+        "tada" => "hooray",
         // confused, heart, rocket, eyes share the same name on both platforms
-        other        => other,
+        other => other,
     }
 }
 
 /// Map a GitHub reaction content string to the GitLab emoji name.
 fn gh_content_to_gl(content: &str) -> &str {
     match content {
-        "+1"    => "thumbsup",
-        "-1"    => "thumbsdown",
+        "+1" => "thumbsup",
+        "-1" => "thumbsdown",
         "laugh" => "laughing",
-        "hooray"=> "tada",
-        other   => other,
+        "hooray" => "tada",
+        other => other,
     }
 }
 
@@ -1644,7 +1761,12 @@ fn map_gl_reaction(r: &serde_json::Value) -> serde_json::Value {
 }
 
 /// Run any `glab api` call with optional `-f key=value` fields.
-fn glab_api(cwd: &str, method: &str, endpoint: &str, fields: &[(&str, &str)]) -> Result<serde_json::Value, String> {
+fn glab_api(
+    cwd: &str,
+    method: &str,
+    endpoint: &str,
+    fields: &[(&str, &str)],
+) -> Result<serde_json::Value, String> {
     let mut cmd = hidden_cmd("glab");
     cmd.args(["api", "-X", method, endpoint]);
     for (k, v) in fields {
@@ -1653,18 +1775,28 @@ fn glab_api(cwd: &str, method: &str, endpoint: &str, fields: &[(&str, &str)]) ->
     cmd.current_dir(cwd);
     let output = output_with_timeout(cmd, GLAB_TIMEOUT).map_err(|e| format!("glab api: {}", e))?;
     if !output.status.success() {
-        return Err(format!("glab api {} {}: {}", method, endpoint, String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "glab api {} {}: {}",
+            method,
+            endpoint,
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let trimmed = stdout.trim();
-    if trimmed.is_empty() { return Ok(serde_json::Value::Null); }
+    if trimmed.is_empty() {
+        return Ok(serde_json::Value::Null);
+    }
     serde_json::from_str(trimmed).map_err(|e| format!("parse glab response: {}", e))
 }
 
 fn award_emoji_path(iid: i64, target_type: &str, target_id: i64) -> String {
     match target_type {
         "pr" => format!("projects/:fullpath/merge_requests/{}/award_emoji", iid),
-        _    => format!("projects/:fullpath/merge_requests/{}/notes/{}/award_emoji", iid, target_id),
+        _ => format!(
+            "projects/:fullpath/merge_requests/{}/notes/{}/award_emoji",
+            iid, target_id
+        ),
     }
 }
 
@@ -1682,8 +1814,12 @@ pub(crate) async fn gl_list_reactions(
     tauri::async_runtime::spawn_blocking(move || {
         let path = award_emoji_path(iid, &target_type, target_id);
         let v = glab_api(&cwd, "GET", &path, &[])?;
-        Ok(v.as_array().map(|a| a.iter().map(map_gl_reaction).collect()).unwrap_or_default())
-    }).await.map_err(|e| e.to_string())?
+        Ok(v.as_array()
+            .map(|a| a.iter().map(map_gl_reaction).collect())
+            .unwrap_or_default())
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// Add an award emoji (reaction) to a MR or note.
@@ -1701,7 +1837,9 @@ pub(crate) async fn gl_add_reaction(
         let path = award_emoji_path(iid, &target_type, target_id);
         let v = glab_api(&cwd, "POST", &path, &[("name", &gl_name)])?;
         Ok(map_gl_reaction(&v))
-    }).await.map_err(|e| e.to_string())?
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// Delete an award emoji (reaction) from a MR or note.
@@ -1718,7 +1856,9 @@ pub(crate) async fn gl_delete_reaction(
         let path = format!("{}/{}", base, reaction_id);
         glab_api(&cwd, "DELETE", &path, &[])?;
         Ok(())
-    }).await.map_err(|e| e.to_string())?
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 #[cfg(test)]
@@ -1727,7 +1867,8 @@ mod gl_list_issues_tests {
 
     #[test]
     fn maps_gitlab_issue_json_to_issue() {
-        let v: serde_json::Value = serde_json::from_str(r#"{
+        let v: serde_json::Value = serde_json::from_str(
+            r#"{
             "iid": 12, "title": "Crash", "state": "opened",
             "author": {"username": "alice"},
             "assignees": [{"username": "bob"}],
@@ -1736,7 +1877,9 @@ mod gl_list_issues_tests {
             "created_at": "2026-01-01T00:00:00Z",
             "updated_at": "2026-01-02T00:00:00Z",
             "milestone": {"title": "M1"}
-        }"#).unwrap();
+        }"#,
+        )
+        .unwrap();
         let i = gl_issue_to_issue(&v);
         assert_eq!(i.number, 12);
         assert_eq!(i.state, "open");
@@ -1815,10 +1958,22 @@ mod gl_mergeable_state_tests {
 
     #[test]
     fn falls_back_to_legacy_merge_status_when_detailed_is_absent() {
-        assert_eq!(gl_mergeable_state(&json!({"merge_status": "can_be_merged"})), "MERGEABLE");
-        assert_eq!(gl_mergeable_state(&json!({"merge_status": "cannot_be_merged"})), "CONFLICTING");
-        assert_eq!(gl_mergeable_state(&json!({"merge_status": "cannot_be_merged_recheck"})), "CONFLICTING");
-        assert_eq!(gl_mergeable_state(&json!({"merge_status": "unchecked"})), "UNKNOWN");
+        assert_eq!(
+            gl_mergeable_state(&json!({"merge_status": "can_be_merged"})),
+            "MERGEABLE"
+        );
+        assert_eq!(
+            gl_mergeable_state(&json!({"merge_status": "cannot_be_merged"})),
+            "CONFLICTING"
+        );
+        assert_eq!(
+            gl_mergeable_state(&json!({"merge_status": "cannot_be_merged_recheck"})),
+            "CONFLICTING"
+        );
+        assert_eq!(
+            gl_mergeable_state(&json!({"merge_status": "unchecked"})),
+            "UNKNOWN"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/gitlab.rs
+++ b/apps/desktop/src-tauri/src/commands/gitlab.rs
@@ -1463,7 +1463,7 @@ fn gl_reviewer_candidates_inner(cwd: String) -> Result<Vec<ReviewerCandidate>, S
         })
         .collect();
 
-    candidates.sort_by(|a, b| a.login.to_lowercase().cmp(&b.login.to_lowercase()));
+    candidates.sort_by_key(|a| a.login.to_lowercase());
     Ok(candidates)
 }
 

--- a/apps/desktop/src-tauri/src/commands/mcp_catalog.rs
+++ b/apps/desktop/src-tauri/src/commands/mcp_catalog.rs
@@ -2,15 +2,15 @@
 //!
 //! Four commands:
 //!   - `mcp_detect_configs`   — discover MCP config files on disk (Claude Desktop,
-//!                              Claude Code, Cursor, Windsurf) with full server_keys list.
+//!     Claude Code, Cursor, Windsurf) with full server_keys list.
 //!   - `mcp_read_config`      — parse a config file and return its current `mcpServers`
-//!                              map as a JSON string.
+//!     map as a JSON string.
 //!   - `mcp_install_server`   — merge a server fragment into one or more config files.
 //!   - `mcp_uninstall_server` — remove a server key from one or more config files.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,8 +59,7 @@ fn read_json(path: &PathBuf) -> Result<Value, String> {
     }
     let raw = std::fs::read_to_string(path)
         .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
-    serde_json::from_str(&raw)
-        .map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
+    serde_json::from_str(&raw).map_err(|e| format!("Failed to parse {}: {}", path.display(), e))
 }
 
 /// Return all keys under `mcpServers` in the given JSON value.
@@ -76,7 +75,7 @@ fn mcp_server_keys(value: &Value) -> Vec<String> {
 // Known config locations
 // ---------------------------------------------------------------------------
 
-fn known_configs(home: &PathBuf) -> Vec<(String, PathBuf)> {
+fn known_configs(home: &Path) -> Vec<(String, PathBuf)> {
     let mut list = vec![
         (
             "Claude Desktop".to_string(),
@@ -88,10 +87,7 @@ fn known_configs(home: &PathBuf) -> Vec<(String, PathBuf)> {
             // Claude Code stores global settings (including mcpServers) in ~/.claude.json
             home.join(".claude.json"),
         ),
-        (
-            "Cursor (global)".to_string(),
-            home.join(".cursor/mcp.json"),
-        ),
+        ("Cursor (global)".to_string(), home.join(".cursor/mcp.json")),
         (
             "Windsurf (global)".to_string(),
             home.join(".windsurf/mcp.json"),
@@ -144,11 +140,17 @@ pub(crate) async fn mcp_detect_configs() -> Result<Vec<McpConfigFile>, String> {
         // Skip platform-specific entries that don't apply to the current OS.
         if !exists {
             #[cfg(target_os = "windows")]
-            if label.contains("Linux") { continue; }
+            if label.contains("Linux") {
+                continue;
+            }
             #[cfg(target_os = "linux")]
-            if label.contains("Windows") { continue; }
+            if label.contains("Windows") {
+                continue;
+            }
             #[cfg(target_os = "macos")]
-            if label.contains("Windows") || label.contains("Linux") { continue; }
+            if label.contains("Windows") || label.contains("Linux") {
+                continue;
+            }
         }
 
         let server_keys = if exists {
@@ -179,8 +181,7 @@ pub(crate) async fn mcp_read_config(path: String) -> Result<String, String> {
         .get("mcpServers")
         .cloned()
         .unwrap_or(Value::Object(Map::new()));
-    serde_json::to_string(&servers)
-        .map_err(|e| format!("Failed to serialize mcpServers: {}", e))
+    serde_json::to_string(&servers).map_err(|e| format!("Failed to serialize mcpServers: {}", e))
 }
 
 /// Merge a server entry into each specified config file.
@@ -198,8 +199,8 @@ pub(crate) async fn mcp_install_server(
     server_json: String,
     config_paths: Vec<String>,
 ) -> Result<(), String> {
-    let fragment: Value = serde_json::from_str(&server_json)
-        .map_err(|e| format!("Invalid server JSON: {}", e))?;
+    let fragment: Value =
+        serde_json::from_str(&server_json).map_err(|e| format!("Invalid server JSON: {}", e))?;
 
     for path_str in &config_paths {
         let path = PathBuf::from(path_str);
@@ -240,9 +241,13 @@ pub(crate) async fn mcp_uninstall_server(
 ) -> Result<(), String> {
     for path_str in &config_paths {
         let path = PathBuf::from(path_str);
-        if !path.exists() { continue; }
+        if !path.exists() {
+            continue;
+        }
         let mut root = read_json(&path)?;
-        if root.is_null() { continue; }
+        if root.is_null() {
+            continue;
+        }
         if let Some(servers) = root.get_mut("mcpServers").and_then(|v| v.as_object_mut()) {
             servers.remove(&server_key);
         }

--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -1,8 +1,8 @@
 pub(crate) mod ai;
-pub(crate) mod curl_util;
 pub(crate) mod azure;
 pub(crate) mod bitbucket;
 pub(crate) mod credentials;
+pub(crate) mod curl_util;
 pub(crate) mod files;
 pub(crate) mod gh;
 pub(crate) mod github_api;

--- a/apps/desktop/src-tauri/src/commands/network.rs
+++ b/apps/desktop/src-tauri/src/commands/network.rs
@@ -94,17 +94,15 @@ fn parse_remote_host_port(url: &str) -> Option<HostPort> {
     // IPv6 literals: `[::1]:443` — split on the closing bracket if present,
     // otherwise on the last colon.
     let (host, port) = if let Some(stripped) = host_port.strip_prefix('[') {
-        match stripped.find(']') {
-            Some(end) => {
-                let host = &stripped[..end];
-                let after = &stripped[end + 1..];
-                let port = after
-                    .strip_prefix(':')
-                    .and_then(|s| s.parse::<u16>().ok())
-                    .unwrap_or(default_port);
-                (host.to_string(), port)
-            }
-            None => return None,
+        {
+            let end = stripped.find(']')?;
+            let host = &stripped[..end];
+            let after = &stripped[end + 1..];
+            let port = after
+                .strip_prefix(':')
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(default_port);
+            (host.to_string(), port)
         }
     } else {
         match host_port.rsplit_once(':') {

--- a/apps/desktop/src-tauri/src/commands/network.rs
+++ b/apps/desktop/src-tauri/src/commands/network.rs
@@ -82,10 +82,7 @@ fn parse_remote_host_port(url: &str) -> Option<HostPort> {
         _ => return None,
     };
     // Drop the path / query / fragment.
-    let authority = rest
-        .split(|c: char| c == '/' || c == '?' || c == '#')
-        .next()
-        .unwrap_or("");
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
     // Strip optional `user[:password]@`.
     let host_port = match authority.rfind('@') {
         Some(at) => &authority[at + 1..],
@@ -246,7 +243,8 @@ mod tests {
         // Empty string is a valid input from the caller's point of view but
         // we can't extract a host, so it must short-circuit to false rather
         // than block on DNS or surface an error.
-        let r = tauri::async_runtime::block_on(check_remote_reachable("".to_string(), 250)).unwrap();
+        let r =
+            tauri::async_runtime::block_on(check_remote_reachable("".to_string(), 250)).unwrap();
         assert!(!r);
     }
 

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -1,10 +1,10 @@
 use crate::git::*;
 use crate::types::*;
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::Instant;
-use rayon::prelude::*;
 
 // ─── Git stage / unstage ─────────────────────────────────────
 
@@ -16,7 +16,9 @@ pub(crate) async fn git_stage(cwd: String, paths: Vec<String>) -> Result<(), Str
     for p in &paths {
         cmd.arg(p);
     }
-    let output = cmd.output().map_err(|e| format!("Failed to run git add: {}", e))?;
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run git add: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git add failed: {}", stderr));
@@ -32,7 +34,9 @@ pub(crate) async fn git_unstage(cwd: String, paths: Vec<String>) -> Result<(), S
     for p in &paths {
         cmd.arg(p);
     }
-    let output = cmd.output().map_err(|e| format!("Failed to run git reset: {}", e))?;
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run git reset: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git reset failed: {}", stderr));
@@ -47,12 +51,18 @@ pub(crate) async fn git_stage_patch(cwd: String, patch: String) -> Result<(), St
     cmd.args(["apply", "--cached", "--unidiff-zero", "-"])
         .current_dir(&cwd)
         .stdin(std::process::Stdio::piped());
-    let mut child = cmd.spawn().map_err(|e| format!("Failed to run git apply: {}", e))?;
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to run git apply: {}", e))?;
     if let Some(ref mut stdin) = child.stdin {
         use std::io::Write;
-        stdin.write_all(patch.as_bytes()).map_err(|e| format!("Failed to write patch: {}", e))?;
+        stdin
+            .write_all(patch.as_bytes())
+            .map_err(|e| format!("Failed to write patch: {}", e))?;
     }
-    let output = child.wait_with_output().map_err(|e| format!("Failed to wait for git apply: {}", e))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait for git apply: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git apply failed: {}", stderr));
@@ -67,12 +77,18 @@ pub(crate) async fn git_unstage_patch(cwd: String, patch: String) -> Result<(), 
     cmd.args(["apply", "--cached", "--reverse", "--unidiff-zero", "-"])
         .current_dir(&cwd)
         .stdin(std::process::Stdio::piped());
-    let mut child = cmd.spawn().map_err(|e| format!("Failed to run git apply: {}", e))?;
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("Failed to run git apply: {}", e))?;
     if let Some(ref mut stdin) = child.stdin {
         use std::io::Write;
-        stdin.write_all(patch.as_bytes()).map_err(|e| format!("Failed to write patch: {}", e))?;
+        stdin
+            .write_all(patch.as_bytes())
+            .map_err(|e| format!("Failed to write patch: {}", e))?;
     }
-    let output = child.wait_with_output().map_err(|e| format!("Failed to wait for git apply: {}", e))?;
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("Failed to wait for git apply: {}", e))?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git apply --reverse failed: {}", stderr));
@@ -95,8 +111,10 @@ pub(crate) async fn git_commit(
     // Inject identity overrides before the `commit` sub-command so git sees them.
     if let (Some(ref name), Some(ref email)) = (&identity_name, &identity_email) {
         if !name.is_empty() && !email.is_empty() {
-            cmd.arg("-c").arg(format!("user.name={}", name))
-               .arg("-c").arg(format!("user.email={}", email));
+            cmd.arg("-c")
+                .arg(format!("user.name={}", name))
+                .arg("-c")
+                .arg(format!("user.email={}", email));
         }
     }
     let output = cmd
@@ -104,7 +122,12 @@ pub(crate) async fn git_commit(
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git commit: {}", e))?;
-    record_cmd(&format!("git commit -m {:?}", message), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git commit -m {:?}", message),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -118,7 +141,9 @@ pub(crate) async fn git_commit(
         .output()
         .map_err(|e| format!("Failed to get commit hash: {}", e))?;
 
-    let hash = String::from_utf8_lossy(&log_output.stdout).trim().to_string();
+    let hash = String::from_utf8_lossy(&log_output.stdout)
+        .trim()
+        .to_string();
     Ok(hash)
 }
 
@@ -131,7 +156,12 @@ pub(crate) async fn git_amend_commit(cwd: String, message: String) -> Result<Str
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git commit --amend: {}", e))?;
-    record_cmd(&format!("git commit --amend -m {:?}", message), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git commit --amend -m {:?}", message),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -144,7 +174,9 @@ pub(crate) async fn git_amend_commit(cwd: String, message: String) -> Result<Str
         .output()
         .map_err(|e| format!("Failed to get commit hash: {}", e))?;
 
-    let hash = String::from_utf8_lossy(&log_output.stdout).trim().to_string();
+    let hash = String::from_utf8_lossy(&log_output.stdout)
+        .trim()
+        .to_string();
     Ok(hash)
 }
 
@@ -187,11 +219,9 @@ pub(crate) async fn git_split_commit(
             .map_err(|e| format!("Failed to read status: {}", e))?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         if !stdout.trim().is_empty() {
-            return Err(
-                "Working tree must be clean before splitting a commit — \
+            return Err("Working tree must be clean before splitting a commit — \
                  commit, stash, or discard your changes first."
-                    .to_string(),
-            );
+                .to_string());
         }
     }
 
@@ -214,8 +244,7 @@ pub(crate) async fn git_split_commit(
         let parent_count = tokens.len().saturating_sub(1);
         if parent_count == 0 {
             return Err(
-                "Cannot split the root commit — it has no parent to reset onto."
-                    .to_string(),
+                "Cannot split the root commit — it has no parent to reset onto.".to_string(),
             );
         }
         if parent_count > 1 {
@@ -300,7 +329,9 @@ pub(crate) async fn git_split_commit(
             .current_dir(&cwd)
             .output()
             .map_err(|e| format!("Failed to read first hash: {}", e))?;
-        String::from_utf8_lossy(&hash_output.stdout).trim().to_string()
+        String::from_utf8_lossy(&hash_output.stdout)
+            .trim()
+            .to_string()
     };
 
     // Step 5: stage everything remaining (working tree ↔ index = inverse of first_patch)
@@ -340,7 +371,9 @@ pub(crate) async fn git_split_commit(
             .current_dir(&cwd)
             .output()
             .map_err(|e| format!("Failed to read second hash: {}", e))?;
-        String::from_utf8_lossy(&hash_output.stdout).trim().to_string()
+        String::from_utf8_lossy(&hash_output.stdout)
+            .trim()
+            .to_string()
     };
 
     Ok(GitSplitCommitResult {
@@ -352,7 +385,11 @@ pub(crate) async fn git_split_commit(
 // ─── Git push / pull / merge ─────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn git_push(cwd: String, set_upstream: Option<bool>, force: Option<bool>) -> Result<GitPushPullResult, String> {
+pub(crate) async fn git_push(
+    cwd: String,
+    set_upstream: Option<bool>,
+    force: Option<bool>,
+) -> Result<GitPushPullResult, String> {
     // Shared guard: push is network-bound and touches only refs, not the
     // index/worktree, so it need not exclude reads — but it must not overlap a
     // writer (checkout/pull/rebase) mutating the refs it is about to publish.
@@ -370,7 +407,12 @@ pub(crate) async fn git_push(cwd: String, set_upstream: Option<bool>, force: Opt
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git push: {}", e))?;
-    record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git {}", args.join(" ")),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -400,7 +442,12 @@ pub(crate) async fn git_fetch(cwd: String) -> Result<GitPushPullResult, String> 
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git fetch: {}", e))?;
-    record_cmd("git fetch --prune", &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        "git fetch --prune",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -425,7 +472,12 @@ pub(crate) async fn git_merge(cwd: String, branch: String) -> Result<GitPushPull
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git merge: {}", e))?;
-    record_cmd(&format!("git merge {}", branch), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git merge {}", branch),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -454,7 +506,12 @@ pub(crate) async fn git_merge_abort(cwd: String) -> Result<GitPushPullResult, St
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git merge --abort: {}", e))?;
-    record_cmd("git merge --abort", &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        "git merge --abort",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
@@ -480,7 +537,12 @@ pub(crate) async fn git_merge_continue(cwd: String) -> Result<GitPushPullResult,
         .env("GIT_EDITOR", "true")
         .output()
         .map_err(|e| format!("Failed to run git merge --continue: {}", e))?;
-    record_cmd("git merge --continue", &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        "git merge --continue",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -497,7 +559,11 @@ pub(crate) async fn git_merge_continue(cwd: String) -> Result<GitPushPullResult,
 }
 
 #[tauri::command]
-pub(crate) async fn git_pull(cwd: String, strategy: String, autostash: Option<bool>) -> Result<GitPushPullResult, String> {
+pub(crate) async fn git_pull(
+    cwd: String,
+    strategy: String,
+    autostash: Option<bool>,
+) -> Result<GitPushPullResult, String> {
     let _t0 = Instant::now();
     // Pass the strategy flag EXPLICITLY so the user's pull-mode choice is
     // authoritative. A bare `git pull` defers to the ambient `pull.rebase`
@@ -521,7 +587,12 @@ pub(crate) async fn git_pull(cwd: String, strategy: String, autostash: Option<bo
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git pull: {}", e))?;
-    record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git {}", args.join(" ")),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
@@ -554,7 +625,12 @@ pub(crate) async fn git_rebase_action(cwd: String, action: String) -> Result<(),
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git rebase --{}: {}", arg, e))?;
-    record_cmd(&format!("git rebase --{}", arg), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git rebase --{}", arg),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
         let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -643,8 +719,10 @@ pub(crate) async fn git_interactive_rebase(
 
     let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
     let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if stderr.contains("CONFLICT") || stderr.contains("could not apply")
-        || stdout.contains("CONFLICT") || stdout.contains("could not apply")
+    if stderr.contains("CONFLICT")
+        || stderr.contains("could not apply")
+        || stdout.contains("CONFLICT")
+        || stdout.contains("could not apply")
     {
         return Ok(InteractiveRebaseResult { conflict: true });
     }
@@ -655,7 +733,11 @@ pub(crate) async fn git_interactive_rebase(
 // ─── Git discard ───────────────────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn git_discard(cwd: String, paths: Vec<String>, untracked: bool) -> Result<(), String> {
+pub(crate) async fn git_discard(
+    cwd: String,
+    paths: Vec<String>,
+    untracked: bool,
+) -> Result<(), String> {
     let _repo = repo_lock::write(&cwd);
     if untracked {
         let mut cmd = git_cmd();
@@ -663,7 +745,9 @@ pub(crate) async fn git_discard(cwd: String, paths: Vec<String>, untracked: bool
         for p in &paths {
             cmd.arg(p);
         }
-        let output = cmd.output().map_err(|e| format!("Failed to run git clean: {}", e))?;
+        let output = cmd
+            .output()
+            .map_err(|e| format!("Failed to run git clean: {}", e))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(format!("git clean failed: {}", stderr));
@@ -674,7 +758,9 @@ pub(crate) async fn git_discard(cwd: String, paths: Vec<String>, untracked: bool
         for p in &paths {
             cmd.arg(p);
         }
-        let output = cmd.output().map_err(|e| format!("Failed to run git checkout: {}", e))?;
+        let output = cmd
+            .output()
+            .map_err(|e| format!("Failed to run git checkout: {}", e))?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(format!("git checkout failed: {}", stderr));
@@ -689,7 +775,8 @@ pub(crate) async fn git_discard(cwd: String, paths: Vec<String>, untracked: bool
         let to_reset: Vec<&String> = paths.iter().filter(|p| sub_paths.contains(*p)).collect();
         if !to_reset.is_empty() {
             let mut cmd = git_cmd();
-            cmd.args(["submodule", "update", "--force", "--"]).current_dir(&cwd);
+            cmd.args(["submodule", "update", "--force", "--"])
+                .current_dir(&cwd);
             for p in &to_reset {
                 cmd.arg(p);
             }
@@ -713,7 +800,13 @@ fn declared_submodule_paths(cwd: &str) -> std::collections::HashSet<String> {
         return out;
     }
     if let Ok(cfg) = git_cmd()
-        .args(["config", "--file", ".gitmodules", "--get-regexp", r"\.path$"])
+        .args([
+            "config",
+            "--file",
+            ".gitmodules",
+            "--get-regexp",
+            r"\.path$",
+        ])
         .current_dir(cwd)
         .output()
     {
@@ -732,7 +825,10 @@ fn declared_submodule_paths(cwd: &str) -> std::collections::HashSet<String> {
 // ─── Git branches ──────────────────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn git_branches(cwd: String, default_branch: Option<String>) -> Result<Vec<GitBranch>, String> {
+pub(crate) async fn git_branches(
+    cwd: String,
+    default_branch: Option<String>,
+) -> Result<Vec<GitBranch>, String> {
     let _repo = repo_lock::read(&cwd);
     let main_name = resolve_default_branch(&cwd, default_branch.as_deref());
     let output = git_cmd()
@@ -758,16 +854,24 @@ pub(crate) async fn git_branches(cwd: String, default_branch: Option<String>) ->
 
     for line in stdout.lines() {
         let line = line.trim();
-        if line.is_empty() { continue; }
+        if line.is_empty() {
+            continue;
+        }
 
         let is_current = line.starts_with('*');
         let line = if is_current { &line[1..] } else { line };
 
         let parts: Vec<&str> = line.split('\x1f').collect();
-        if parts.len() < 3 { continue; }
+        if parts.len() < 3 {
+            continue;
+        }
 
         let name = parts[0].to_string();
-        let upstream = if parts[1].is_empty() { None } else { Some(parts[1].to_string()) };
+        let upstream = if parts[1].is_empty() {
+            None
+        } else {
+            Some(parts[1].to_string())
+        };
         let track_info = parts[2];
 
         let mut ahead: i32 = 0;
@@ -775,15 +879,31 @@ pub(crate) async fn git_branches(cwd: String, default_branch: Option<String>) ->
         if !track_info.is_empty() {
             for part in track_info.split(", ") {
                 if part.starts_with("ahead ") {
-                    ahead = part.strip_prefix("ahead ").unwrap_or("0").parse().unwrap_or(0);
+                    ahead = part
+                        .strip_prefix("ahead ")
+                        .unwrap_or("0")
+                        .parse()
+                        .unwrap_or(0);
                 } else if part.starts_with("behind ") {
-                    behind = part.strip_prefix("behind ").unwrap_or("0").parse().unwrap_or(0);
+                    behind = part
+                        .strip_prefix("behind ")
+                        .unwrap_or("0")
+                        .parse()
+                        .unwrap_or(0);
                 }
             }
         }
 
-        let last_commit = if parts.len() > 3 { parts[3].to_string() } else { String::new() };
-        let last_commit_date = if parts.len() > 4 { parts[4].trim().to_string() } else { String::new() };
+        let last_commit = if parts.len() > 3 {
+            parts[3].to_string()
+        } else {
+            String::new()
+        };
+        let last_commit_date = if parts.len() > 4 {
+            parts[4].trim().to_string()
+        } else {
+            String::new()
+        };
 
         let main_count = if parts.len() > 5 {
             let ab = parts[5].split_whitespace().next().unwrap_or("0");
@@ -792,7 +912,9 @@ pub(crate) async fn git_branches(cwd: String, default_branch: Option<String>) ->
             0
         };
 
-        if name.contains("HEAD ->") || name == "origin/HEAD" { continue; }
+        if name.contains("HEAD ->") || name == "origin/HEAD" {
+            continue;
+        }
 
         let is_remote = name.starts_with("origin/") || name.starts_with("remotes/");
         let clean_name = if name.starts_with("remotes/") {
@@ -803,17 +925,20 @@ pub(crate) async fn git_branches(cwd: String, default_branch: Option<String>) ->
 
         main_counts.insert(clean_name.clone(), main_count);
 
-        branches_raw.push((GitBranch {
-            name: clean_name,
-            is_current,
-            is_remote,
-            upstream: upstream.clone(),
-            ahead,
-            behind,
-            main_commit_count: 0, // Fill later
-            last_commit,
-            last_commit_date,
-        }, upstream));
+        branches_raw.push((
+            GitBranch {
+                name: clean_name,
+                is_current,
+                is_remote,
+                upstream: upstream.clone(),
+                ahead,
+                behind,
+                main_commit_count: 0, // Fill later
+                last_commit,
+                last_commit_date,
+            },
+            upstream,
+        ));
     }
 
     let mut branches = Vec::new();
@@ -834,32 +959,51 @@ pub(crate) async fn git_branches(cwd: String, default_branch: Option<String>) ->
 }
 
 #[tauri::command]
-pub(crate) async fn git_create_branch(cwd: String, name: String, checkout: bool, start_point: Option<String>) -> Result<(), String> {
+pub(crate) async fn git_create_branch(
+    cwd: String,
+    name: String,
+    checkout: bool,
+    start_point: Option<String>,
+) -> Result<(), String> {
     let _repo = repo_lock::write(&cwd);
     if checkout {
         let mut args = vec!["checkout", "-b", &name];
-        if let Some(ref sp) = start_point { args.push(sp); }
+        if let Some(ref sp) = start_point {
+            args.push(sp);
+        }
         let _t0 = Instant::now();
         let output = git_cmd()
             .args(&args)
             .current_dir(&cwd)
             .output()
             .map_err(|e| format!("Failed to create branch: {}", e))?;
-        record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+        record_cmd(
+            &format!("git {}", args.join(" ")),
+            &cwd,
+            _t0.elapsed().as_millis() as u64,
+            output.status.code().unwrap_or(-1),
+        );
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(format!("git checkout -b failed: {}", stderr));
         }
     } else {
         let mut args = vec!["branch", &name];
-        if let Some(ref sp) = start_point { args.push(sp); }
+        if let Some(ref sp) = start_point {
+            args.push(sp);
+        }
         let _t0 = Instant::now();
         let output = git_cmd()
             .args(&args)
             .current_dir(&cwd)
             .output()
             .map_err(|e| format!("Failed to create branch: {}", e))?;
-        record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+        record_cmd(
+            &format!("git {}", args.join(" ")),
+            &cwd,
+            _t0.elapsed().as_millis() as u64,
+            output.status.code().unwrap_or(-1),
+        );
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             return Err(format!("git branch failed: {}", stderr));
@@ -877,7 +1021,12 @@ pub(crate) async fn git_switch_branch(cwd: String, name: String) -> Result<(), S
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to switch branch: {}", e))?;
-    record_cmd(&format!("git checkout {}", name), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git checkout {}", name),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git checkout failed: {}", stderr));
@@ -886,7 +1035,11 @@ pub(crate) async fn git_switch_branch(cwd: String, name: String) -> Result<(), S
 }
 
 #[tauri::command]
-pub(crate) async fn git_delete_branch(cwd: String, name: String, force: bool) -> Result<(), String> {
+pub(crate) async fn git_delete_branch(
+    cwd: String,
+    name: String,
+    force: bool,
+) -> Result<(), String> {
     let _repo = repo_lock::write(&cwd);
     let flag = if force { "-D" } else { "-d" };
     let _t0 = Instant::now();
@@ -895,7 +1048,12 @@ pub(crate) async fn git_delete_branch(cwd: String, name: String, force: bool) ->
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to delete branch: {}", e))?;
-    record_cmd(&format!("git branch {} {}", flag, name), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git branch {} {}", flag, name),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git branch {} failed: {}", flag, stderr));
@@ -904,14 +1062,23 @@ pub(crate) async fn git_delete_branch(cwd: String, name: String, force: bool) ->
 }
 
 #[tauri::command]
-pub(crate) async fn git_delete_remote_branch(cwd: String, remote: String, name: String) -> Result<(), String> {
+pub(crate) async fn git_delete_remote_branch(
+    cwd: String,
+    remote: String,
+    name: String,
+) -> Result<(), String> {
     let _t0 = Instant::now();
     let output = git_cmd()
         .args(["push", &remote, "--delete", &name])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to delete remote branch: {}", e))?;
-    record_cmd(&format!("git push {} --delete {}", remote, name), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git push {} --delete {}", remote, name),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git push --delete failed: {}", stderr));
@@ -920,7 +1087,11 @@ pub(crate) async fn git_delete_remote_branch(cwd: String, remote: String, name: 
 }
 
 #[tauri::command]
-pub(crate) async fn git_rename_branch(cwd: String, old_name: String, new_name: String) -> Result<(), String> {
+pub(crate) async fn git_rename_branch(
+    cwd: String,
+    old_name: String,
+    new_name: String,
+) -> Result<(), String> {
     let output = git_cmd()
         .args(["branch", "-m", &old_name, &new_name])
         .current_dir(&cwd)
@@ -950,7 +1121,12 @@ pub(crate) async fn git_stash(cwd: String, message: Option<String>) -> Result<()
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git stash: {}", e))?;
-    record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git {}", args.join(" ")),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git stash failed: {}", stderr));
@@ -967,7 +1143,12 @@ pub(crate) async fn git_stash_pop(cwd: String) -> Result<(), String> {
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git stash pop: {}", e))?;
-    record_cmd("git stash pop", &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        "git stash pop",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         return Err(format!("git stash pop failed: {}", stderr));
@@ -998,7 +1179,10 @@ pub(crate) async fn git_stash_list(cwd: String) -> Result<Vec<StashEntry>, Strin
             let (branch, message) = if subject.starts_with("On ") {
                 // "On <branch>: <custom-message>"
                 if let Some(colon_pos) = subject.find(": ") {
-                    (subject[3..colon_pos].to_string(), subject[colon_pos + 2..].to_string())
+                    (
+                        subject[3..colon_pos].to_string(),
+                        subject[colon_pos + 2..].to_string(),
+                    )
                 } else {
                     (String::new(), subject.to_string())
                 }
@@ -1008,7 +1192,11 @@ pub(crate) async fn git_stash_list(cwd: String) -> Result<Vec<StashEntry>, Strin
                     let branch = subject[7..colon_pos].to_string();
                     // drop the leading "<sha> " from the commit message portion
                     let rest = &subject[colon_pos + 2..];
-                    let msg = rest.splitn(2, ' ').nth(1).unwrap_or(rest).to_string();
+                    let msg = rest
+                        .split_once(' ')
+                        .map(|x| x.1)
+                        .unwrap_or(rest)
+                        .to_string();
                     (branch, msg)
                 } else {
                     (String::new(), subject.to_string())
@@ -1040,7 +1228,12 @@ pub(crate) async fn git_stash_apply(cwd: String, index: usize) -> Result<(), Str
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to apply stash: {}", e))?;
-    record_cmd(&format!("git stash apply {}", stash_ref), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git stash apply {}", stash_ref),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         return Err(format!(
             "git stash apply failed: {}",
@@ -1106,7 +1299,10 @@ pub(crate) async fn git_stash_show(cwd: String, index: usize) -> Result<String, 
 // ─── Cherry-pick ─────────────────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn git_cherry_pick(cwd: String, hashes: Vec<String>) -> Result<GitPushPullResult, String> {
+pub(crate) async fn git_cherry_pick(
+    cwd: String,
+    hashes: Vec<String>,
+) -> Result<GitPushPullResult, String> {
     let _repo = repo_lock::write(&cwd);
     let git = git_binary();
     let mut args = vec!["cherry-pick".to_string()];
@@ -1118,7 +1314,12 @@ pub(crate) async fn git_cherry_pick(cwd: String, hashes: Vec<String>) -> Result<
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git cherry-pick: {}", e))?;
-    record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git {}", args.join(" ")),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
@@ -1126,7 +1327,11 @@ pub(crate) async fn git_cherry_pick(cwd: String, hashes: Vec<String>) -> Result<
 
     Ok(GitPushPullResult {
         success: output.status.success(),
-        message: if output.status.success() { stdout } else { stderr },
+        message: if output.status.success() {
+            stdout
+        } else {
+            stderr
+        },
         conflicts: Some(has_conflicts),
     })
 }
@@ -1139,7 +1344,12 @@ pub(crate) async fn git_cherry_pick_abort(cwd: String) -> Result<(), String> {
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to abort cherry-pick: {}", e))?;
-    record_cmd("git cherry-pick --abort", &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        "git cherry-pick --abort",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         return Err(format!(
             "cherry-pick --abort failed: {}",
@@ -1159,14 +1369,23 @@ pub(crate) async fn git_cherry_pick_continue(cwd: String) -> Result<GitPushPullR
         .env("GIT_EDITOR", "true") // skip editor for commit message
         .output()
         .map_err(|e| format!("Failed to continue cherry-pick: {}", e))?;
-    record_cmd("git cherry-pick --continue", &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        "git cherry-pick --continue",
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
 
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
 
     Ok(GitPushPullResult {
         success: output.status.success(),
-        message: if output.status.success() { stdout } else { stderr },
+        message: if output.status.success() {
+            stdout
+        } else {
+            stderr
+        },
         conflicts: None,
     })
 }
@@ -1182,7 +1401,12 @@ pub(crate) async fn git_checkout_commit(cwd: String, sha: String) -> Result<(), 
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to checkout commit: {}", e))?;
-    record_cmd(&format!("git checkout {}", sha), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git checkout {}", sha),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         return Err(format!(
             "git checkout failed: {}",
@@ -1193,7 +1417,11 @@ pub(crate) async fn git_checkout_commit(cwd: String, sha: String) -> Result<(), 
 }
 
 #[tauri::command]
-pub(crate) async fn git_reset_to_commit(cwd: String, sha: String, mode: String) -> Result<(), String> {
+pub(crate) async fn git_reset_to_commit(
+    cwd: String,
+    sha: String,
+    mode: String,
+) -> Result<(), String> {
     let _repo = repo_lock::write(&cwd);
     let flag = match mode.as_str() {
         "soft" => "--soft",
@@ -1206,7 +1434,12 @@ pub(crate) async fn git_reset_to_commit(cwd: String, sha: String, mode: String) 
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to reset: {}", e))?;
-    record_cmd(&format!("git reset {} {}", flag, sha), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git reset {} {}", flag, sha),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     if !output.status.success() {
         return Err(format!(
             "git reset {} failed: {}",
@@ -1218,7 +1451,11 @@ pub(crate) async fn git_reset_to_commit(cwd: String, sha: String, mode: String) 
 }
 
 #[tauri::command]
-pub(crate) async fn git_revert_commit(cwd: String, sha: String, mainline: Option<u32>) -> Result<GitPushPullResult, String> {
+pub(crate) async fn git_revert_commit(
+    cwd: String,
+    sha: String,
+    mainline: Option<u32>,
+) -> Result<GitPushPullResult, String> {
     let _repo = repo_lock::write(&cwd);
     let mut args = vec!["revert".to_string(), "--no-edit".to_string()];
     if let Some(m) = mainline {
@@ -1232,13 +1469,22 @@ pub(crate) async fn git_revert_commit(cwd: String, sha: String, mainline: Option
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to revert commit: {}", e))?;
-    record_cmd(&format!("git {}", args.join(" ")), &cwd, _t0.elapsed().as_millis() as u64, output.status.code().unwrap_or(-1));
+    record_cmd(
+        &format!("git {}", args.join(" ")),
+        &cwd,
+        _t0.elapsed().as_millis() as u64,
+        output.status.code().unwrap_or(-1),
+    );
     let stdout = String::from_utf8_lossy(&output.stdout).to_string();
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();
     let has_conflicts = stderr.contains("CONFLICT") || stdout.contains("CONFLICT");
     Ok(GitPushPullResult {
         success: output.status.success(),
-        message: if output.status.success() { stdout } else { stderr },
+        message: if output.status.success() {
+            stdout
+        } else {
+            stderr
+        },
         conflicts: Some(has_conflicts),
     })
 }
@@ -1246,11 +1492,23 @@ pub(crate) async fn git_revert_commit(cwd: String, sha: String, mainline: Option
 // ─── Git tags ──────────────────────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn git_create_tag(cwd: String, name: String, sha: String, message: Option<String>) -> Result<(), String> {
+pub(crate) async fn git_create_tag(
+    cwd: String,
+    name: String,
+    sha: String,
+    message: Option<String>,
+) -> Result<(), String> {
     let tag_name = name.clone();
     let trimmed = message.as_deref().map(str::trim).filter(|s| !s.is_empty());
     let args: Vec<String> = if let Some(m) = trimmed {
-        vec!["tag".into(), "-a".into(), name, sha, "-m".into(), m.to_string()]
+        vec![
+            "tag".into(),
+            "-a".into(),
+            name,
+            sha,
+            "-m".into(),
+            m.to_string(),
+        ]
     } else {
         vec!["tag".into(), name, sha]
     };
@@ -1300,20 +1558,33 @@ pub(crate) async fn git_list_tags(cwd: String) -> Result<Vec<TagEntry>, String> 
         s = sep
     );
     let output = git_cmd()
-        .args(["tag", "-l", "--sort=-version:refname", "--sort=-creatordate", &format!("--format={}", fmt)])
+        .args([
+            "tag",
+            "-l",
+            "--sort=-version:refname",
+            "--sort=-creatordate",
+            &format!("--format={}", fmt),
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to list tags: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git tag failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git tag failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut tags = Vec::new();
     for line in stdout.lines() {
         let parts: Vec<&str> = line.split('\x1f').collect();
-        if parts.len() < 7 { continue; }
+        if parts.len() < 7 {
+            continue;
+        }
         let name = parts[0].trim().to_string();
-        if name.is_empty() { continue; }
+        if name.is_empty() {
+            continue;
+        }
         let obj_type = parts[1].trim();
         let is_annotated = obj_type == "tag";
         let hash = if is_annotated && !parts[3].trim().is_empty() {
@@ -1327,7 +1598,13 @@ pub(crate) async fn git_list_tags(cwd: String) -> Result<Vec<TagEntry>, String> 
             parts[5].trim().to_string()
         };
         let message = parts[6].trim().to_string();
-        tags.push(TagEntry { name, hash, is_annotated, date, message });
+        tags.push(TagEntry {
+            name,
+            hash,
+            is_annotated,
+            date,
+            message,
+        });
     }
     Ok(tags)
 }
@@ -1340,13 +1617,21 @@ pub(crate) async fn git_delete_tag(cwd: String, name: String) -> Result<(), Stri
         .output()
         .map_err(|e| format!("Failed to delete tag: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git tag -d failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git tag -d failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     Ok(())
 }
 
 #[tauri::command]
-pub(crate) async fn git_push_tags(cwd: String, remote: String, mode: String, tag_name: Option<String>) -> Result<(), String> {
+pub(crate) async fn git_push_tags(
+    cwd: String,
+    remote: String,
+    mode: String,
+    tag_name: Option<String>,
+) -> Result<(), String> {
     let mut args = vec!["push".to_string(), remote.clone()];
     match mode.as_str() {
         "single" => {
@@ -1365,7 +1650,10 @@ pub(crate) async fn git_push_tags(cwd: String, remote: String, mode: String, tag
         .output()
         .map_err(|e| format!("Failed to push tags: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git push tags failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git push tags failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     Ok(())
 }
@@ -1409,14 +1697,21 @@ pub(crate) async fn git_unpushed_tags(cwd: String, remote: String) -> Result<Vec
 }
 
 #[tauri::command]
-pub(crate) async fn git_delete_remote_tag(cwd: String, remote: String, name: String) -> Result<(), String> {
+pub(crate) async fn git_delete_remote_tag(
+    cwd: String,
+    remote: String,
+    name: String,
+) -> Result<(), String> {
     let output = git_cmd()
         .args(["push", &remote, "--delete", &format!("refs/tags/{}", name)])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to delete remote tag: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git push --delete failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git push --delete failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     Ok(())
 }
@@ -1424,7 +1719,10 @@ pub(crate) async fn git_delete_remote_tag(cwd: String, remote: String, name: Str
 // ─── Git conflict check ─────────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn git_conflict_check(cwd: String, target_branch: String) -> Result<ConflictRisk, String> {
+pub(crate) async fn git_conflict_check(
+    cwd: String,
+    target_branch: String,
+) -> Result<ConflictRisk, String> {
     let git = git_binary();
 
     let base_out = hidden_cmd(&git)
@@ -1547,11 +1845,20 @@ pub(crate) async fn git_submodule_list(cwd: String) -> Result<Vec<SubmoduleEntry
         }
         .to_string();
 
-        let name = path_to_name.get(&path).cloned().unwrap_or_else(|| path.clone());
+        let name = path_to_name
+            .get(&path)
+            .cloned()
+            .unwrap_or_else(|| path.clone());
         let url = url_map.get(&name).cloned().unwrap_or_default();
         let branch = branch_map.get(&name).cloned();
 
-        entries.push(SubmoduleEntry { path, url, sha, branch, status });
+        entries.push(SubmoduleEntry {
+            path,
+            url,
+            sha,
+            branch,
+            status,
+        });
     }
 
     Ok(entries)
@@ -1564,7 +1871,9 @@ pub(crate) async fn git_submodule_list(cwd: String) -> Result<Vec<SubmoduleEntry
 /// to be called on demand (when the Submodules hub opens), never on a poll.
 /// Submodules that are offline / unreachable are skipped silently.
 #[tauri::command]
-pub(crate) async fn git_submodule_check_updates(cwd: String) -> Result<Vec<SubmoduleUpdate>, String> {
+pub(crate) async fn git_submodule_check_updates(
+    cwd: String,
+) -> Result<Vec<SubmoduleUpdate>, String> {
     let _repo = repo_lock::read(&cwd);
     let gitmodules = std::path::Path::new(&cwd).join(".gitmodules");
     if !gitmodules.exists() {
@@ -1585,9 +1894,15 @@ pub(crate) async fn git_submodule_check_updates(cwd: String) -> Result<Vec<Submo
             if let Some(eq) = line.find('=') {
                 let key = &line[..eq];
                 let val = &line[eq + 1..];
-                if let Some(name) = key.strip_prefix("submodule.").and_then(|s| s.strip_suffix(".branch")) {
+                if let Some(name) = key
+                    .strip_prefix("submodule.")
+                    .and_then(|s| s.strip_suffix(".branch"))
+                {
                     name_branch.insert(name.to_string(), val.to_string());
-                } else if let Some(name) = key.strip_prefix("submodule.").and_then(|s| s.strip_suffix(".path")) {
+                } else if let Some(name) = key
+                    .strip_prefix("submodule.")
+                    .and_then(|s| s.strip_suffix(".path"))
+                {
                     name_path.insert(name.to_string(), val.to_string());
                 }
             }
@@ -1635,7 +1950,11 @@ pub(crate) async fn git_submodule_check_updates(cwd: String) -> Result<Vec<Submo
             let configured = path_branch.get(&path).cloned();
             submodule_behind(&sub_dir, configured.as_deref())
                 .filter(|&behind| behind > 0)
-                .map(|behind| SubmoduleUpdate { path, behind, branch: configured })
+                .map(|behind| SubmoduleUpdate {
+                    path,
+                    behind,
+                    branch: configured,
+                })
         })
         .collect();
 
@@ -1694,7 +2013,10 @@ fn submodule_behind(sub_dir: &std::path::Path, configured_branch: Option<&str>) 
     if !count.status.success() {
         return None;
     }
-    String::from_utf8_lossy(&count.stdout).trim().parse::<u32>().ok()
+    String::from_utf8_lossy(&count.stdout)
+        .trim()
+        .parse::<u32>()
+        .ok()
 }
 
 #[tauri::command]
@@ -1715,7 +2037,11 @@ pub(crate) async fn git_submodule_init(cwd: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub(crate) async fn git_submodule_update(cwd: String, init: bool, recursive: bool) -> Result<(), String> {
+pub(crate) async fn git_submodule_update(
+    cwd: String,
+    init: bool,
+    recursive: bool,
+) -> Result<(), String> {
     let _repo = repo_lock::write(&cwd);
     let mut cmd = git_cmd();
     cmd.arg("submodule").arg("update");
@@ -1750,7 +2076,15 @@ pub(crate) async fn git_submodule_update_one(cwd: String, path: String) -> Resul
     let _repo = repo_lock::write(&cwd);
 
     let output = git_cmd()
-        .args(["submodule", "update", "--remote", "--rebase", "--init", "--", &path])
+        .args([
+            "submodule",
+            "update",
+            "--remote",
+            "--rebase",
+            "--init",
+            "--",
+            &path,
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to update submodule: {}", e))?;
@@ -1764,7 +2098,11 @@ pub(crate) async fn git_submodule_update_one(cwd: String, path: String) -> Resul
 }
 
 #[tauri::command]
-pub(crate) async fn git_submodule_add(cwd: String, url: String, path: String) -> Result<(), String> {
+pub(crate) async fn git_submodule_add(
+    cwd: String,
+    url: String,
+    path: String,
+) -> Result<(), String> {
     let _repo = repo_lock::write(&cwd);
     let output = git_cmd()
         .args(["submodule", "add", &url, &path])
@@ -1923,10 +2261,12 @@ pub(crate) async fn git_commit_submodule_changes(
             continue;
         }
         if let Some(ref sha) = current {
-            map.entry(sha.clone()).or_default().push(CommitSubmoduleChange {
-                path,
-                pointed_sha: new_sha.to_string(),
-            });
+            map.entry(sha.clone())
+                .or_default()
+                .push(CommitSubmoduleChange {
+                    path,
+                    pointed_sha: new_sha.to_string(),
+                });
         }
     }
 
@@ -1967,11 +2307,11 @@ fn list_worktrees(cwd: &str) -> Result<Vec<WorktreeEntry>, String> {
     let mut current: Option<WorktreeEntry> = None;
 
     for line in stdout.lines() {
-        if line.starts_with("worktree ") {
+        if let Some(path) = line.strip_prefix("worktree ") {
             if let Some(e) = current.take() {
                 entries.push(e);
             }
-            let path = line["worktree ".len()..].to_string();
+            let path = path.to_string();
             current = Some(WorktreeEntry {
                 path,
                 branch: String::new(),
@@ -1987,23 +2327,22 @@ fn list_worktrees(cwd: &str) -> Result<Vec<WorktreeEntry>, String> {
             if line == "main" {
                 // Attribut explicite depuis git 2.36
                 e.is_main = true;
-            } else if line.starts_with("HEAD ") {
-                e.head = line["HEAD ".len()..].to_string();
-            } else if line.starts_with("branch ") {
-                let full = &line["branch ".len()..];
+            } else if let Some(head) = line.strip_prefix("HEAD ") {
+                e.head = head.to_string();
+            } else if let Some(full) = line.strip_prefix("branch ") {
                 e.branch = full.strip_prefix("refs/heads/").unwrap_or(full).to_string();
             } else if line == "bare" {
                 e.is_bare = true;
-            } else if line.starts_with("locked") {
+            } else if let Some(rest) = line.strip_prefix("locked") {
                 e.is_locked = true;
                 // Format : "locked" seul ou "locked <raison>" avec raison inline
-                let reason = line["locked".len()..].trim();
+                let reason = rest.trim();
                 if !reason.is_empty() {
                     e.lock_reason = Some(reason.to_string());
                 }
-            } else if line.starts_with("prunable") {
+            } else if let Some(rest) = line.strip_prefix("prunable") {
                 e.is_prunable = true;
-                let reason = line["prunable".len()..].trim();
+                let reason = rest.trim();
                 if !reason.is_empty() {
                     e.prunable_reason = Some(reason.to_string());
                 }
@@ -2089,7 +2428,11 @@ pub(crate) async fn git_worktree_add(
 }
 
 #[tauri::command]
-pub(crate) async fn git_worktree_remove(cwd: String, path: String, force: Option<bool>) -> Result<(), String> {
+pub(crate) async fn git_worktree_remove(
+    cwd: String,
+    path: String,
+    force: Option<bool>,
+) -> Result<(), String> {
     let mut cmd = git_cmd();
     cmd.arg("worktree").arg("remove");
     if force.unwrap_or(false) {
@@ -2129,64 +2472,84 @@ pub(crate) async fn git_worktree_prune(cwd: String) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub(crate) async fn git_worktree_status_all(cwd: String) -> Result<Vec<WorkspaceRepoStatus>, String> {
+pub(crate) async fn git_worktree_status_all(
+    cwd: String,
+) -> Result<Vec<WorkspaceRepoStatus>, String> {
     let worktrees = list_worktrees(&cwd)?;
 
-    let statuses = worktrees.into_par_iter().map(|wt| {
-        let path = wt.path.clone();
-        let name = wt.branch.trim_start_matches("refs/heads/").to_string();
+    let statuses = worktrees
+        .into_par_iter()
+        .map(|wt| {
+            let path = wt.path.clone();
+            let name = wt.branch.trim_start_matches("refs/heads/").to_string();
 
-        let branch = git_cmd()
-            .args(["rev-parse", "--abbrev-ref", "HEAD"])
-            .current_dir(&path)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .unwrap_or_default();
+            let branch = git_cmd()
+                .args(["rev-parse", "--abbrev-ref", "HEAD"])
+                .current_dir(&path)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default();
 
-        // Upstream : détecter si une remote est configurée, et extraire ahead/behind
-        let upstream_out = git_cmd()
-            .args(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])
-            .current_dir(&path)
-            .output()
-            .ok()
-            .filter(|o| o.status.success());
+            // Upstream : détecter si une remote est configurée, et extraire ahead/behind
+            let upstream_out = git_cmd()
+                .args(["rev-list", "--left-right", "--count", "HEAD...@{upstream}"])
+                .current_dir(&path)
+                .output()
+                .ok()
+                .filter(|o| o.status.success());
 
-        let has_upstream = upstream_out.is_some();
-        let (ahead, behind) = upstream_out
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .and_then(|s| {
-                let parts: Vec<&str> = s.trim().split_whitespace().collect();
-                if parts.len() == 2 {
-                    Some((parts[0].parse::<u32>().unwrap_or(0), parts[1].parse::<u32>().unwrap_or(0)))
-                } else { None }
-            })
-            .unwrap_or((0, 0));
+            let has_upstream = upstream_out.is_some();
+            let (ahead, behind) = upstream_out
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .and_then(|s| {
+                    let parts: Vec<&str> = s.split_whitespace().collect();
+                    if parts.len() == 2 {
+                        Some((
+                            parts[0].parse::<u32>().unwrap_or(0),
+                            parts[1].parse::<u32>().unwrap_or(0),
+                        ))
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or((0, 0));
 
-        // Status : séparer les fichiers en conflit (UU/AA/DD/AU/UA/DU/UD) des simples modifiés
-        let status_out = git_cmd()
-            .args(["status", "--porcelain", "--untracked-files=no"])
-            .current_dir(&path)
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .unwrap_or_default();
+            // Status : séparer les fichiers en conflit (UU/AA/DD/AU/UA/DU/UD) des simples modifiés
+            let status_out = git_cmd()
+                .args(["status", "--porcelain", "--untracked-files=no"])
+                .current_dir(&path)
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .unwrap_or_default();
 
-        const CONFLICT_CODES: &[&str] = &["UU", "AA", "DD", "AU", "UA", "DU", "UD"];
-        let conflicted = status_out
-            .lines()
-            .filter(|l| l.len() >= 2 && CONFLICT_CODES.contains(&&l[..2]))
-            .count() as u32;
-        let modified = status_out
-            .lines()
-            .filter(|l| l.len() >= 2 && !CONFLICT_CODES.contains(&&l[..2]))
-            .count() as u32;
+            const CONFLICT_CODES: &[&str] = &["UU", "AA", "DD", "AU", "UA", "DU", "UD"];
+            let conflicted = status_out
+                .lines()
+                .filter(|l| l.len() >= 2 && CONFLICT_CODES.contains(&&l[..2]))
+                .count() as u32;
+            let modified = status_out
+                .lines()
+                .filter(|l| l.len() >= 2 && !CONFLICT_CODES.contains(&&l[..2]))
+                .count() as u32;
 
-        WorkspaceRepoStatus { path, name, branch, ahead, behind, has_upstream, modified, conflicted, error: None }
-    }).collect();
+            WorkspaceRepoStatus {
+                path,
+                name,
+                branch,
+                ahead,
+                behind,
+                has_upstream,
+                modified,
+                conflicted,
+                error: None,
+            }
+        })
+        .collect();
 
     Ok(statuses)
 }
@@ -2225,9 +2588,9 @@ pub(crate) async fn git_worktree_repair(cwd: String, paths: Vec<String>) -> Resu
 /// One progress update emitted as a Tauri event.
 #[derive(serde::Serialize, Clone)]
 struct CloneProgress {
-    stage:   String,   // "init" | "counting" | "compressing" | "receiving" | "resolving" | "done"
-    percent: f32,      // 0 – 100
-    message: String,   // raw trimmed line
+    stage: String, // "init" | "counting" | "compressing" | "receiving" | "resolving" | "done"
+    percent: f32,  // 0 – 100
+    message: String, // raw trimmed line
 }
 
 fn extract_percent(line: &str) -> f32 {
@@ -2245,38 +2608,76 @@ fn extract_percent(line: &str) -> f32 {
 
 fn parse_clone_progress(line: &str) -> Option<CloneProgress> {
     let l = line.trim();
-    if l.is_empty() { return None; }
+    if l.is_empty() {
+        return None;
+    }
     if l.starts_with("Cloning into") {
-        return Some(CloneProgress { stage: "init".into(),        percent: 0.0,                 message: l.to_string() });
+        return Some(CloneProgress {
+            stage: "init".into(),
+            percent: 0.0,
+            message: l.to_string(),
+        });
     }
     if l.starts_with("remote: Counting") || l.starts_with("remote: Enumerating") {
-        return Some(CloneProgress { stage: "counting".into(),    percent: extract_percent(l),   message: l.to_string() });
+        return Some(CloneProgress {
+            stage: "counting".into(),
+            percent: extract_percent(l),
+            message: l.to_string(),
+        });
     }
     if l.starts_with("remote: Compressing") {
-        return Some(CloneProgress { stage: "compressing".into(), percent: extract_percent(l),   message: l.to_string() });
+        return Some(CloneProgress {
+            stage: "compressing".into(),
+            percent: extract_percent(l),
+            message: l.to_string(),
+        });
     }
     if l.starts_with("Receiving objects:") {
-        return Some(CloneProgress { stage: "receiving".into(),   percent: extract_percent(l),   message: l.to_string() });
+        return Some(CloneProgress {
+            stage: "receiving".into(),
+            percent: extract_percent(l),
+            message: l.to_string(),
+        });
     }
     if l.starts_with("Resolving deltas:") {
-        return Some(CloneProgress { stage: "resolving".into(),   percent: extract_percent(l),   message: l.to_string() });
+        return Some(CloneProgress {
+            stage: "resolving".into(),
+            percent: extract_percent(l),
+            message: l.to_string(),
+        });
     }
     if l.contains("done") || l.contains("complete") {
-        return Some(CloneProgress { stage: "done".into(),        percent: 100.0,                message: l.to_string() });
+        return Some(CloneProgress {
+            stage: "done".into(),
+            percent: 100.0,
+            message: l.to_string(),
+        });
     }
     // Emit unknown lines too so the modal can show them
-    Some(CloneProgress { stage: "info".into(), percent: 0.0, message: l.to_string() })
+    Some(CloneProgress {
+        stage: "info".into(),
+        percent: 0.0,
+        message: l.to_string(),
+    })
 }
 
 #[tauri::command]
-pub(crate) async fn git_clone(url: String, dest: String, app_handle: tauri::AppHandle) -> Result<String, String> {
+pub(crate) async fn git_clone(
+    url: String,
+    dest: String,
+    app_handle: tauri::AppHandle,
+) -> Result<String, String> {
     use std::io::Read;
     use tauri::Emitter;
 
     let url_trim = url.trim().to_string();
     let dest_trim = dest.trim().to_string();
-    if url_trim.is_empty() { return Err("Empty URL".to_string()); }
-    if dest_trim.is_empty() { return Err("Empty destination".to_string()); }
+    if url_trim.is_empty() {
+        return Err("Empty URL".to_string());
+    }
+    if dest_trim.is_empty() {
+        return Err("Empty destination".to_string());
+    }
 
     let _t0 = Instant::now();
 
@@ -2301,7 +2702,7 @@ pub(crate) async fn git_clone(url: String, dest: String, app_handle: tauri::AppH
                     all_stderr.extend_from_slice(&buf[..n]);
                     let chunk = String::from_utf8_lossy(&buf[..n]);
                     let combined = carry.clone() + &chunk;
-                    let parts: Vec<&str> = combined.split(|c| c == '\r' || c == '\n').collect();
+                    let parts: Vec<&str> = combined.split(['\r', '\n']).collect();
                     let carry_idx = parts.len().saturating_sub(1);
                     carry = parts[carry_idx].to_string();
                     for part in &parts[..carry_idx] {
@@ -2318,18 +2719,34 @@ pub(crate) async fn git_clone(url: String, dest: String, app_handle: tauri::AppH
         }
     }
 
-    let status = child.wait().map_err(|e| format!("Failed to wait for git clone: {}", e))?;
-    record_cmd(&format!("git clone {}", url_trim), &dest_trim, _t0.elapsed().as_millis() as u64, status.code().unwrap_or(-1));
+    let status = child
+        .wait()
+        .map_err(|e| format!("Failed to wait for git clone: {}", e))?;
+    record_cmd(
+        &format!("git clone {}", url_trim),
+        &dest_trim,
+        _t0.elapsed().as_millis() as u64,
+        status.code().unwrap_or(-1),
+    );
 
     if !status.success() {
         let stderr_text = String::from_utf8_lossy(&all_stderr).trim().to_string();
-        return Err(if stderr_text.is_empty() { "git clone failed".to_string() } else { stderr_text });
+        return Err(if stderr_text.is_empty() {
+            "git clone failed".to_string()
+        } else {
+            stderr_text
+        });
     }
 
     // Emit final "done" event
-    let _ = app_handle.emit("clone-progress", CloneProgress {
-        stage: "done".into(), percent: 100.0, message: "Clone complete".to_string(),
-    });
+    let _ = app_handle.emit(
+        "clone-progress",
+        CloneProgress {
+            stage: "done".into(),
+            percent: 100.0,
+            message: "Clone complete".to_string(),
+        },
+    );
 
     Ok(dest_trim)
 }
@@ -2373,14 +2790,20 @@ pub(crate) async fn gh_fork(url: String, parent_dir: String) -> Result<String, S
         return Err(detail);
     }
 
-    Ok(format!("{}/{}", parent_trim.trim_end_matches('/'), repo_name))
+    Ok(format!(
+        "{}/{}",
+        parent_trim.trim_end_matches('/'),
+        repo_name
+    ))
 }
 
 // ─── Git hooks ─────────────────────────────────────────────
 
 #[tauri::command]
 pub(crate) async fn git_hook_list(cwd: String) -> Result<Vec<HookEntry>, String> {
-    if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
+    if cwd.trim().is_empty() {
+        return Err("cwd must not be empty".to_string());
+    }
     let repo = PathBuf::from(&cwd);
     let hooks_dir = repo.join(".git").join("hooks");
 
@@ -2433,7 +2856,12 @@ pub(crate) async fn git_hook_list(cwd: String) -> Result<Vec<HookEntry>, String>
             .take(80)
             .collect();
 
-        entries.push(HookEntry { name, enabled, executable, preview });
+        entries.push(HookEntry {
+            name,
+            enabled,
+            executable,
+            preview,
+        });
     }
 
     entries.sort_by(|a, b| {
@@ -2451,11 +2879,17 @@ pub(crate) async fn git_hook_list(cwd: String) -> Result<Vec<HookEntry>, String>
 }
 
 #[tauri::command]
-pub(crate) async fn git_hook_toggle(cwd: String, name: String, enabled: bool) -> Result<(), String> {
+pub(crate) async fn git_hook_toggle(
+    cwd: String,
+    name: String,
+    enabled: bool,
+) -> Result<(), String> {
     if name.contains('/') || name.contains('\\') || name.contains('.') {
         return Err(format!("Invalid hook name: {}", name));
     }
-    if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
+    if cwd.trim().is_empty() {
+        return Err("cwd must not be empty".to_string());
+    }
     let repo = PathBuf::from(&cwd);
     let hooks_dir = repo.join(".git").join("hooks");
 
@@ -2477,11 +2911,17 @@ pub(crate) async fn git_hook_toggle(cwd: String, name: String, enabled: bool) ->
 }
 
 #[tauri::command]
-pub(crate) async fn git_hook_create(cwd: String, name: String, content: String) -> Result<(), String> {
+pub(crate) async fn git_hook_create(
+    cwd: String,
+    name: String,
+    content: String,
+) -> Result<(), String> {
     if name.contains('/') || name.contains('\\') || name.contains('.') {
         return Err(format!("Invalid hook name: {}", name));
     }
-    if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
+    if cwd.trim().is_empty() {
+        return Err("cwd must not be empty".to_string());
+    }
     let repo = PathBuf::from(&cwd);
     let hooks_dir = repo.join(".git").join("hooks");
 
@@ -2496,8 +2936,7 @@ pub(crate) async fn git_hook_create(cwd: String, name: String, content: String) 
         format!("#!/usr/bin/env bash\n{}", content)
     };
 
-    std::fs::write(&hook_path, script)
-        .map_err(|e| format!("Failed to write hook: {}", e))?;
+    std::fs::write(&hook_path, script).map_err(|e| format!("Failed to write hook: {}", e))?;
 
     #[cfg(unix)]
     {
@@ -2518,7 +2957,9 @@ pub(crate) async fn git_hook_delete(cwd: String, name: String) -> Result<(), Str
     if name.contains('/') || name.contains('\\') || name.contains('.') {
         return Err(format!("Invalid hook name: {}", name));
     }
-    if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
+    if cwd.trim().is_empty() {
+        return Err("cwd must not be empty".to_string());
+    }
     let repo = PathBuf::from(&cwd);
     let hooks_dir = repo.join(".git").join("hooks");
 
@@ -2526,8 +2967,7 @@ pub(crate) async fn git_hook_delete(cwd: String, name: String) -> Result<(), Str
     let disabled_path = hooks_dir.join(format!("{}.disabled", name));
 
     if enabled_path.exists() {
-        std::fs::remove_file(&enabled_path)
-            .map_err(|e| format!("Failed to delete hook: {}", e))?;
+        std::fs::remove_file(&enabled_path).map_err(|e| format!("Failed to delete hook: {}", e))?;
     }
     if disabled_path.exists() {
         let _ = std::fs::remove_file(&disabled_path);
@@ -2562,15 +3002,21 @@ fn active_cwds_for_tool(tool_name: &str) -> HashSet<String> {
     if let Ok(entries) = std::fs::read_dir("/proc") {
         for entry in entries.flatten() {
             let pid_path = entry.path();
-            if !entry.file_name().to_string_lossy().chars().all(|c| c.is_ascii_digit()) {
+            if !entry
+                .file_name()
+                .to_string_lossy()
+                .chars()
+                .all(|c| c.is_ascii_digit())
+            {
                 continue;
             }
             let exe_path = pid_path.join("exe");
             if let Ok(exe) = std::fs::read_link(&exe_path) {
-                let basename = exe.file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("");
-                if !basename.to_lowercase().starts_with(&tool_name.to_lowercase()) {
+                let basename = exe.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if !basename
+                    .to_lowercase()
+                    .starts_with(&tool_name.to_lowercase())
+                {
                     continue;
                 }
             } else {
@@ -2606,7 +3052,9 @@ fn detect_agent_tool(worktree_path: &str) -> Option<String> {
 
 #[tauri::command]
 pub(crate) async fn agent_session_list(cwd: String) -> Result<Vec<AgentSession>, String> {
-    if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
+    if cwd.trim().is_empty() {
+        return Err("cwd must not be empty".to_string());
+    }
     let path = PathBuf::from(&cwd);
     let worktrees = list_worktrees(&path.to_string_lossy())?;
 
@@ -2640,9 +3088,12 @@ pub(crate) async fn agent_session_list(cwd: String) -> Result<Vec<AgentSession>,
                 .filter(|o| o.status.success())
                 .and_then(|o| String::from_utf8(o.stdout).ok())
                 .and_then(|s| {
-                    let v: Vec<&str> = s.trim().split_whitespace().collect();
+                    let v: Vec<&str> = s.split_whitespace().collect();
                     if v.len() == 2 {
-                        Some((v[0].parse::<u32>().unwrap_or(0), v[1].parse::<u32>().unwrap_or(0)))
+                        Some((
+                            v[0].parse::<u32>().unwrap_or(0),
+                            v[1].parse::<u32>().unwrap_or(0),
+                        ))
                     } else {
                         None
                     }
@@ -2659,7 +3110,15 @@ pub(crate) async fn agent_session_list(cwd: String) -> Result<Vec<AgentSession>,
                 .map(|s| s.lines().filter(|l| !l.is_empty()).count() as u32)
                 .unwrap_or(0);
 
-            Some(AgentSession { path: wt.path, branch, tool, active, ahead, behind, modified })
+            Some(AgentSession {
+                path: wt.path,
+                branch,
+                tool,
+                active,
+                ahead,
+                behind,
+                modified,
+            })
         })
         .collect();
 
@@ -2668,12 +3127,14 @@ pub(crate) async fn agent_session_list(cwd: String) -> Result<Vec<AgentSession>,
 
 #[tauri::command]
 pub(crate) async fn agent_session_launch(cwd: String, tool: String) -> Result<(), String> {
-    if cwd.trim().is_empty() { return Err("cwd must not be empty".to_string()); }
+    if cwd.trim().is_empty() {
+        return Err("cwd must not be empty".to_string());
+    }
     let path = PathBuf::from(&cwd);
     let binary = match tool.as_str() {
-        "cursor"   => "cursor",
+        "cursor" => "cursor",
         "windsurf" => "windsurf",
-        _          => "claude",
+        _ => "claude",
     };
 
     hidden_cmd(binary)
@@ -2706,10 +3167,7 @@ pub(crate) async fn git_shortlog(cwd: String) -> Result<Vec<ShortlogEntry>, Stri
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut entries: Vec<ShortlogEntry> = stdout
-        .lines()
-        .filter_map(parse_shortlog_line)
-        .collect();
+    let mut entries: Vec<ShortlogEntry> = stdout.lines().filter_map(parse_shortlog_line).collect();
     entries.sort_by(|a, b| b.count.cmp(&a.count));
     Ok(entries)
 }
@@ -2753,8 +3211,14 @@ pub(crate) async fn git_author_line_stats(cwd: String) -> Result<Vec<AuthorLineS
             continue;
         }
         let mut parts = line.split('\t');
-        let added = parts.next().and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
-        let deleted = parts.next().and_then(|s| s.parse::<u64>().ok()).unwrap_or(0);
+        let added = parts
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
+        let deleted = parts
+            .next()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(0);
         if added == 0 && deleted == 0 {
             continue;
         }
@@ -2765,7 +3229,11 @@ pub(crate) async fn git_author_line_stats(cwd: String) -> Result<Vec<AuthorLineS
 
     let mut stats: Vec<AuthorLineStat> = totals
         .into_iter()
-        .map(|(email, (added, deleted))| AuthorLineStat { email, added, deleted })
+        .map(|(email, (added, deleted))| AuthorLineStat {
+            email,
+            added,
+            deleted,
+        })
         .collect();
     stats.sort_by(|a, b| (b.added + b.deleted).cmp(&(a.added + a.deleted)));
     Ok(stats)
@@ -2798,8 +3266,7 @@ pub(crate) async fn git_branch_top_authors(
                 // full history when that range is empty (the base branch itself,
                 // or a branch with nothing ahead of base).
                 let range = format!("{}..{}", base, branch);
-                let top = shortlog_top(&cwd, &range)
-                    .or_else(|| shortlog_top(&cwd, &branch))?;
+                let top = shortlog_top(&cwd, &range).or_else(|| shortlog_top(&cwd, &branch))?;
                 Some(BranchTopAuthor {
                     branch,
                     name: top.name,
@@ -2865,11 +3332,35 @@ pub(crate) async fn git_autocomplete(cwd: String, partial: String) -> Result<Vec
 
     if !partial.contains(' ') {
         let subcommands = [
-            "add", "bisect", "blame", "branch", "checkout", "cherry-pick",
-            "clone", "commit", "config", "diff", "fetch", "grep", "init",
-            "log", "merge", "mv", "pull", "push", "rebase", "remote",
-            "reset", "restore", "revert", "rm", "show", "stash", "status",
-            "switch", "tag",
+            "add",
+            "bisect",
+            "blame",
+            "branch",
+            "checkout",
+            "cherry-pick",
+            "clone",
+            "commit",
+            "config",
+            "diff",
+            "fetch",
+            "grep",
+            "init",
+            "log",
+            "merge",
+            "mv",
+            "pull",
+            "push",
+            "rebase",
+            "remote",
+            "reset",
+            "restore",
+            "revert",
+            "rm",
+            "show",
+            "stash",
+            "status",
+            "switch",
+            "tag",
         ];
         for cmd in &subcommands {
             if cmd.starts_with(&partial) {
@@ -2885,7 +3376,12 @@ pub(crate) async fn git_autocomplete(cwd: String, partial: String) -> Result<Vec
         };
 
         let output = git_cmd()
-            .args(["for-each-ref", "--format=%(refname:short)", "refs/heads/", "refs/tags/"])
+            .args([
+                "for-each-ref",
+                "--format=%(refname:short)",
+                "refs/heads/",
+                "refs/tags/",
+            ])
             .current_dir(&cwd)
             .output();
 
@@ -2971,34 +3467,48 @@ fn collect_tree_conflicts(cwd: &str) -> Result<Vec<crate::types::TreeConflict>, 
     let mut result = Vec::new();
     for record in stdout.split('\0') {
         // Unmerged entries start with "u ".
-        let Some(rest) = record.strip_prefix("u ") else { continue };
+        let Some(rest) = record.strip_prefix("u ") else {
+            continue;
+        };
         // Porcelain-v2 unmerged format (10 space-separated tokens):
         //   XY sub m1 m2 m3 mW h1 h2 h3 path
         // splitn(10, ' ') puts path at index 9.
         let mut parts = rest.splitn(10, ' ');
-        let code = parts.next().unwrap_or("").to_string();   // XY
-        let _sub = parts.next();                              // submodule state
-        let m1 = parts.next().unwrap_or("000000");           // stage 1 (base)
-        let m2 = parts.next().unwrap_or("000000");           // stage 2 (ours)
-        let m3 = parts.next().unwrap_or("000000");           // stage 3 (theirs)
-        let _mw = parts.next();                               // worktree mode
+        let code = parts.next().unwrap_or("").to_string(); // XY
+        let _sub = parts.next(); // submodule state
+        let m1 = parts.next().unwrap_or("000000"); // stage 1 (base)
+        let m2 = parts.next().unwrap_or("000000"); // stage 2 (ours)
+        let m3 = parts.next().unwrap_or("000000"); // stage 3 (theirs)
+        let _mw = parts.next(); // worktree mode
         let _h1 = parts.next();
         let _h2 = parts.next();
         let _h3 = parts.next();
-        let path = parts.next().unwrap_or("").to_string();   // remainder = path
-        if path.is_empty() { continue; }
+        let path = parts.next().unwrap_or("").to_string(); // remainder = path
+        if path.is_empty() {
+            continue;
+        }
         let has_base = m1 != "000000";
         let has_ours = m2 != "000000";
         let has_theirs = m3 != "000000";
         // Only markerless tree conflicts: at least one side missing.
-        if has_ours && has_theirs { continue; }
-        result.push(crate::types::TreeConflict { path, code, has_base, has_ours, has_theirs });
+        if has_ours && has_theirs {
+            continue;
+        }
+        result.push(crate::types::TreeConflict {
+            path,
+            code,
+            has_base,
+            has_ours,
+            has_theirs,
+        });
     }
     Ok(result)
 }
 
 #[tauri::command]
-pub(crate) async fn get_tree_conflicts(cwd: String) -> Result<Vec<crate::types::TreeConflict>, String> {
+pub(crate) async fn get_tree_conflicts(
+    cwd: String,
+) -> Result<Vec<crate::types::TreeConflict>, String> {
     collect_tree_conflicts(&cwd)
 }
 
@@ -3028,7 +3538,11 @@ fn apply_tree_resolution(cwd: &str, path: &str, choice: &str) -> Result<(), Stri
             run_git_checked(cwd, &["add", "--", path], "add")?;
         }
         "theirs" => {
-            run_git_checked(cwd, &["checkout", "--theirs", "--", path], "checkout --theirs")?;
+            run_git_checked(
+                cwd,
+                &["checkout", "--theirs", "--", path],
+                "checkout --theirs",
+            )?;
             run_git_checked(cwd, &["add", "--", path], "add")?;
         }
         "delete" => {
@@ -3040,7 +3554,11 @@ fn apply_tree_resolution(cwd: &str, path: &str, choice: &str) -> Result<(), Stri
 }
 
 #[tauri::command]
-pub(crate) async fn resolve_tree_conflict(cwd: String, path: String, choice: String) -> Result<(), String> {
+pub(crate) async fn resolve_tree_conflict(
+    cwd: String,
+    path: String,
+    choice: String,
+) -> Result<(), String> {
     apply_tree_resolution(&cwd, &path, &choice)
 }
 
@@ -3062,7 +3580,7 @@ fn read_stage_blob(cwd: &str, stage: u8, path: &str) -> Vec<u8> {
 fn reconstruct_conflict_impl(cwd: &str, path: &str) -> Result<ReconstructedConflict, String> {
     let _ = safe_repo_path(cwd, path)?; // traversal guard
 
-    let base = read_stage_blob(cwd, 1, path);   // may be empty (add/add)
+    let base = read_stage_blob(cwd, 1, path); // may be empty (add/add)
     let ours = read_stage_blob(cwd, 2, path);
     let theirs = read_stage_blob(cwd, 3, path);
     if ours.is_empty() && theirs.is_empty() {
@@ -3079,7 +3597,10 @@ fn reconstruct_conflict_impl(cwd: &str, path: &str) -> Result<ReconstructedConfl
     let write_tmp = |name: &str, data: &[u8]| -> Result<std::path::PathBuf, String> {
         let p = dir.join(name);
         std::fs::File::create(&p)
-            .and_then(|mut f| { use std::io::Write; f.write_all(data) })
+            .and_then(|mut f| {
+                use std::io::Write;
+                f.write_all(data)
+            })
             .map_err(|e| format!("write {}: {}", name, e))?;
         Ok(p)
     };
@@ -3090,8 +3611,15 @@ fn reconstruct_conflict_impl(cwd: &str, path: &str) -> Result<ReconstructedConfl
         let theirs_p = write_tmp("theirs", &theirs)?;
         let out = git_cmd()
             .args([
-                "merge-file", "-p", "--diff3",
-                "-L", "ours", "-L", "base", "-L", "theirs",
+                "merge-file",
+                "-p",
+                "--diff3",
+                "-L",
+                "ours",
+                "-L",
+                "base",
+                "-L",
+                "theirs",
                 ours_p.to_str().ok_or("bad temp path")?,
                 base_p.to_str().ok_or("bad temp path")?,
                 theirs_p.to_str().ok_or("bad temp path")?,
@@ -3101,7 +3629,10 @@ fn reconstruct_conflict_impl(cwd: &str, path: &str) -> Result<ReconstructedConfl
             .map_err(|e| format!("git merge-file: {}", e))?;
         // exit 255 = real error; 0/N = clean/conflicts (stdout is the merged content either way)
         if out.status.code() == Some(255) {
-            return Err(format!("git merge-file error: {}", String::from_utf8_lossy(&out.stderr)));
+            return Err(format!(
+                "git merge-file error: {}",
+                String::from_utf8_lossy(&out.stderr)
+            ));
         }
         Ok(String::from_utf8_lossy(&out.stdout).into_owned())
     })();
@@ -3112,11 +3643,17 @@ fn reconstruct_conflict_impl(cwd: &str, path: &str) -> Result<ReconstructedConfl
     let wt = std::fs::read(safe_repo_path(cwd, path)?).unwrap_or_default();
     let wt_matches_side = (!ours.is_empty() && wt == ours) || (!theirs.is_empty() && wt == theirs);
 
-    Ok(ReconstructedConflict { content, wt_matches_side })
+    Ok(ReconstructedConflict {
+        content,
+        wt_matches_side,
+    })
 }
 
 #[tauri::command]
-pub(crate) async fn reconstruct_conflict(cwd: String, path: String) -> Result<ReconstructedConflict, String> {
+pub(crate) async fn reconstruct_conflict(
+    cwd: String,
+    path: String,
+) -> Result<ReconstructedConflict, String> {
     reconstruct_conflict_impl(&cwd, &path)
 }
 
@@ -3203,7 +3740,9 @@ pub(crate) async fn git_get_user(cwd: String) -> Result<serde_json::Value, Strin
         .output()
         .map_err(|e| format!("Failed to run git config: {}", e))?;
     let name = String::from_utf8_lossy(&name_out.stdout).trim().to_string();
-    let email = String::from_utf8_lossy(&email_out.stdout).trim().to_string();
+    let email = String::from_utf8_lossy(&email_out.stdout)
+        .trim()
+        .to_string();
     Ok(serde_json::json!({ "name": name, "email": email }))
 }
 
@@ -3219,8 +3758,7 @@ pub(crate) async fn detect_monorepo(cwd: String) -> Result<MonorepoInfo, String>
     // ── 1. pnpm ──────────────────────────────────────────────────────────
     let pnpm_ws = cwd_path.join("pnpm-workspace.yaml");
     if pnpm_ws.exists() {
-        let content = std::fs::read_to_string(&pnpm_ws)
-            .unwrap_or_default();
+        let content = std::fs::read_to_string(&pnpm_ws).unwrap_or_default();
         let packages = find_workspace_packages(&cwd, &content, "pnpm");
         return Ok(MonorepoInfo {
             is_monorepo: true,
@@ -3432,9 +3970,13 @@ pub(crate) async fn pr_files(cwd: String, number: i64) -> Result<Vec<String>, St
     }
     let output = hidden_cmd("gh")
         .args([
-            "pr", "view", &number.to_string(),
-            "--json", "files",
-            "--jq", "[.files[].path]",
+            "pr",
+            "view",
+            &number.to_string(),
+            "--json",
+            "files",
+            "--jq",
+            "[.files[].path]",
         ])
         .current_dir(&cwd)
         .output()
@@ -3443,8 +3985,7 @@ pub(crate) async fn pr_files(cwd: String, number: i64) -> Result<Vec<String>, St
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
     let json = String::from_utf8_lossy(&output.stdout);
-    serde_json::from_str::<Vec<String>>(json.trim())
-        .map_err(|e| e.to_string())
+    serde_json::from_str::<Vec<String>>(json.trim()).map_err(|e| e.to_string())
 }
 
 // ─── Fork Point (v2.11) ──────────────────────────────────────
@@ -3458,7 +3999,11 @@ pub(crate) async fn pr_files(cwd: String, number: i64) -> Result<Vec<String>, St
 // common ancestor (unrelated histories, empty repo).
 
 #[tauri::command]
-pub(crate) async fn git_merge_base(cwd: String, ref1: String, ref2: String) -> Result<String, String> {
+pub(crate) async fn git_merge_base(
+    cwd: String,
+    ref1: String,
+    ref2: String,
+) -> Result<String, String> {
     let output = git_cmd()
         .args(["merge-base", &ref1, &ref2])
         .current_dir(&cwd)
@@ -3642,7 +4187,11 @@ fn try_open_linux(mut cmd: std::process::Command, label: &str) -> Result<(), Str
 // ─── Open in external editor ─────────────────────────────────
 
 #[tauri::command]
-pub(crate) async fn open_in_editor(cwd: String, path: String, editor: String) -> Result<(), String> {
+pub(crate) async fn open_in_editor(
+    cwd: String,
+    path: String,
+    editor: String,
+) -> Result<(), String> {
     let editor_cmd = if editor.trim().is_empty() {
         "code".to_string()
     } else {
@@ -3677,16 +4226,16 @@ mod open_url_tests {
     fn opener_exiting_nonzero_is_error() {
         let err = try_open_linux(Command::new("false"), "false").unwrap_err();
         assert!(err.contains("false"), "error should name the opener: {err}");
-        assert!(err.contains("status"), "error should report the exit: {err}");
+        assert!(
+            err.contains("status"),
+            "error should report the exit: {err}"
+        );
     }
 
     #[test]
     fn missing_opener_is_error() {
-        let err = try_open_linux(
-            Command::new("gitwand-no-such-opener-binary"),
-            "ghost",
-        )
-        .unwrap_err();
+        let err =
+            try_open_linux(Command::new("gitwand-no-such-opener-binary"), "ghost").unwrap_err();
         assert!(err.contains("ghost"), "error should name the opener: {err}");
     }
 
@@ -3710,14 +4259,24 @@ mod tree_conflict_tests {
 
     static COUNTER: AtomicU64 = AtomicU64::new(0);
 
-    struct TempRepo { path: PathBuf }
-    impl Drop for TempRepo { fn drop(&mut self) { let _ = std::fs::remove_dir_all(&self.path); } }
+    struct TempRepo {
+        path: PathBuf,
+    }
+    impl Drop for TempRepo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
     impl TempRepo {
         fn new() -> Self {
             let n = COUNTER.fetch_add(1, Ordering::SeqCst);
             let pid = std::process::id();
-            let nanos = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
-            let dir = std::env::temp_dir().join(format!("gitwand-tree-test-{}-{}-{}", pid, n, nanos));
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir =
+                std::env::temp_dir().join(format!("gitwand-tree-test-{}-{}-{}", pid, n, nanos));
             std::fs::create_dir_all(&dir).unwrap();
             let repo = TempRepo { path: dir };
             repo.git(&["init", "-q", "-b", "main"]);
@@ -3726,22 +4285,37 @@ mod tree_conflict_tests {
             repo.git(&["config", "commit.gpgsign", "false"]);
             repo
         }
-        fn cwd(&self) -> String { self.path.to_str().unwrap().to_string() }
+        fn cwd(&self) -> String {
+            self.path.to_str().unwrap().to_string()
+        }
         fn git(&self, args: &[&str]) -> std::process::Output {
-            let out = Command::new(git_binary()).args(args).current_dir(&self.path).output()
+            let out = Command::new(git_binary())
+                .args(args)
+                .current_dir(&self.path)
+                .output()
                 .unwrap_or_else(|e| panic!("git {:?} spawn: {}", args, e));
             out
         }
         fn git_ok(&self, args: &[&str]) {
             let out = self.git(args);
-            assert!(out.status.success(), "git {:?} failed: {}", args, String::from_utf8_lossy(&out.stderr));
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
         }
         fn write(&self, rel: &str, content: &str) {
             let p = self.path.join(rel);
-            if let Some(parent) = p.parent() { std::fs::create_dir_all(parent).unwrap(); }
+            if let Some(parent) = p.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
             std::fs::write(p, content).unwrap();
         }
-        fn commit_all(&self, msg: &str) { self.git_ok(&["add", "-A"]); self.git_ok(&["commit", "-q", "-m", msg]); }
+        fn commit_all(&self, msg: &str) {
+            self.git_ok(&["add", "-A"]);
+            self.git_ok(&["commit", "-q", "-m", msg]);
+        }
     }
 
     /// Build a modify/delete conflict: main deletes the file, feature modifies it,
@@ -3765,7 +4339,10 @@ mod tree_conflict_tests {
         let repo = TempRepo::new();
         make_modify_delete(&repo);
         let conflicts = collect_tree_conflicts(&repo.cwd()).expect("collect_tree_conflicts failed");
-        let tc = conflicts.iter().find(|c| c.path == "doomed.txt").expect("doomed.txt is a tree conflict");
+        let tc = conflicts
+            .iter()
+            .find(|c| c.path == "doomed.txt")
+            .expect("doomed.txt is a tree conflict");
         assert!(tc.has_ours, "feature (ours) modified it → stage 2 present");
         assert!(!tc.has_theirs, "main (theirs) deleted it → stage 3 absent");
         assert_eq!(tc.code, "UD");
@@ -3800,9 +4377,15 @@ mod tree_conflict_tests {
         make_modify_delete(&repo); // feature(ours) modified doomed.txt, main(theirs) deleted it
         apply_tree_resolution(&repo.cwd(), "doomed.txt", "ours").unwrap();
         // No longer unmerged:
-        assert!(collect_tree_conflicts(&repo.cwd()).unwrap().iter().all(|c| c.path != "doomed.txt"));
+        assert!(collect_tree_conflicts(&repo.cwd())
+            .unwrap()
+            .iter()
+            .all(|c| c.path != "doomed.txt"));
         // Working tree keeps the modified version:
-        assert_eq!(std::fs::read_to_string(repo.path.join("doomed.txt")).unwrap(), "MODIFIED by feature\n");
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("doomed.txt")).unwrap(),
+            "MODIFIED by feature\n"
+        );
     }
 
     #[test]
@@ -3810,8 +4393,14 @@ mod tree_conflict_tests {
         let repo = TempRepo::new();
         make_modify_delete(&repo);
         apply_tree_resolution(&repo.cwd(), "doomed.txt", "delete").unwrap();
-        assert!(collect_tree_conflicts(&repo.cwd()).unwrap().iter().all(|c| c.path != "doomed.txt"));
-        assert!(!repo.path.join("doomed.txt").exists(), "file removed from working tree");
+        assert!(collect_tree_conflicts(&repo.cwd())
+            .unwrap()
+            .iter()
+            .all(|c| c.path != "doomed.txt"));
+        assert!(
+            !repo.path.join("doomed.txt").exists(),
+            "file removed from working tree"
+        );
     }
 
     #[test]
@@ -3836,7 +4425,10 @@ mod tree_conflict_tests {
         repo.git_ok(&["checkout", "-q", "feature"]);
         let _ = repo.git(&["merge", "--no-edit", "main"]);
         let conflicts = collect_tree_conflicts(&repo.cwd()).expect("collect_tree_conflicts failed");
-        assert!(conflicts.iter().all(|c| c.path != "shared.txt"), "content conflict (UU) must NOT be reported as a tree conflict");
+        assert!(
+            conflicts.iter().all(|c| c.path != "shared.txt"),
+            "content conflict (UU) must NOT be reported as a tree conflict"
+        );
     }
 
     /// Build a UU content conflict on `shared.txt`, leaving markers in the working tree.
@@ -3860,7 +4452,10 @@ mod tree_conflict_tests {
         // Remove markers, leave working tree == ours (stage 2).
         repo.git_ok(&["checkout", "--ours", "--", "shared.txt"]);
         let rec = reconstruct_conflict_impl(&repo.cwd(), "shared.txt").unwrap();
-        assert!(rec.content.contains("<<<<<<<"), "reconstructed content must carry conflict markers");
+        assert!(
+            rec.content.contains("<<<<<<<"),
+            "reconstructed content must carry conflict markers"
+        );
         assert!(rec.content.contains(">>>>>>>"));
         assert!(rec.wt_matches_side, "working tree == ours → matches a side");
     }
@@ -3873,7 +4468,10 @@ mod tree_conflict_tests {
         repo.write("shared.txt", "line1\nMANUAL RESOLUTION\nline3\n");
         let rec = reconstruct_conflict_impl(&repo.cwd(), "shared.txt").unwrap();
         assert!(rec.content.contains("<<<<<<<"));
-        assert!(!rec.wt_matches_side, "working tree matches neither side → manual edit");
+        assert!(
+            !rec.wt_matches_side,
+            "working tree matches neither side → manual edit"
+        );
     }
 
     // ── Remote selection + unpushed-tag detection ─────────────
@@ -3896,7 +4494,11 @@ mod tree_conflict_tests {
             .arg(&dir)
             .output()
             .expect("git init --bare spawn");
-        assert!(out.status.success(), "git init --bare failed: {}", String::from_utf8_lossy(&out.stderr));
+        assert!(
+            out.status.success(),
+            "git init --bare failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
         dir
     }
 
@@ -3937,10 +4539,9 @@ mod tree_conflict_tests {
         // A tag that lives on origin must NOT be reported as unpushed.
         repo.git_ok(&["tag", "v1.0.0"]);
         repo.git_ok(&["push", "-q", "origin", "v1.0.0"]);
-        let unpushed = tauri::async_runtime::block_on(
-            git_unpushed_tags(repo.cwd(), "origin".to_string()),
-        )
-        .expect("git_unpushed_tags failed");
+        let unpushed =
+            tauri::async_runtime::block_on(git_unpushed_tags(repo.cwd(), "origin".to_string()))
+                .expect("git_unpushed_tags failed");
         assert!(
             unpushed.is_empty(),
             "v1.0.0 is on origin, expected none unpushed, got {:?}",
@@ -3949,10 +4550,9 @@ mod tree_conflict_tests {
 
         // A local-only tag IS unpushed.
         repo.git_ok(&["tag", "v2.0.0"]);
-        let unpushed2 = tauri::async_runtime::block_on(
-            git_unpushed_tags(repo.cwd(), "origin".to_string()),
-        )
-        .expect("git_unpushed_tags failed");
+        let unpushed2 =
+            tauri::async_runtime::block_on(git_unpushed_tags(repo.cwd(), "origin".to_string()))
+                .expect("git_unpushed_tags failed");
         assert_eq!(
             unpushed2,
             vec!["v2.0.0".to_string()],
@@ -4072,7 +4672,10 @@ mod interactive_rebase_tests {
             !repo.path.join("b.txt").exists(),
             "dropped commit's file must be absent"
         );
-        assert!(repo.path.join("c.txt").exists(), "kept commit's file remains");
+        assert!(
+            repo.path.join("c.txt").exists(),
+            "kept commit's file remains"
+        );
     }
 
     #[test]
@@ -4132,8 +4735,10 @@ mod default_branch_setting_tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let dir = std::env::temp_dir()
-                .join(format!("gitwand-default-branch-test-{}-{}-{}", pid, n, nanos));
+            let dir = std::env::temp_dir().join(format!(
+                "gitwand-default-branch-test-{}-{}-{}",
+                pid, n, nanos
+            ));
             std::fs::create_dir_all(&dir).unwrap();
             let repo = TempRepo { path: dir };
             repo.git_ok(&["init", "-q", "-b", "trunk"]);
@@ -4217,11 +4822,9 @@ mod default_branch_setting_tests {
 
         // With "trunk" configured explicitly (Settings > Git > Default Branch),
         // feature's ahead-count relative to trunk must be 1.
-        let branches = tauri::async_runtime::block_on(git_branches(
-            repo.cwd(),
-            Some("trunk".to_string()),
-        ))
-        .expect("git_branches with a configured default branch must succeed");
+        let branches =
+            tauri::async_runtime::block_on(git_branches(repo.cwd(), Some("trunk".to_string())))
+                .expect("git_branches with a configured default branch must succeed");
         let feature = branches
             .iter()
             .find(|b| b.name == "feature")
@@ -4349,7 +4952,11 @@ mod stash_and_tag_date_tests {
             );
             // A space separator or a colon-less offset is exactly the %ai shape
             // this test exists to keep out.
-            assert!(!e.date.contains(' '), "date must not contain a space: {:?}", e.date);
+            assert!(
+                !e.date.contains(' '),
+                "date must not contain a space: {:?}",
+                e.date
+            );
         }
         // Sanity: the rest of the entry is still parsed correctly.
         assert_eq!(entries[0].message, "second stash");
@@ -4373,7 +4980,13 @@ mod stash_and_tag_date_tests {
         // silently shifting the timezone.
         let iso_strict_from_git = String::from_utf8_lossy(
             &repo
-                .git(&["log", "-1", "--date=iso-strict", "--format=%ad", &entries[0].hash])
+                .git(&[
+                    "log",
+                    "-1",
+                    "--date=iso-strict",
+                    "--format=%ad",
+                    &entries[0].hash,
+                ])
                 .stdout,
         )
         .trim()

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -3168,7 +3168,7 @@ pub(crate) async fn git_shortlog(cwd: String) -> Result<Vec<ShortlogEntry>, Stri
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut entries: Vec<ShortlogEntry> = stdout.lines().filter_map(parse_shortlog_line).collect();
-    entries.sort_by(|a, b| b.count.cmp(&a.count));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.count));
     Ok(entries)
 }
 
@@ -3235,7 +3235,7 @@ pub(crate) async fn git_author_line_stats(cwd: String) -> Result<Vec<AuthorLineS
             deleted,
         })
         .collect();
-    stats.sort_by(|a, b| (b.added + b.deleted).cmp(&(a.added + a.deleted)));
+    stats.sort_by_key(|b| std::cmp::Reverse(b.added + b.deleted));
     Ok(stats)
 }
 

--- a/apps/desktop/src-tauri/src/commands/read.rs
+++ b/apps/desktop/src-tauri/src/commands/read.rs
@@ -44,10 +44,7 @@ use crate::types::*;
 // fallback ensures we never regress vs. the v2.8 baseline.
 
 #[tauri::command]
-pub(crate) async fn git_status(
-    cwd: String,
-    pathspec: Option<String>,
-) -> Result<GitStatus, String> {
+pub(crate) async fn git_status(cwd: String, pathspec: Option<String>) -> Result<GitStatus, String> {
     // Shared guard: block only while a writer mutates this repo (checkout /
     // fetch / submodule update), so a background status refresh can't observe a
     // half-rebuilt working tree — the source of the `os error 2` on git status
@@ -70,7 +67,10 @@ pub(crate) async fn git_status(
         Err(e) => {
             // Soft-fail: log but keep going. Don't surface libgit2 errors
             // to the UI when CLI works.
-            eprintln!("[git_status] libgit2 fast path failed ({}); falling back to CLI", e);
+            eprintln!(
+                "[git_status] libgit2 fast path failed ({}); falling back to CLI",
+                e
+            );
             git_status_cli(cwd, None)
         }
     }
@@ -93,8 +93,7 @@ pub(crate) async fn git_status(
 ///     no direct equivalent. Calling git here for the few users with
 ///     triangular setups is acceptable; the common case is unaffected.
 pub(crate) fn git_status_libgit2(cwd: &str) -> Result<GitStatus, String> {
-    let repo = git2::Repository::open(cwd)
-        .map_err(|e| format!("git2 open: {}", e))?;
+    let repo = git2::Repository::open(cwd).map_err(|e| format!("git2 open: {}", e))?;
 
     // ── Branch + upstream + ahead/behind ────────────────────────────────
     let (branch, ahead, behind, remote, remote_branch_exists) = libgit2_branch_status(&repo);
@@ -103,8 +102,7 @@ pub(crate) fn git_status_libgit2(cwd: &str) -> Result<GitStatus, String> {
     let (staged, unstaged, untracked, conflicted) = libgit2_file_statuses(&repo)?;
 
     // ── Push remote (triangular workflow) — CLI fallback ────────────────
-    let (push_remote, ahead_push) =
-        compute_push_remote_via_cli(cwd, remote.as_deref());
+    let (push_remote, ahead_push) = compute_push_remote_via_cli(cwd, remote.as_deref());
 
     let main_commit_count = compute_main_commit_count(cwd, &branch);
 
@@ -159,11 +157,7 @@ fn libgit2_branch_status(repo: &git2::Repository) -> (String, i32, i32, Option<S
     };
     // upstream.name() returns Result<Option<&str>>: None when the ref name
     // is non-UTF-8 (extremely rare). Keep ahead/behind=0 in that case.
-    let upstream_name = upstream
-        .name()
-        .ok()
-        .flatten()
-        .map(|s| s.to_string());
+    let upstream_name = upstream.name().ok().flatten().map(|s| s.to_string());
     let upstream_oid = match upstream.get().target() {
         Some(o) => o,
         None => return (branch, 0, 0, upstream_name, true),
@@ -191,7 +185,9 @@ fn detect_untracked_remote_branch(
     for candidate in remote_tracking_candidates(repo, branch) {
         if let Ok(rb) = repo.find_branch(&candidate, git2::BranchType::Remote) {
             if let Some(remote_oid) = rb.get().target() {
-                let (a, b) = repo.graph_ahead_behind(local_oid, remote_oid).unwrap_or((0, 0));
+                let (a, b) = repo
+                    .graph_ahead_behind(local_oid, remote_oid)
+                    .unwrap_or((0, 0));
                 return (branch.to_string(), a as i32, b as i32, None, true);
             }
         }
@@ -214,12 +210,14 @@ fn remote_tracking_candidates(repo: &git2::Repository, branch: &str) -> Vec<Stri
     candidates
 }
 
+/// (staged, unstaged, untracked, conflicted) file lists.
+type FileStatusesResult =
+    Result<(Vec<FileChange>, Vec<FileChange>, Vec<String>, Vec<String>), String>;
+
 /// Build (staged, unstaged, untracked, conflicted) from `repo.statuses()`.
 /// Mirrors the porcelain v2 logic in `git_status_cli`: a single file with
 /// both index and worktree changes appears in BOTH `staged` and `unstaged`.
-fn libgit2_file_statuses(
-    repo: &git2::Repository,
-) -> Result<(Vec<FileChange>, Vec<FileChange>, Vec<String>, Vec<String>), String> {
+fn libgit2_file_statuses(repo: &git2::Repository) -> FileStatusesResult {
     let mut opts = git2::StatusOptions::new();
     opts.include_untracked(true)
         .include_ignored(false)
@@ -393,17 +391,32 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
 
     for line in stdout.lines() {
         if line.starts_with("# branch.head ") {
-            branch = line.strip_prefix("# branch.head ").unwrap_or("unknown").to_string();
+            branch = line
+                .strip_prefix("# branch.head ")
+                .unwrap_or("unknown")
+                .to_string();
         } else if line.starts_with("# branch.ab ") {
             let parts: Vec<&str> = line.split_whitespace().collect();
             if parts.len() >= 4 {
-                ahead = parts[2].strip_prefix('+').unwrap_or("0").parse().unwrap_or(0);
-                behind = parts[3].strip_prefix('-').unwrap_or("0").parse().unwrap_or(0);
+                ahead = parts[2]
+                    .strip_prefix('+')
+                    .unwrap_or("0")
+                    .parse()
+                    .unwrap_or(0);
+                behind = parts[3]
+                    .strip_prefix('-')
+                    .unwrap_or("0")
+                    .parse()
+                    .unwrap_or(0);
             }
         } else if line.starts_with("# branch.oid ") {
             // track oid if needed
         } else if line.starts_with("# branch.upstream ") {
-            remote = Some(line.strip_prefix("# branch.upstream ").unwrap_or("").to_string());
+            remote = Some(
+                line.strip_prefix("# branch.upstream ")
+                    .unwrap_or("")
+                    .to_string(),
+            );
         } else if line.starts_with("u ") {
             // unmerged (conflicted) — porcelain v2 format:
             // u <xy> <sub> <m1> <m2> <m3> <mW> <h1> <h2> <h3> <path>
@@ -466,7 +479,11 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
             // 2 <XY> <sub> <mH> <mI> <mW> <hH> <hI> <Xscore> <path>\t<origPath>
             // Fields separated by spaces, but path and origPath separated by tab
             let tab_idx = line.find('\t');
-            let meta_part = if let Some(idx) = tab_idx { &line[..idx] } else { line };
+            let meta_part = if let Some(idx) = tab_idx {
+                &line[..idx]
+            } else {
+                line
+            };
             let fields: Vec<&str> = meta_part.split_whitespace().collect();
             if fields.len() < 10 {
                 continue;
@@ -532,7 +549,6 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
             if rev_output.status.success() {
                 let rev_str = String::from_utf8_lossy(&rev_output.stdout);
                 let nums: Vec<i32> = rev_str
-                    .trim()
                     .split_whitespace()
                     .filter_map(|s| s.parse().ok())
                     .collect();
@@ -565,7 +581,6 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
             {
                 if rl.status.success() {
                     let nums: Vec<i32> = String::from_utf8_lossy(&rl.stdout)
-                        .trim()
                         .split_whitespace()
                         .filter_map(|s| s.parse().ok())
                         .collect();
@@ -606,7 +621,9 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
                 if let Ok(o) = rl {
                     if o.status.success() {
                         ahead_push = String::from_utf8_lossy(&o.stdout)
-                            .trim().parse().unwrap_or(0);
+                            .trim()
+                            .parse()
+                            .unwrap_or(0);
                     }
                 }
                 push_remote = Some(push_ref);
@@ -637,11 +654,7 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
 /// "origin/feature") or None. Uses exact `rev-parse --verify` lookups so a
 /// branch named "x" never matches an unrelated "remote/foo/x".
 fn find_untracked_remote_ref_cli(cwd: &str, branch: &str) -> Option<String> {
-    let remotes_out = git_cmd()
-        .args(["remote"])
-        .current_dir(cwd)
-        .output()
-        .ok()?;
+    let remotes_out = git_cmd().args(["remote"]).current_dir(cwd).output().ok()?;
     if !remotes_out.status.success() {
         return None;
     }
@@ -788,6 +801,11 @@ pub(crate) async fn git_diff(cwd: String, path: String, staged: bool) -> Result<
 
 // ─── Git log ─────────────────────────────────────────────────
 
+// This signature is the Tauri IPC contract (see `backend.ts`); regrouping
+// its optional filters into a params struct is a frontend+backend API-shape
+// change, not a mechanical clippy fix. Deferred out of this chore(ci) PR —
+// see PR1 clippy cleanup notes.
+#[allow(clippy::too_many_arguments)]
 #[tauri::command]
 pub(crate) async fn git_log(
     cwd: String,
@@ -801,7 +819,7 @@ pub(crate) async fn git_log(
 ) -> Result<Vec<GitLogEntry>, String> {
     let _repo = repo_lock::read(&cwd);
     let limit = count.unwrap_or(100);
-    let skip  = offset.unwrap_or(0).max(0);
+    let skip = offset.unwrap_or(0).max(0);
     // Default: current branch only (like `git log`). Pass `all: true` to include all refs.
     let include_all = all.unwrap_or(false);
 
@@ -887,7 +905,6 @@ pub(crate) async fn git_log(
         }
 
         let parents: Vec<String> = fields[7]
-            .trim()
             .split_whitespace()
             .filter(|s| !s.is_empty())
             .map(|s| s.to_string())
@@ -906,7 +923,9 @@ pub(crate) async fn git_log(
         });
     }
 
-    entries.retain(|e| !e.message.starts_with("index on ") && !e.message.starts_with("untracked files on "));
+    entries.retain(|e| {
+        !e.message.starts_with("index on ") && !e.message.starts_with("untracked files on ")
+    });
 
     Ok(entries)
 }
@@ -930,10 +949,7 @@ pub(crate) async fn git_rev_count(
 ) -> Result<usize, String> {
     let include_all = all.unwrap_or(false);
 
-    let mut args: Vec<String> = vec![
-        "rev-list".to_string(),
-        "--count".to_string(),
-    ];
+    let mut args: Vec<String> = vec!["rev-list".to_string(), "--count".to_string()];
 
     if include_all {
         args.push("--all".to_string());
@@ -985,13 +1001,17 @@ pub(crate) async fn git_repo_state(cwd: String) -> Result<RepoOperationState, St
     let rebase_merge = git_dir.join("rebase-merge");
     if rebase_merge.exists() {
         let is_interactive = rebase_merge.join("interactive").exists();
-        let step  = read_git_u32(&rebase_merge.join("msgnum"));
+        let step = read_git_u32(&rebase_merge.join("msgnum"));
         let total = read_git_u32(&rebase_merge.join("end"));
-        let head  = read_git_file(&git_dir.join("REBASE_HEAD"));
+        let head = read_git_file(&git_dir.join("REBASE_HEAD"));
         let branch = read_git_file(&rebase_merge.join("head-name"))
             .map(|s| s.trim_start_matches("refs/heads/").to_string());
         return Ok(RepoOperationState {
-            state: if is_interactive { "rebase_interactive".into() } else { "rebase".into() },
+            state: if is_interactive {
+                "rebase_interactive".into()
+            } else {
+                "rebase".into()
+            },
             has_conflict: has_unresolved_conflicts(&cwd),
             operation_head: head,
             target_branch: branch,
@@ -1003,9 +1023,9 @@ pub(crate) async fn git_repo_state(cwd: String) -> Result<RepoOperationState, St
     // ── Old-style rebase-apply (git am / old --apply) ─────────────────────
     let rebase_apply = git_dir.join("rebase-apply");
     if rebase_apply.exists() {
-        let step  = read_git_u32(&rebase_apply.join("next"));
+        let step = read_git_u32(&rebase_apply.join("next"));
         let total = read_git_u32(&rebase_apply.join("last"));
-        let head  = read_git_file(&git_dir.join("REBASE_HEAD"));
+        let head = read_git_file(&git_dir.join("REBASE_HEAD"));
         let branch = read_git_file(&rebase_apply.join("head-name"))
             .map(|s| s.trim_start_matches("refs/heads/").to_string());
         return Ok(RepoOperationState {
@@ -1189,7 +1209,7 @@ pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, 
                     new_line_no: None,
                 });
                 old_line_no += 1;
-            } else if line.starts_with(' ') {
+            } else if let Some(stripped) = line.strip_prefix(' ') {
                 // Only accept lines that start with a literal space as context.
                 // Empty strings (from split on blank separator lines or trailing
                 // EOF newline) must NOT be classified as context — doing so adds
@@ -1198,7 +1218,7 @@ pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, 
                 // for new-file hunks (header becomes `-0,1` instead of `-0,0`).
                 hunk.lines.push(DiffLine {
                     r#type: "context".to_string(),
-                    content: line[1..].to_string(),
+                    content: stripped.to_string(),
                     old_line_no: Some(old_line_no),
                     new_line_no: Some(new_line_no),
                 });
@@ -1228,43 +1248,83 @@ pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, 
 // ─── File log (v1.9) — pickaxe + line-range ──────────────
 
 #[tauri::command]
-pub(crate) async fn git_file_log(cwd: String, path: String, count: Option<u32>) -> Result<Vec<FileLogEntry>, String> {
+pub(crate) async fn git_file_log(
+    cwd: String,
+    path: String,
+    count: Option<u32>,
+) -> Result<Vec<FileLogEntry>, String> {
     let _repo = repo_lock::read(&cwd);
     let n = count.unwrap_or(50).to_string();
     let fmt = "%H\n%h\n%an\n%aI\n%s\n%b\n---END---";
     let output = git_cmd()
-        .args(["log", "--follow", "-n", &n, &format!("--format={}", fmt), "--", &path])
+        .args([
+            "log",
+            "--follow",
+            "-n",
+            &n,
+            &format!("--format={}", fmt),
+            "--",
+            &path,
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("git log failed: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git log failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git log failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
-    Ok(parse_file_log_output(&String::from_utf8_lossy(&output.stdout)))
+    Ok(parse_file_log_output(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
 }
 
 /// Pickaxe: find commits that added or removed `search` string.
 /// mode: "S" (literal string) | "G" (regex)
 #[tauri::command]
-pub(crate) async fn git_file_log_pickaxe(cwd: String, path: String, search: String, mode: String) -> Result<Vec<FileLogEntry>, String> {
+pub(crate) async fn git_file_log_pickaxe(
+    cwd: String,
+    path: String,
+    search: String,
+    mode: String,
+) -> Result<Vec<FileLogEntry>, String> {
     let _repo = repo_lock::read(&cwd);
     let flag = if mode == "G" { "-G" } else { "-S" };
     let fmt = "%H\n%h\n%an\n%aI\n%s\n%b\n---END---";
     let output = git_cmd()
-        .args(["log", "--follow", flag, &search, &format!("--format={}", fmt), "--", &path])
+        .args([
+            "log",
+            "--follow",
+            flag,
+            &search,
+            &format!("--format={}", fmt),
+            "--",
+            &path,
+        ])
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("git log pickaxe failed: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git log pickaxe failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git log pickaxe failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
-    Ok(parse_file_log_output(&String::from_utf8_lossy(&output.stdout)))
+    Ok(parse_file_log_output(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
 }
 
 /// Line-range history: commits that touched lines [start..end] in path.
 /// Uses git log -L <start>,<end>:<path> (no --follow; incompatible with -L).
 #[tauri::command]
-pub(crate) async fn git_file_log_range(cwd: String, path: String, start_line: u32, end_line: u32) -> Result<Vec<FileLogEntry>, String> {
+pub(crate) async fn git_file_log_range(
+    cwd: String,
+    path: String,
+    start_line: u32,
+    end_line: u32,
+) -> Result<Vec<FileLogEntry>, String> {
     let _repo = repo_lock::read(&cwd);
     let range = format!("{},{}:{}", start_line, end_line, path);
     let fmt = "%H\n%h\n%an\n%aI\n%s\n%b\n---END---";
@@ -1274,15 +1334,24 @@ pub(crate) async fn git_file_log_range(cwd: String, path: String, start_line: u3
         .output()
         .map_err(|e| format!("git log -L failed: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git log -L failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git log -L failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
-    Ok(parse_file_log_output(&String::from_utf8_lossy(&output.stdout)))
+    Ok(parse_file_log_output(&String::from_utf8_lossy(
+        &output.stdout,
+    )))
 }
 
 /// Run `git blame --porcelain` on a file.
 /// algorithm: "histogram" | "patience" | "minimal" | "myers" (default "histogram").
 #[tauri::command]
-pub(crate) async fn git_blame(cwd: String, path: String, algorithm: Option<String>) -> Result<Vec<BlameLine>, String> {
+pub(crate) async fn git_blame(
+    cwd: String,
+    path: String,
+    algorithm: Option<String>,
+) -> Result<Vec<BlameLine>, String> {
     let _repo = repo_lock::read(&cwd);
     let algo = algorithm.as_deref().unwrap_or("histogram");
     let diff_algo_flag = format!("--diff-algorithm={}", algo);
@@ -1292,7 +1361,10 @@ pub(crate) async fn git_blame(cwd: String, path: String, algorithm: Option<Strin
         .output()
         .map_err(|e| format!("Failed to run git blame: {}", e))?;
     if !output.status.success() {
-        return Err(format!("git blame failed: {}", String::from_utf8_lossy(&output.stderr)));
+        return Err(format!(
+            "git blame failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
     }
     let raw = String::from_utf8_lossy(&output.stdout);
     let lines: Vec<&str> = raw.lines().collect();
@@ -1330,7 +1402,16 @@ pub(crate) async fn git_blame(cwd: String, path: String, algorithm: Option<Strin
             content = lines[i][1..].to_string();
             i += 1;
         }
-        blame_lines.push(BlameLine { hash, hash_full, final_line, orig_line, author, author_date, summary, content });
+        blame_lines.push(BlameLine {
+            hash,
+            hash_full,
+            final_line,
+            orig_line,
+            author,
+            author_date,
+            summary,
+            content,
+        });
     }
     Ok(blame_lines)
 }
@@ -1350,7 +1431,10 @@ pub(crate) async fn git_blame(cwd: String, path: String, algorithm: Option<Strin
 //   7. Retourner la liste brute — le résolveur tourne côté frontend (TypeScript)
 
 #[tauri::command]
-pub(crate) async fn preview_merge(cwd: String, source_branch: String) -> Result<Vec<FileMergePreview>, String> {
+pub(crate) async fn preview_merge(
+    cwd: String,
+    source_branch: String,
+) -> Result<Vec<FileMergePreview>, String> {
     let git = git_binary();
 
     // 1. Merge-base
@@ -1374,19 +1458,29 @@ pub(crate) async fn preview_merge(cwd: String, source_branch: String) -> Result<
 
     // 4. Intersection : modifiés des deux côtés
     let ours_set: std::collections::HashSet<&String> = ours_files.iter().collect();
-    let both_modified: Vec<&String> = theirs_files.iter().filter(|f| ours_set.contains(f)).collect();
+    let both_modified: Vec<&String> = theirs_files
+        .iter()
+        .filter(|f| ours_set.contains(f))
+        .collect();
 
     // 5. Fichiers supprimés/ajoutés unilatéralement
     let theirs_set: std::collections::HashSet<&String> = theirs_files.iter().collect();
-    let only_ours: Vec<&String> = ours_files.iter().filter(|f| !theirs_set.contains(f)).collect();
-    let only_theirs: Vec<&String> = theirs_files.iter().filter(|f| !ours_set.contains(f)).collect();
+    let only_ours: Vec<&String> = ours_files
+        .iter()
+        .filter(|f| !theirs_set.contains(f))
+        .collect();
+    let only_theirs: Vec<&String> = theirs_files
+        .iter()
+        .filter(|f| !ours_set.contains(f))
+        .collect();
 
     let tmp = std::env::temp_dir();
     let mut results: Vec<FileMergePreview> = Vec::new();
 
     // 6. Pour chaque fichier modifié des deux côtés → tenter git merge-file
     for file_path in both_modified {
-        let preview = merge_file_preview(&git, &cwd, &base, "HEAD", &source_branch, file_path, &tmp);
+        let preview =
+            merge_file_preview(&git, &cwd, &base, "HEAD", &source_branch, file_path, &tmp);
         results.push(preview);
     }
 
@@ -1412,7 +1506,8 @@ pub(crate) async fn preview_merge(cwd: String, source_branch: String) -> Result<
 
     // Trier : conflits en premier, puis par chemin
     results.sort_by(|a, b| {
-        b.has_conflicts.cmp(&a.has_conflicts)
+        b.has_conflicts
+            .cmp(&a.has_conflicts)
             .then(a.file_path.cmp(&b.file_path))
     });
 
@@ -1473,15 +1568,26 @@ fn build_3way_preview(
     let ours_set: std::collections::HashSet<&String> = ours_files.iter().collect();
     let theirs_set: std::collections::HashSet<&String> = theirs_files.iter().collect();
 
-    let both_modified: Vec<&String> = theirs_files.iter().filter(|f| ours_set.contains(f)).collect();
-    let only_ours: Vec<&String> = ours_files.iter().filter(|f| !theirs_set.contains(f)).collect();
-    let only_theirs: Vec<&String> = theirs_files.iter().filter(|f| !ours_set.contains(f)).collect();
+    let both_modified: Vec<&String> = theirs_files
+        .iter()
+        .filter(|f| ours_set.contains(f))
+        .collect();
+    let only_ours: Vec<&String> = ours_files
+        .iter()
+        .filter(|f| !theirs_set.contains(f))
+        .collect();
+    let only_theirs: Vec<&String> = theirs_files
+        .iter()
+        .filter(|f| !ours_set.contains(f))
+        .collect();
 
     let tmp = std::env::temp_dir();
     let mut results: Vec<FileMergePreview> = Vec::new();
 
     for file_path in both_modified {
-        results.push(merge_file_preview(git, cwd, ancestor, ours_ref, theirs_ref, file_path, &tmp));
+        results.push(merge_file_preview(
+            git, cwd, ancestor, ours_ref, theirs_ref, file_path, &tmp,
+        ));
     }
     for file_path in only_ours {
         results.push(FileMergePreview {
@@ -1501,7 +1607,8 @@ fn build_3way_preview(
     }
 
     results.sort_by(|a, b| {
-        b.has_conflicts.cmp(&a.has_conflicts)
+        b.has_conflicts
+            .cmp(&a.has_conflicts)
             .then(a.file_path.cmp(&b.file_path))
     });
 
@@ -1524,7 +1631,10 @@ fn build_3way_preview(
 /// multiple commits, the entry with the most conflicts is kept so that
 /// intermediate conflicts are not silently dropped.
 #[tauri::command]
-pub(crate) async fn preview_rebase(cwd: String, onto: String) -> Result<Vec<FileMergePreview>, String> {
+pub(crate) async fn preview_rebase(
+    cwd: String,
+    onto: String,
+) -> Result<Vec<FileMergePreview>, String> {
     let git = git_binary();
 
     // Fail fast on an unknown / invalid `onto` ref.
@@ -1594,12 +1704,20 @@ pub(crate) async fn preview_rebase(cwd: String, onto: String) -> Result<Vec<File
             Some(existing) => {
                 // Prefer the entry with more conflict signal:
                 // is_add_delete > has_conflicts (with markers) > clean.
-                let new_score = if preview.is_add_delete { 2u8 }
-                    else if preview.has_conflicts { 1 }
-                    else { 0 };
-                let old_score = if existing.is_add_delete { 2u8 }
-                    else if existing.has_conflicts { 1 }
-                    else { 0 };
+                let new_score = if preview.is_add_delete {
+                    2u8
+                } else if preview.has_conflicts {
+                    1
+                } else {
+                    0
+                };
+                let old_score = if existing.is_add_delete {
+                    2u8
+                } else if existing.has_conflicts {
+                    1
+                } else {
+                    0
+                };
                 new_score > old_score
             }
         };
@@ -1610,7 +1728,8 @@ pub(crate) async fn preview_rebase(cwd: String, onto: String) -> Result<Vec<File
 
     let mut results: Vec<FileMergePreview> = by_file.into_values().collect();
     results.sort_by(|a, b| {
-        b.has_conflicts.cmp(&a.has_conflicts)
+        b.has_conflicts
+            .cmp(&a.has_conflicts)
             .then(a.file_path.cmp(&b.file_path))
     });
 
@@ -1625,7 +1744,10 @@ pub(crate) async fn preview_rebase(cwd: String, onto: String) -> Result<Vec<File
 ///   - ours  = HEAD   (where it is being applied)
 ///   - theirs = commit (the change being picked)
 #[tauri::command]
-pub(crate) async fn preview_cherry_pick(cwd: String, commit: String) -> Result<Vec<FileMergePreview>, String> {
+pub(crate) async fn preview_cherry_pick(
+    cwd: String,
+    commit: String,
+) -> Result<Vec<FileMergePreview>, String> {
     let git = git_binary();
 
     // Resolve the commit and ensure HEAD exists (clear error on a fresh repo).
@@ -1665,7 +1787,11 @@ fn merge_file_preview(
             .current_dir(cwd)
             .output()
             .ok()?;
-        if out.status.success() { Some(out.stdout) } else { None }
+        if out.status.success() {
+            Some(out.stdout)
+        } else {
+            None
+        }
     }
 
     let base_bytes = git_show_file(git, cwd, base_ref, file_path);
@@ -1687,8 +1813,8 @@ fn merge_file_preview(
 
     // Écrire les trois versions dans des fichiers temporaires
     let prefix = file_path.replace(['/', '\\', '.'], "_");
-    let tmp_base  = tmp.join(format!("{}_base.tmp", prefix));
-    let tmp_ours  = tmp.join(format!("{}_ours.tmp", prefix));
+    let tmp_base = tmp.join(format!("{}_base.tmp", prefix));
+    let tmp_ours = tmp.join(format!("{}_ours.tmp", prefix));
     let tmp_theirs = tmp.join(format!("{}_theirs.tmp", prefix));
 
     let write_or_empty = |path: &std::path::Path, bytes: &Option<Vec<u8>>| {
@@ -1752,7 +1878,10 @@ fn merge_file_preview(
 /// Excludes the current branch and the default branch itself.
 /// Equivalent to `git branch --merged <default_branch> --format="%(refname:short)"`.
 #[tauri::command]
-pub(crate) async fn git_branch_merged(cwd: String, default_branch: Option<String>) -> Result<Vec<String>, String> {
+pub(crate) async fn git_branch_merged(
+    cwd: String,
+    default_branch: Option<String>,
+) -> Result<Vec<String>, String> {
     use crate::git::cmd::{git_cmd, resolve_default_branch};
 
     let _repo = repo_lock::read(&cwd);
@@ -1809,7 +1938,9 @@ pub(crate) async fn git_config_identity(cwd: String) -> Result<(String, String),
         .map_err(|e| e.to_string())?;
 
     let name = String::from_utf8_lossy(&name_out.stdout).trim().to_string();
-    let email = String::from_utf8_lossy(&email_out.stdout).trim().to_string();
+    let email = String::from_utf8_lossy(&email_out.stdout)
+        .trim()
+        .to_string();
 
     if name.is_empty() || email.is_empty() {
         return Err("git user.name or user.email is not configured".to_string());
@@ -1839,11 +1970,11 @@ pub(crate) async fn git_commit_template_path(cwd: String) -> Result<Option<Strin
     }
 
     // Expand leading ~
-    let expanded = if raw.starts_with('~') {
+    let expanded = if let Some(stripped) = raw.strip_prefix('~') {
         let home = std::env::var("HOME")
             .or_else(|_| std::env::var("USERPROFILE"))
             .unwrap_or_default();
-        format!("{}{}", home, &raw[1..])
+        format!("{}{}", home, stripped)
     } else {
         raw
     };
@@ -1886,7 +2017,8 @@ mod predictor_tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let dir = std::env::temp_dir().join(format!("gitwand-predictor-test-{}-{}-{}", pid, n, nanos));
+            let dir = std::env::temp_dir()
+                .join(format!("gitwand-predictor-test-{}-{}-{}", pid, n, nanos));
             std::fs::create_dir_all(&dir).unwrap();
             let repo = TempRepo { path: dir };
             repo.git(&["init", "-q", "-b", "main"]);
@@ -2004,7 +2136,11 @@ mod predictor_tests {
 
         // Working tree + HEAD must be untouched.
         assert_eq!(repo.head_sha(), head_before, "HEAD moved during preview");
-        assert_eq!(porcelain(&repo), status_before, "working tree mutated during preview");
+        assert_eq!(
+            porcelain(&repo),
+            status_before,
+            "working tree mutated during preview"
+        );
         assert_eq!(repo.read("shared.txt"), "line1\nFEATURE\nline3\n");
     }
 
@@ -2097,8 +2233,16 @@ mod predictor_tests {
             .output()
             .unwrap();
         let commits_str = String::from_utf8_lossy(&commits_out.stdout);
-        let commits: Vec<&str> = commits_str.lines().map(|l| l.trim()).filter(|l| !l.is_empty()).collect();
-        assert_eq!(commits.len(), 2, "should have exactly 2 commits in the stack");
+        let commits: Vec<&str> = commits_str
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .collect();
+        assert_eq!(
+            commits.len(),
+            2,
+            "should have exactly 2 commits in the stack"
+        );
 
         let mut all_previews: Vec<FileMergePreview> = Vec::new();
         for commit in &commits {
@@ -2108,7 +2252,8 @@ mod predictor_tests {
             all_previews.append(&mut pp);
         }
         // At least one entry for shared.txt must have has_conflicts = true.
-        let conflict_files: Vec<String> = all_previews.iter()
+        let conflict_files: Vec<String> = all_previews
+            .iter()
             .filter(|p| p.has_conflicts)
             .map(|p| p.file_path.clone())
             .collect();
@@ -2158,7 +2303,11 @@ mod predictor_tests {
         );
 
         assert_eq!(repo.head_sha(), head_before, "HEAD moved during preview");
-        assert_eq!(porcelain(&repo), status_before, "working tree mutated during preview");
+        assert_eq!(
+            porcelain(&repo),
+            status_before,
+            "working tree mutated during preview"
+        );
         assert_eq!(repo.read("shared.txt"), "x\nMAIN\nz\n");
     }
 
@@ -2235,8 +2384,8 @@ mod pathspec_tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let dir = std::env::temp_dir()
-                .join(format!("gitwand-pathspec-test-{}-{}-{}", pid, n, nanos));
+            let dir =
+                std::env::temp_dir().join(format!("gitwand-pathspec-test-{}-{}-{}", pid, n, nanos));
             std::fs::create_dir_all(&dir).unwrap();
             let repo = TempRepo { path: dir };
             repo.git(&["init", "-q", "-b", "main"]);
@@ -2300,13 +2449,23 @@ mod pathspec_tests {
 
         let all_entries = tauri::async_runtime::block_on(git_log(
             repo.cwd(),
-            None, None, None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ))
         .expect("git_log(all) failed");
 
         let scoped_a = tauri::async_runtime::block_on(git_log(
             repo.cwd(),
-            None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
             Some("packages/a".to_string()),
             None,
         ))
@@ -2314,7 +2473,11 @@ mod pathspec_tests {
 
         let scoped_b = tauri::async_runtime::block_on(git_log(
             repo.cwd(),
-            None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
             Some("packages/b".to_string()),
             None,
         ))
@@ -2323,11 +2486,19 @@ mod pathspec_tests {
         // All: 3 commits
         assert_eq!(all_entries.len(), 3, "expected 3 unscoped commits");
         // packages/a: commits 1 (add a) + 3 (touch both) = 2
-        assert_eq!(scoped_a.len(), 2, "expected 2 commits for packages/a, got {:?}",
-            scoped_a.iter().map(|e| &e.message).collect::<Vec<_>>());
+        assert_eq!(
+            scoped_a.len(),
+            2,
+            "expected 2 commits for packages/a, got {:?}",
+            scoped_a.iter().map(|e| &e.message).collect::<Vec<_>>()
+        );
         // packages/b: commits 2 (add b) + 3 (touch both) = 2
-        assert_eq!(scoped_b.len(), 2, "expected 2 commits for packages/b, got {:?}",
-            scoped_b.iter().map(|e| &e.message).collect::<Vec<_>>());
+        assert_eq!(
+            scoped_b.len(),
+            2,
+            "expected 2 commits for packages/b, got {:?}",
+            scoped_b.iter().map(|e| &e.message).collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -2338,7 +2509,13 @@ mod pathspec_tests {
 
         let entries = tauri::async_runtime::block_on(git_log(
             repo.cwd(),
-            None, None, None, None, None, None, None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ))
         .expect("git_log failed");
 
@@ -2357,18 +2534,28 @@ mod pathspec_tests {
         repo.write("a.txt", "3");
         repo.commit_all("c3");
 
-        let count = tauri::async_runtime::block_on(git_rev_count(
-            repo.cwd(), None, None, None,
-        ))
-        .expect("git_rev_count failed");
+        let count = tauri::async_runtime::block_on(git_rev_count(repo.cwd(), None, None, None))
+            .expect("git_rev_count failed");
 
         let log = tauri::async_runtime::block_on(git_log(
             repo.cwd(),
-            Some(1000), None, None, None, None, None, None,
+            Some(1000),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
         ))
         .expect("git_log failed");
 
-        assert_eq!(count, log.len(), "rev_count ({}) should match log len ({})", count, log.len());
+        assert_eq!(
+            count,
+            log.len(),
+            "rev_count ({}) should match log len ({})",
+            count,
+            log.len()
+        );
     }
 
     #[test]
@@ -2384,20 +2571,32 @@ mod pathspec_tests {
         repo.commit_all("b1");
 
         let count_a = tauri::async_runtime::block_on(git_rev_count(
-            repo.cwd(), None, None, Some("packages/a".to_string()),
+            repo.cwd(),
+            None,
+            None,
+            Some("packages/a".to_string()),
         ))
         .expect("git_rev_count(a) failed");
 
         let log_a = tauri::async_runtime::block_on(git_log(
             repo.cwd(),
-            Some(1000), None, None, None, None,
+            Some(1000),
+            None,
+            None,
+            None,
+            None,
             Some("packages/a".to_string()),
             None,
         ))
         .expect("git_log(a) failed");
 
-        assert_eq!(count_a, log_a.len(),
-            "scoped rev_count ({}) should match scoped log len ({})", count_a, log_a.len());
+        assert_eq!(
+            count_a,
+            log_a.len(),
+            "scoped rev_count ({}) should match scoped log len ({})",
+            count_a,
+            log_a.len()
+        );
         assert_eq!(count_a, 2, "packages/a has 2 commits");
     }
 
@@ -2405,10 +2604,8 @@ mod pathspec_tests {
     fn git_rev_count_empty_repo_returns_zero() {
         let repo = TempRepo::new();
         // fresh repo — HEAD doesn't exist yet
-        let count = tauri::async_runtime::block_on(git_rev_count(
-            repo.cwd(), None, None, None,
-        ))
-        .expect("git_rev_count on empty repo failed");
+        let count = tauri::async_runtime::block_on(git_rev_count(repo.cwd(), None, None, None))
+            .expect("git_rev_count on empty repo failed");
         assert_eq!(count, 0);
     }
 
@@ -2432,11 +2629,13 @@ mod pathspec_tests {
         let untracked_a: Vec<&str> = status_a.untracked.iter().map(|s| s.as_str()).collect();
         assert!(
             untracked_a.iter().any(|p| p.contains("packages/a")),
-            "expected packages/a in untracked: {:?}", untracked_a
+            "expected packages/a in untracked: {:?}",
+            untracked_a
         );
         assert!(
             !untracked_a.iter().any(|p| p.contains("packages/b")),
-            "packages/b should NOT appear in packages/a scope: {:?}", untracked_a
+            "packages/b should NOT appear in packages/a scope: {:?}",
+            untracked_a
         );
     }
 
@@ -2448,13 +2647,18 @@ mod pathspec_tests {
         repo.write("packages/a/dirty.txt", "dirty a");
         repo.write("packages/b/dirty.txt", "dirty b");
 
-        let status = git_status_cli(repo.cwd(), None)
-            .expect("git_status_cli(None) failed");
+        let status = git_status_cli(repo.cwd(), None).expect("git_status_cli(None) failed");
 
         let all_paths: Vec<&str> = status.untracked.iter().map(|s| s.as_str()).collect();
         // Both subtrees should appear
-        let has_a = all_paths.iter().any(|p| p.contains("packages/a") || p.contains("packages/"));
-        assert!(has_a, "unscoped status should show all changes: {:?}", all_paths);
+        let has_a = all_paths
+            .iter()
+            .any(|p| p.contains("packages/a") || p.contains("packages/"));
+        assert!(
+            has_a,
+            "unscoped status should show all changes: {:?}",
+            all_paths
+        );
     }
 
     // ── Remote branch existence without configured upstream ───────
@@ -2471,8 +2675,7 @@ mod pathspec_tests {
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let dir = std::env::temp_dir()
-            .join(format!("gitwand-bare-remote-{}-{}-{}", pid, n, nanos));
+        let dir = std::env::temp_dir().join(format!("gitwand-bare-remote-{}-{}-{}", pid, n, nanos));
         let out = Command::new(git_binary())
             .args(["init", "--bare", "-q", "-b", "main"])
             .arg(&dir)
@@ -2501,14 +2704,20 @@ mod pathspec_tests {
         let s = tauri::async_runtime::block_on(git_status(repo.cwd(), None))
             .expect("git_status failed");
         assert_eq!(s.remote, None, "no upstream should be configured");
-        assert!(s.remote_branch_exists, "remote-tracking ref should be detected");
+        assert!(
+            s.remote_branch_exists,
+            "remote-tracking ref should be detected"
+        );
         assert_eq!(s.ahead, 1, "one local commit ahead of origin/main");
         assert_eq!(s.behind, 0);
 
         // CLI fallback path must agree.
         let c = git_status_cli(repo.cwd(), None).expect("git_status_cli failed");
         assert_eq!(c.remote, None);
-        assert!(c.remote_branch_exists, "CLI path should also detect the remote ref");
+        assert!(
+            c.remote_branch_exists,
+            "CLI path should also detect the remote ref"
+        );
         assert_eq!(c.ahead, 1);
         assert_eq!(c.behind, 0);
 
@@ -2531,10 +2740,16 @@ mod pathspec_tests {
         let s = tauri::async_runtime::block_on(git_status(repo.cwd(), None))
             .expect("git_status failed");
         assert_eq!(s.remote, None);
-        assert!(!s.remote_branch_exists, "unpushed branch must not look published");
+        assert!(
+            !s.remote_branch_exists,
+            "unpushed branch must not look published"
+        );
 
         let c = git_status_cli(repo.cwd(), None).expect("git_status_cli failed");
-        assert!(!c.remote_branch_exists, "CLI path agrees: branch is unpublished");
+        assert!(
+            !c.remote_branch_exists,
+            "CLI path agrees: branch is unpublished"
+        );
 
         let _ = std::fs::remove_dir_all(&bare);
     }
@@ -2552,7 +2767,10 @@ mod pathspec_tests {
         let s = tauri::async_runtime::block_on(git_status(repo.cwd(), None))
             .expect("git_status failed");
         assert_eq!(s.remote.as_deref(), Some("origin/main"));
-        assert!(s.remote_branch_exists, "configured upstream implies it exists");
+        assert!(
+            s.remote_branch_exists,
+            "configured upstream implies it exists"
+        );
 
         let _ = std::fs::remove_dir_all(&bare);
     }
@@ -2589,8 +2807,10 @@ mod branch_merged_tests {
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
                 .as_nanos();
-            let dir = std::env::temp_dir()
-                .join(format!("gitwand-branch-merged-test-{}-{}-{}", pid, n, nanos));
+            let dir = std::env::temp_dir().join(format!(
+                "gitwand-branch-merged-test-{}-{}-{}",
+                pid, n, nanos
+            ));
             std::fs::create_dir_all(&dir).unwrap();
             let repo = TempRepo { path: dir };
             repo.git_ok(&["init", "-q", "-b", "trunk"]);

--- a/apps/desktop/src-tauri/src/commands/scratch.rs
+++ b/apps/desktop/src-tauri/src/commands/scratch.rs
@@ -76,12 +76,15 @@ fn validate_scratch_path(cwd: &Path, scratch_path: &str) -> Result<PathBuf, Stri
     // Must be registered as a worktree of this repo (porcelain output lists the
     // absolute path on each `worktree ` line).
     let list = git_in(cwd, &["worktree", "list", "--porcelain"])?;
-    let registered = list.lines().filter_map(|l| l.strip_prefix("worktree ")).any(|p| {
-        Path::new(p)
-            .canonicalize()
-            .map(|c| c == candidate)
-            .unwrap_or(false)
-    });
+    let registered = list
+        .lines()
+        .filter_map(|l| l.strip_prefix("worktree "))
+        .any(|p| {
+            Path::new(p)
+                .canonicalize()
+                .map(|c| c == candidate)
+                .unwrap_or(false)
+        });
     if !registered {
         return Err(format!(
             "scratch_path is not a registered worktree of this repo: {}",
@@ -158,8 +161,21 @@ fn scratch_worktree_create_impl(
     // commit. This rejects a leading-dash value (e.g. "--no-checkout", "--detach")
     // — which git would otherwise treat as a flag — as `fatal: invalid reference`.
     // The trailing `--` separator below is a second, defence-in-depth guard.
-    if git_in(&repo_root, &["rev-parse", "--verify", "--quiet", &format!("{}^{{commit}}", base_ref)]).is_err() {
-        return Err(format!("source ref does not resolve to a commit: {}", base_ref));
+    if git_in(
+        &repo_root,
+        &[
+            "rev-parse",
+            "--verify",
+            "--quiet",
+            &format!("{}^{{commit}}", base_ref),
+        ],
+    )
+    .is_err()
+    {
+        return Err(format!(
+            "source ref does not resolve to a commit: {}",
+            base_ref
+        ));
     }
 
     // Timestamp generated Rust-side so the frontend never has to.
@@ -299,7 +315,13 @@ fn scratch_worktree_merge_back_impl(cwd: String, scratch_path: String) -> Result
     // from the main working tree + index, then overlay the remaining content.
     let deleted = git_in(
         &repo_root,
-        &["diff", "--name-only", "--diff-filter=D", "HEAD", &scratch_branch],
+        &[
+            "diff",
+            "--name-only",
+            "--diff-filter=D",
+            "HEAD",
+            &scratch_branch,
+        ],
     )?;
     for path in deleted.lines().map(str::trim).filter(|p| !p.is_empty()) {
         // `--` separates the pathspec from options; `--ignore-unmatch` keeps the
@@ -445,8 +467,8 @@ mod tests {
         repo.commit_all("base");
 
         // Create the scratch worktree off the current HEAD.
-        let scratch = scratch_worktree_create_impl(repo.cwd(), None, None)
-            .expect("create should succeed");
+        let scratch =
+            scratch_worktree_create_impl(repo.cwd(), None, None).expect("create should succeed");
 
         assert!(scratch.branch.starts_with("gitwand-scratch-"));
         assert_eq!(scratch.source_branch, "main");
@@ -490,7 +512,9 @@ mod tests {
         // test's own temp parent dir is named "gitwand-scratch-test-…".)
         let list = repo.worktree_list();
         assert!(
-            !list.lines().any(|l| l.starts_with("branch refs/heads/gitwand-scratch-")),
+            !list
+                .lines()
+                .any(|l| l.starts_with("branch refs/heads/gitwand-scratch-")),
             "no scratch worktree should remain registered, got: {}",
             list
         );
@@ -516,8 +540,8 @@ mod tests {
             .output()
             .unwrap();
 
-        let scratch = scratch_worktree_create_impl(repo.cwd(), None, None)
-            .expect("create should succeed");
+        let scratch =
+            scratch_worktree_create_impl(repo.cwd(), None, None).expect("create should succeed");
 
         let err = scratch_worktree_merge_back_impl(repo.cwd(), scratch.path.clone())
             .expect_err("merge_back must be refused on a conflicted main checkout");
@@ -537,8 +561,8 @@ mod tests {
         repo.write("file.txt", "original\n");
         repo.commit_all("base");
 
-        let scratch = scratch_worktree_create_impl(repo.cwd(), None, None)
-            .expect("create should succeed");
+        let scratch =
+            scratch_worktree_create_impl(repo.cwd(), None, None).expect("create should succeed");
         assert!(Path::new(&scratch.path).exists());
 
         scratch_worktree_discard_impl(repo.cwd(), scratch.path.clone())
@@ -551,7 +575,9 @@ mod tests {
         // test's own temp parent dir is named "gitwand-scratch-test-…".)
         let list = repo.worktree_list();
         assert!(
-            !list.lines().any(|l| l.starts_with("branch refs/heads/gitwand-scratch-")),
+            !list
+                .lines()
+                .any(|l| l.starts_with("branch refs/heads/gitwand-scratch-")),
             "no scratch worktree should remain registered, got: {}",
             list
         );
@@ -561,9 +587,18 @@ mod tests {
 
     #[test]
     fn slugify_produces_ref_safe_names_or_none() {
-        assert_eq!(slugify_task_name("Fix login bug"), Some("fix-login-bug".to_string()));
-        assert_eq!(slugify_task_name("  Refactor!! API  "), Some("refactor-api".to_string()));
-        assert_eq!(slugify_task_name("feature/foo@bar"), Some("feature-foo-bar".to_string()));
+        assert_eq!(
+            slugify_task_name("Fix login bug"),
+            Some("fix-login-bug".to_string())
+        );
+        assert_eq!(
+            slugify_task_name("  Refactor!! API  "),
+            Some("refactor-api".to_string())
+        );
+        assert_eq!(
+            slugify_task_name("feature/foo@bar"),
+            Some("feature-foo-bar".to_string())
+        );
         // All-punctuation / empty → no usable slug.
         assert_eq!(slugify_task_name("   "), None);
         assert_eq!(slugify_task_name("!!!"), None);
@@ -586,7 +621,11 @@ mod tests {
                 .expect("create should succeed");
 
         assert_eq!(scratch.branch, "gitwand-scratch-fix-login-bug");
-        let base = Path::new(&scratch.path).file_name().unwrap().to_str().unwrap();
+        let base = Path::new(&scratch.path)
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap();
         assert_eq!(base, "gitwand-scratch-fix-login-bug");
 
         // Still recognised + removable by the validated cleanup path.

--- a/apps/desktop/src-tauri/src/commands/secrets.rs
+++ b/apps/desktop/src-tauri/src/commands/secrets.rs
@@ -151,7 +151,10 @@ const BUILT_IN_PATTERNS: &[BuiltInPattern] = &[
 
 /// Pure, synchronously-testable core scanner. Mirrors `scanSecrets` in
 /// `packages/core/src/secrets/scanner.ts`.
-pub(crate) fn scan_lines(files: &[ScanFileInput], config: &SecretsScanConfig) -> Vec<SecretFinding> {
+pub(crate) fn scan_lines(
+    files: &[ScanFileInput],
+    config: &SecretsScanConfig,
+) -> Vec<SecretFinding> {
     if !config.enabled {
         return Vec::new();
     }
@@ -162,6 +165,12 @@ pub(crate) fn scan_lines(files: &[ScanFileInput], config: &SecretsScanConfig) ->
         .map(|s| s.to_string())
         .chain(config.ignore.iter().cloned())
         .collect();
+
+    // Precompile the ignore set once — `is_ignored()` used to recompile every entry's regex
+    // (up to 12+ for `DEFAULT_IGNORE_GLOBS` alone) on every call, and it's called once per
+    // pattern match AND once per high-entropy token, for every added line of every file. See
+    // apps/desktop/CLAUDE.md / AGENTS.md perf notes on this module.
+    let compiled_ignore = CompiledIgnore::compile(&effective_ignore);
 
     // Compile built-in + user patterns once. A malformed user regex is skipped, never fatal —
     // `regex` is linear-time so it can't hang the app, but we still don't trust arbitrary
@@ -193,7 +202,7 @@ pub(crate) fn scan_lines(files: &[ScanFileInput], config: &SecretsScanConfig) ->
                         continue;
                     }
                     matched_ranges.push((m.start(), m.end()));
-                    if !is_ignored(&file.path, value, &effective_ignore) {
+                    if !is_ignored(&file.path, value, &compiled_ignore) {
                         findings.push(SecretFinding {
                             file: file.path.clone(),
                             line: line.line,
@@ -218,7 +227,7 @@ pub(crate) fn scan_lines(files: &[ScanFileInput], config: &SecretsScanConfig) ->
                         continue;
                     }
                     if shannon_entropy(token) >= config.entropy_threshold
-                        && !is_ignored(&file.path, token, &effective_ignore)
+                        && !is_ignored(&file.path, token, &compiled_ignore)
                     {
                         findings.push(SecretFinding {
                             file: file.path.clone(),
@@ -272,42 +281,85 @@ fn redact(value: &str) -> String {
     format!("{}\u{2026}{}", lead, trail)
 }
 
+/// One precompiled path-glob entry from `.gitwandrc` `secrets.ignore[]`. `basename_only` mirrors
+/// the "pattern has no `/`" branch of the old `match_glob` — decided once per entry at compile
+/// time instead of being recomputed on every candidate value.
+struct CompiledGlob {
+    basename_only: bool,
+    re: Regex,
+}
+
+/// Precompiled form of `effective_ignore`, built once per `scan_lines()` call and reused by
+/// every `is_ignored()` call for that scan (once per pattern match, once per high-entropy
+/// token, for every added line of every file). Mirrors the split of the TS `.gitwandrc`
+/// `secrets.ignore[]` semantics: value-regex literals (`/.../ `) vs. path globs.
+struct CompiledIgnore {
+    /// Path-glob entries (anything not wrapped in `/.../ `).
+    globs: Vec<CompiledGlob>,
+    /// Value-regex-literal entries (`/.../ `), tested against the matched value, never the path.
+    regexes: Vec<Regex>,
+}
+
+impl CompiledIgnore {
+    /// Compiles every `.gitwandrc` `secrets.ignore[]` entry exactly once. A malformed
+    /// value-regex-literal is silently skipped, never fatal (same tolerance as the pattern
+    /// compilation above) — it simply never contributes a match.
+    fn compile(ignore: &[String]) -> Self {
+        let mut globs = Vec::new();
+        let mut regexes = Vec::new();
+        for entry in ignore {
+            if entry.len() >= 2 && entry.starts_with('/') && entry.ends_with('/') {
+                let body = &entry[1..entry.len() - 1];
+                if let Ok(re) = Regex::new(body) {
+                    regexes.push(re);
+                }
+                continue;
+            }
+            let normalized_pattern = entry.replace('\\', "/");
+            let basename_only = !normalized_pattern.contains('/');
+            globs.push(CompiledGlob {
+                basename_only,
+                re: glob_regex(&normalized_pattern),
+            });
+        }
+        CompiledIgnore { globs, regexes }
+    }
+}
+
 /// `true` if the matched value or file should be ignored, per `.gitwandrc` `secrets.ignore[]`.
 /// A `/.../ ` entry is a regex literal tested against the matched value; anything else is a path
-/// glob tested against `path` (mirrors `matchGlob` in `packages/core/src/config.ts`).
-fn is_ignored(path: &str, value: &str, ignore: &[String]) -> bool {
-    for entry in ignore {
-        if entry.len() >= 2 && entry.starts_with('/') && entry.ends_with('/') {
-            let body = &entry[1..entry.len() - 1];
-            if let Ok(re) = Regex::new(body) {
-                if re.is_match(value) {
-                    return true;
-                }
-            }
-            continue;
+/// glob tested against `path` (mirrors `matchGlob` in `packages/core/src/config.ts`). Takes the
+/// set precompiled once by `CompiledIgnore::compile` — never compiles a regex itself.
+fn is_ignored(path: &str, value: &str, ignore: &CompiledIgnore) -> bool {
+    for re in &ignore.regexes {
+        if re.is_match(value) {
+            return true;
         }
-        if match_glob(entry, path) {
+    }
+    if ignore.globs.is_empty() {
+        return false;
+    }
+    let normalized_path = path.replace('\\', "/");
+    for glob in &ignore.globs {
+        let subject: &str = if glob.basename_only {
+            normalized_path
+                .rsplit('/')
+                .next()
+                .unwrap_or(&normalized_path)
+        } else {
+            normalized_path.as_str()
+        };
+        if glob.re.is_match(subject) {
             return true;
         }
     }
     false
 }
 
-/// Minimal glob matcher — mirrors `matchGlob` in `packages/core/src/config.ts`.
-/// Supports `*` (any char but `/`), `**` (any char), `?` (one char but `/`), and basename
-/// matching when the pattern has no `/`.
-fn match_glob(pattern: &str, file_path: &str) -> bool {
-    let normalized_path = file_path.replace('\\', "/");
-    let normalized_pattern = pattern.replace('\\', "/");
-
-    if !normalized_pattern.contains('/') {
-        let basename = normalized_path.rsplit('/').next().unwrap_or(&normalized_path);
-        return glob_regex(&normalized_pattern).is_match(basename);
-    }
-
-    glob_regex(&normalized_pattern).is_match(&normalized_path)
-}
-
+/// Minimal glob-to-regex compiler — mirrors `globRegex` in `packages/core/src/config.ts`.
+/// Supports `*` (any char but `/`), `**` (any char), `?` (one char but `/`). Called only at
+/// `CompiledIgnore::compile()` time now, never in the hot scanning loop. Its internal logic
+/// (placeholder for `**`, escaping, `^...$` anchoring) is unchanged — locked by the parity test.
 fn glob_regex(pattern: &str) -> Regex {
     const DSTAR_PLACEHOLDER: &str = "\u{0}DSTAR\u{0}";
 
@@ -328,7 +380,8 @@ fn glob_regex(pattern: &str) -> Regex {
         .replace('?', "[^/]")
         .replace(DSTAR_PLACEHOLDER, ".*");
 
-    Regex::new(&format!("^{}$", replaced)).unwrap_or_else(|_| Regex::new("$^").expect("literal never-match regex must compile"))
+    Regex::new(&format!("^{}$", replaced))
+        .unwrap_or_else(|_| Regex::new("$^").expect("literal never-match regex must compile"))
 }
 
 // ─── Git extraction + Tauri command wiring ──────────────────────────
@@ -417,7 +470,10 @@ fn extract_staged_added_lines(cwd: &str) -> Result<Vec<ScanFileInput>, String> {
 
 /// Pure(-ish) core of `scan_secrets`, kept sync + separate from the `async` command so it is
 /// unit-testable without a Tokio runtime.
-pub(crate) fn scan_staged(cwd: &str, config: &SecretsScanConfig) -> Result<Vec<SecretFinding>, String> {
+pub(crate) fn scan_staged(
+    cwd: &str,
+    config: &SecretsScanConfig,
+) -> Result<Vec<SecretFinding>, String> {
     if cwd.trim().is_empty() {
         return Err("cwd must not be empty".to_string());
     }
@@ -429,7 +485,10 @@ pub(crate) fn scan_staged(cwd: &str, config: &SecretsScanConfig) -> Result<Vec<S
 }
 
 #[tauri::command]
-pub(crate) async fn scan_secrets(cwd: String, config: SecretsScanConfig) -> Result<Vec<SecretFinding>, String> {
+pub(crate) async fn scan_secrets(
+    cwd: String,
+    config: SecretsScanConfig,
+) -> Result<Vec<SecretFinding>, String> {
     scan_staged(&cwd, &config)
 }
 
@@ -511,7 +570,10 @@ mod tests {
 
     #[test]
     fn detects_a_user_extra_pattern() {
-        let files = [file_with("src/x.ts", &["const t = \"itok_deadbeefdeadbeef\";"])];
+        let files = [file_with(
+            "src/x.ts",
+            &["const t = \"itok_deadbeefdeadbeef\";"],
+        )];
         let mut config = base_config();
         config.extra_patterns.push(SecretPatternInput {
             id: "internal_token".to_string(),
@@ -540,7 +602,10 @@ mod tests {
 
     #[test]
     fn an_ignore_glob_suppresses_findings_on_a_matching_path() {
-        let files = [file_with("fixtures/sample.ts", &["const key = \"AKIAABCDEFGHIJKLMNOP\";"])];
+        let files = [file_with(
+            "fixtures/sample.ts",
+            &["const key = \"AKIAABCDEFGHIJKLMNOP\";"],
+        )];
         let mut config = base_config();
         config.ignore.push("fixtures/**".to_string());
         let findings = scan_lines(&files, &config);
@@ -549,7 +614,10 @@ mod tests {
 
     #[test]
     fn an_ignore_value_regex_suppresses_a_specific_value() {
-        let files = [file_with("src/x.ts", &["const key = \"AKIAABCDEFGHIJKLMNOP\";"])];
+        let files = [file_with(
+            "src/x.ts",
+            &["const key = \"AKIAABCDEFGHIJKLMNOP\";"],
+        )];
         let mut config = base_config();
         config.ignore.push("/AKIAABCDEFGHIJKLMNOP/".to_string());
         let findings = scan_lines(&files, &config);
@@ -558,7 +626,10 @@ mod tests {
 
     #[test]
     fn ignore_does_not_suppress_unrelated_path_or_value() {
-        let files = [file_with("src/x.ts", &["const key = \"AKIAABCDEFGHIJKLMNOP\";"])];
+        let files = [file_with(
+            "src/x.ts",
+            &["const key = \"AKIAABCDEFGHIJKLMNOP\";"],
+        )];
         let mut config = base_config();
         config.ignore.push("other/**".to_string());
         config.ignore.push("/NOTTHEKEY/".to_string());
@@ -608,7 +679,11 @@ mod tests {
             let mut config = base_config();
             config.entropy_threshold = 4.0;
             let findings = scan_lines(&files, &config);
-            assert!(findings.is_empty(), "expected {} to be ignored by default", path);
+            assert!(
+                findings.is_empty(),
+                "expected {} to be ignored by default",
+                path
+            );
         }
     }
 
@@ -635,7 +710,9 @@ mod tests {
         let mut config = base_config();
         config.entropy_threshold = 4.0;
         let findings = scan_lines(&files, &config);
-        assert!(findings.iter().any(|f| f.pattern_id == "high_entropy" && f.severity == "low"));
+        assert!(findings
+            .iter()
+            .any(|f| f.pattern_id == "high_entropy" && f.severity == "low"));
     }
 
     #[test]
@@ -652,7 +729,10 @@ mod tests {
 
     #[test]
     fn entropy_pass_does_not_double_report_a_regex_covered_token() {
-        let files = [file_with("src/x.ts", &["const key = \"AKIAABCDEFGHIJKLMNOP\";"])];
+        let files = [file_with(
+            "src/x.ts",
+            &["const key = \"AKIAABCDEFGHIJKLMNOP\";"],
+        )];
         let mut config = base_config();
         config.entropy_threshold = 3.0;
         let findings = scan_lines(&files, &config);
@@ -663,7 +743,10 @@ mod tests {
     #[test]
     fn redaction_never_equals_the_raw_planted_value() {
         let secret = "AKIAABCDEFGHIJKLMNOP";
-        let files = [file_with("src/x.ts", &[&format!("const key = \"{}\";", secret)])];
+        let files = [file_with(
+            "src/x.ts",
+            &[&format!("const key = \"{}\";", secret)],
+        )];
         let findings = scan_lines(&files, &base_config());
         for f in &findings {
             assert_ne!(f.redacted_excerpt, secret);
@@ -673,7 +756,10 @@ mod tests {
 
     #[test]
     fn enabled_false_returns_empty() {
-        let files = [file_with("src/x.ts", &["const key = \"AKIAABCDEFGHIJKLMNOP\";"])];
+        let files = [file_with(
+            "src/x.ts",
+            &["const key = \"AKIAABCDEFGHIJKLMNOP\";"],
+        )];
         let mut config = base_config();
         config.enabled = false;
         let findings = scan_lines(&files, &config);
@@ -689,6 +775,59 @@ mod tests {
         let files = [file_with("src/x.ts", &line_refs)];
         let findings = scan_lines(&files, &base_config());
         assert_eq!(findings.len(), 500);
+    }
+
+    // ─── Non-regression: is_ignored precompilation refactor (perf) ──
+
+    /// ~500 added lines across two files, a realistic `entropy_threshold`, and 5 custom
+    /// `.gitwandrc` ignore entries — locks `scan_lines`'s FINDINGS (never timing, which is flaky
+    /// in CI) across the `is_ignored`/`glob_regex` precompilation refactor. Must pass identically
+    /// before and after that refactor.
+    #[test]
+    fn scan_lines_on_a_large_diff_with_custom_ignore_globs_finds_only_the_non_ignored_secrets() {
+        let mut config = base_config();
+        config.entropy_threshold = 4.0;
+        config.ignore = vec![
+            "vendor/**".to_string(),
+            "*.snapshot.ts".to_string(),
+            "fixtures/**".to_string(),
+            "/^IGNOREME_.*$/".to_string(),
+            "build-artifacts/**".to_string(),
+        ];
+
+        // src/app.ts (300 lines): every 10th line plants a real AWS key (30 hits expected),
+        // every 10th-plus-5 line plants a high-entropy token matched by the `/^IGNOREME_.*$/`
+        // ignore literal (must be suppressed), the rest are inert comments.
+        let app_lines: Vec<String> = (0..300)
+            .map(|i| match i % 10 {
+                0 => format!("const key{} = \"AKIAABCDEFGHIJKLMNOP\";", i),
+                5 => format!("IGNOREME_aB3xQ9mK2pL7vN5wR8tY1cB4fH6jD0s{:03}", i),
+                _ => format!("// comment line {}", i),
+            })
+            .collect();
+        let app_refs: Vec<&str> = app_lines.iter().map(|s| s.as_str()).collect();
+
+        // vendor/generated.ts (200 lines): all plant real AWS keys, but the whole path is
+        // ignored wholesale by the custom `vendor/**` glob — none of these must surface.
+        let vendor_lines: Vec<String> = (0..200)
+            .map(|i| format!("const secretKey{} = \"AKIAABCDEFGHIJKLMNOP\";", i))
+            .collect();
+        let vendor_refs: Vec<&str> = vendor_lines.iter().map(|s| s.as_str()).collect();
+
+        let files = [
+            file_with("src/app.ts", &app_refs),
+            file_with("vendor/generated.ts", &vendor_refs),
+        ];
+
+        let findings = scan_lines(&files, &config);
+
+        assert_eq!(
+            findings.len(),
+            30,
+            "expected exactly the 30 planted AWS keys in src/app.ts"
+        );
+        assert!(findings.iter().all(|f| f.file == "src/app.ts"));
+        assert!(findings.iter().all(|f| f.pattern_id == "aws_access_key_id"));
     }
 
     // ─── scan_staged: real temp-repo integration tests (Task 5) ─────
@@ -720,8 +859,10 @@ mod tests {
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
                     .as_nanos();
-                let dir = std::env::temp_dir()
-                    .join(format!("gitwand-secrets-test-{}-{}-{}-{}", label, pid, n, nanos));
+                let dir = std::env::temp_dir().join(format!(
+                    "gitwand-secrets-test-{}-{}-{}-{}",
+                    label, pid, n, nanos
+                ));
                 std::fs::create_dir_all(&dir).unwrap();
                 let repo = TempRepo { path: dir };
                 repo.git(&["init", "-q"]);

--- a/apps/desktop/src-tauri/src/commands/terminal.rs
+++ b/apps/desktop/src-tauri/src/commands/terminal.rs
@@ -44,14 +44,19 @@ static NEXT_ID: AtomicU64 = AtomicU64::new(1);
 /// We accept:
 ///   - bare names like `"zsh"` or `"bash"` (no path separator)
 ///   - absolute paths like `"/bin/zsh"` or `"C:\\Windows\\System32\\cmd.exe"`
+///
 /// We reject (fall back to default) any path that contains a separator
 /// but is not absolute, to prevent directory-traversal attacks via settings.
 fn resolve_shell(shell: &Option<String>) -> String {
     fn default_shell() -> String {
         #[cfg(windows)]
-        { std::env::var("ComSpec").unwrap_or_else(|_| "powershell.exe".to_string()) }
+        {
+            std::env::var("ComSpec").unwrap_or_else(|_| "powershell.exe".to_string())
+        }
         #[cfg(not(windows))]
-        { std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string()) }
+        {
+            std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
+        }
     }
 
     if let Some(s) = shell {
@@ -111,7 +116,12 @@ pub(crate) fn terminal_open(
 
     let pty_system = native_pty_system();
     let pair = pty_system
-        .openpty(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+        .openpty(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
         .map_err(|e| format!("openpty failed: {e}"))?;
 
     // First-class agent vs shell resolution. Each agent is resolved via its
@@ -167,11 +177,17 @@ pub(crate) fn terminal_open(
     // it becomes an orphaned process holding a PTY slave indefinitely.
     let mut reader = match pair.master.try_clone_reader() {
         Ok(r) => r,
-        Err(e) => { let _ = child.kill(); return Err(format!("clone reader failed: {e}")); }
+        Err(e) => {
+            let _ = child.kill();
+            return Err(format!("clone reader failed: {e}"));
+        }
     };
     let writer = match pair.master.take_writer() {
         Ok(w) => w,
-        Err(e) => { let _ = child.kill(); return Err(format!("take writer failed: {e}")); }
+        Err(e) => {
+            let _ = child.kill();
+            return Err(format!("take writer failed: {e}"));
+        }
     };
 
     let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
@@ -181,7 +197,11 @@ pub(crate) fn terminal_open(
 
     lock_sessions().insert(
         id,
-        PtyHandle { master: master_arc, writer: writer_arc, child },
+        PtyHandle {
+            master: master_arc,
+            writer: writer_arc,
+            child,
+        },
     );
 
     // Thread lecteur : pousse les chunks vers le frontend.
@@ -258,12 +278,19 @@ pub(crate) fn terminal_resize(id: u64, cols: u16, rows: u16) -> Result<(), Strin
     // (and any other command) for ALL sessions during every resize event.
     let master_arc = {
         let map = lock_sessions();
-        map.get(&id).map(|h| Arc::clone(&h.master)).ok_or("session not found")?
+        map.get(&id)
+            .map(|h| Arc::clone(&h.master))
+            .ok_or("session not found")?
     };
     let result = master_arc
         .lock()
         .unwrap_or_else(|e| e.into_inner())
-        .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+        .resize(PtySize {
+            rows,
+            cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
         .map_err(|e| format!("resize failed: {e}"));
     result
 }
@@ -283,4 +310,3 @@ pub(crate) fn terminal_close_all() {
         let _ = h.child.kill();
     }
 }
-

--- a/apps/desktop/src-tauri/src/commands/workspace.rs
+++ b/apps/desktop/src-tauri/src/commands/workspace.rs
@@ -24,23 +24,23 @@ pub(crate) async fn workspace_read(path: String) -> Result<WorkspaceConfig, Stri
     if !file.exists() {
         return Err(format!("No workspace file found at {}", file.display()));
     }
-    let content = std::fs::read_to_string(&file)
-        .map_err(|e| format!("Failed to read workspace: {}", e))?;
-    serde_json::from_str(&content)
-        .map_err(|e| format!("Failed to parse workspace: {}", e))
+    let content =
+        std::fs::read_to_string(&file).map_err(|e| format!("Failed to read workspace: {}", e))?;
+    serde_json::from_str(&content).map_err(|e| format!("Failed to parse workspace: {}", e))
 }
 
 /// Write a `.gitwand-workspace.json` to the given directory.
 #[tauri::command]
-pub(crate) async fn workspace_write(path: String, workspace: WorkspaceConfig) -> Result<(), String> {
+pub(crate) async fn workspace_write(
+    path: String,
+    workspace: WorkspaceConfig,
+) -> Result<(), String> {
     let dir = std::path::Path::new(&path);
     let file = dir.join(".gitwand-workspace.json");
-    std::fs::create_dir_all(dir)
-        .map_err(|e| format!("Failed to create directory: {}", e))?;
+    std::fs::create_dir_all(dir).map_err(|e| format!("Failed to create directory: {}", e))?;
     let content = serde_json::to_string_pretty(&workspace)
         .map_err(|e| format!("Failed to serialize workspace: {}", e))?;
-    std::fs::write(&file, content)
-        .map_err(|e| format!("Failed to write workspace: {}", e))
+    std::fs::write(&file, content).map_err(|e| format!("Failed to write workspace: {}", e))
 }
 
 /// Check whether `rel`, resolved under `cwd`, exists on disk.
@@ -64,25 +64,28 @@ pub(crate) async fn path_exists(cwd: String, rel: String) -> Result<bool, String
 /// because `Vec<T>::into_par_iter()` is an `IndexedParallelIterator`.
 #[tauri::command]
 pub(crate) async fn workspace_status_all(repos: Vec<WorkspaceRepo>) -> Vec<WorkspaceRepoStatus> {
-    repos.into_par_iter().map(|repo| {
-        let path = repo.path.clone();
-        let name = repo.name.clone();
+    repos
+        .into_par_iter()
+        .map(|repo| {
+            let path = repo.path.clone();
+            let name = repo.name.clone();
 
-        let (branch, ahead, behind, no_upstream) = libgit2_branch_ab(&path);
-        let modified = libgit2_modified_count(&path);
+            let (branch, ahead, behind, no_upstream) = libgit2_branch_ab(&path);
+            let modified = libgit2_modified_count(&path);
 
-        WorkspaceRepoStatus {
-            path,
-            name,
-            branch,
-            ahead,
-            behind,
-            has_upstream: !no_upstream,
-            modified,
-            conflicted: 0, // non calculé dans la vue workspace (libgit2 ne distingue pas les conflits ici)
-            error: None,
-        }
-    }).collect()
+            WorkspaceRepoStatus {
+                path,
+                name,
+                branch,
+                ahead,
+                behind,
+                has_upstream: !no_upstream,
+                modified,
+                conflicted: 0, // non calculé dans la vue workspace (libgit2 ne distingue pas les conflits ici)
+                error: None,
+            }
+        })
+        .collect()
 }
 
 /// Run `git fetch` on all repos in a workspace (best-effort; errors captured per-repo).
@@ -131,31 +134,33 @@ pub(crate) async fn workspace_pull_all(repos: Vec<WorkspaceRepo>) -> Vec<Workspa
 /// went from ~750 ms wall-clock to ~30 ms in the typical case.
 #[tauri::command]
 pub(crate) async fn workspace_wip_all(repos: Vec<WorkspaceRepo>) -> Vec<WorkspaceWipItem> {
-    repos.into_par_iter().map(|repo| {
-        let path = repo.path.clone();
-        let name = repo.name.clone();
+    repos
+        .into_par_iter()
+        .map(|repo| {
+            let path = repo.path.clone();
+            let name = repo.name.clone();
 
-        let (branch, ahead, behind, has_no_upstream) = libgit2_branch_ab(&path);
-        let (staged_count, unstaged_count, untracked_count, changed_files) =
-            libgit2_wip_status(&path);
-        let last_commit_at = libgit2_last_commit_at(&path);
+            let (branch, ahead, behind, has_no_upstream) = libgit2_branch_ab(&path);
+            let (staged_count, unstaged_count, untracked_count, changed_files) =
+                libgit2_wip_status(&path);
+            let last_commit_at = libgit2_last_commit_at(&path);
 
-        WorkspaceWipItem {
-            path,
-            name,
-            branch,
-            ahead,
-            behind,
-            staged_count,
-            unstaged_count,
-            untracked_count,
-            last_commit_at,
-            has_no_upstream,
-            error: None,
-            changed_files,
-        }
-    })
-    .collect()
+            WorkspaceWipItem {
+                path,
+                name,
+                branch,
+                ahead,
+                behind,
+                staged_count,
+                unstaged_count,
+                untracked_count,
+                last_commit_at,
+                has_no_upstream,
+                error: None,
+                changed_files,
+            }
+        })
+        .collect()
 }
 
 /// Aggregate open PRs from all repos in a workspace (via `gh pr list`).
@@ -250,7 +255,10 @@ pub(crate) async fn workspace_prs_all(repos: Vec<WorkspaceRepo>) -> Vec<Workspac
 /// Parallelized via rayon (P3.2). `filter` is captured by-ref and read-only
 /// so it's safe to share across threads.
 #[tauri::command]
-pub(crate) async fn workspace_issues_all(repos: Vec<WorkspaceRepo>, filter: String) -> Vec<WorkspaceRepoIssues> {
+pub(crate) async fn workspace_issues_all(
+    repos: Vec<WorkspaceRepo>,
+    filter: String,
+) -> Vec<WorkspaceRepoIssues> {
     // OAuth/REST path (#73): same routing rule as `workspace_prs_all`. The
     // assigned/created/mentioned filters map `@me` to a concrete login, so we
     // resolve the authenticated user once (a single REST round-trip) and pass it
@@ -263,73 +271,12 @@ pub(crate) async fn workspace_issues_all(repos: Vec<WorkspaceRepo>, filter: Stri
             }
             _ => String::new(),
         };
-        return repos.into_par_iter().map(|repo| {
-            let repo_path = repo.path.clone();
-            let repo_name = repo.name.clone();
-            match github_api::rest_list_issues(&repo_path, &filter, &me, 100, tok) {
-                Ok(issues) => WorkspaceRepoIssues {
-                    repo_path, repo_name, issues, filter: filter.clone(), error: None,
-                },
-                Err(e) => WorkspaceRepoIssues {
-                    repo_path, repo_name, issues: vec![], filter: filter.clone(), error: Some(e),
-                },
-            }
-        }).collect();
-    }
-
-    repos.into_par_iter().map(|repo| {
-        let repo_path = repo.path.clone();
-        let repo_name = repo.name.clone();
-
-        let mut args: Vec<String> = vec![
-            "issue".to_string(), "list".to_string(),
-            "--state".to_string(), "open".to_string(),
-            "--json".to_string(),
-            "number,title,state,author,assignees,labels,url,createdAt,updatedAt,milestone".to_string(),
-            "--limit".to_string(), "100".to_string(),
-        ];
-        match filter.as_str() {
-            "assigned" => {
-                args.push("--assignee".to_string());
-                args.push("@me".to_string());
-            }
-            "created" => {
-                args.push("--author".to_string());
-                args.push("@me".to_string());
-            }
-            "mentioned" => {
-                args.push("--search".to_string());
-                args.push("mentions:@me".to_string());
-            }
-            _ => {} // "" or unknown = no extra filter
-        }
-
-        let output = hidden_cmd("gh")
-            .args(&args)
-            .current_dir(&repo_path)
-            .output();
-
-        match output {
-            Err(e) => WorkspaceRepoIssues {
-                repo_path,
-                repo_name,
-                issues: vec![],
-                filter: filter.clone(),
-                error: Some(format!("gh not available: {}", e)),
-            },
-            Ok(out) if !out.status.success() => {
-                let stderr = String::from_utf8_lossy(&out.stderr);
-                WorkspaceRepoIssues {
-                    repo_path,
-                    repo_name,
-                    issues: vec![],
-                    filter: filter.clone(),
-                    error: Some(format!("gh issue list failed: {}", stderr.trim())),
-                }
-            }
-            Ok(out) => {
-                let stdout = String::from_utf8_lossy(&out.stdout);
-                match parse_gh_issue_json(&stdout) {
+        return repos
+            .into_par_iter()
+            .map(|repo| {
+                let repo_path = repo.path.clone();
+                let repo_name = repo.name.clone();
+                match github_api::rest_list_issues(&repo_path, &filter, &me, 100, tok) {
                     Ok(issues) => WorkspaceRepoIssues {
                         repo_path,
                         repo_name,
@@ -345,8 +292,86 @@ pub(crate) async fn workspace_issues_all(repos: Vec<WorkspaceRepo>, filter: Stri
                         error: Some(e),
                     },
                 }
+            })
+            .collect();
+    }
+
+    repos
+        .into_par_iter()
+        .map(|repo| {
+            let repo_path = repo.path.clone();
+            let repo_name = repo.name.clone();
+
+            let mut args: Vec<String> = vec![
+                "issue".to_string(),
+                "list".to_string(),
+                "--state".to_string(),
+                "open".to_string(),
+                "--json".to_string(),
+                "number,title,state,author,assignees,labels,url,createdAt,updatedAt,milestone"
+                    .to_string(),
+                "--limit".to_string(),
+                "100".to_string(),
+            ];
+            match filter.as_str() {
+                "assigned" => {
+                    args.push("--assignee".to_string());
+                    args.push("@me".to_string());
+                }
+                "created" => {
+                    args.push("--author".to_string());
+                    args.push("@me".to_string());
+                }
+                "mentioned" => {
+                    args.push("--search".to_string());
+                    args.push("mentions:@me".to_string());
+                }
+                _ => {} // "" or unknown = no extra filter
             }
-        }
-    })
-    .collect()
+
+            let output = hidden_cmd("gh")
+                .args(&args)
+                .current_dir(&repo_path)
+                .output();
+
+            match output {
+                Err(e) => WorkspaceRepoIssues {
+                    repo_path,
+                    repo_name,
+                    issues: vec![],
+                    filter: filter.clone(),
+                    error: Some(format!("gh not available: {}", e)),
+                },
+                Ok(out) if !out.status.success() => {
+                    let stderr = String::from_utf8_lossy(&out.stderr);
+                    WorkspaceRepoIssues {
+                        repo_path,
+                        repo_name,
+                        issues: vec![],
+                        filter: filter.clone(),
+                        error: Some(format!("gh issue list failed: {}", stderr.trim())),
+                    }
+                }
+                Ok(out) => {
+                    let stdout = String::from_utf8_lossy(&out.stdout);
+                    match parse_gh_issue_json(&stdout) {
+                        Ok(issues) => WorkspaceRepoIssues {
+                            repo_path,
+                            repo_name,
+                            issues,
+                            filter: filter.clone(),
+                            error: None,
+                        },
+                        Err(e) => WorkspaceRepoIssues {
+                            repo_path,
+                            repo_name,
+                            issues: vec![],
+                            filter: filter.clone(),
+                            error: Some(e),
+                        },
+                    }
+                }
+            }
+        })
+        .collect()
 }

--- a/apps/desktop/src-tauri/src/git/cmd.rs
+++ b/apps/desktop/src-tauri/src/git/cmd.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::{Mutex, OnceLock};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // ─── Transparent command log ──────────────────────────────────
@@ -13,12 +13,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// One entry in the transparent command log.
 #[derive(serde::Serialize, Clone)]
 pub(crate) struct CmdLogEntry {
-    pub id:          u64,
-    pub label:       String,   // human-readable "git push origin HEAD"
-    pub cwd:         String,
+    pub id: u64,
+    pub label: String, // human-readable "git push origin HEAD"
+    pub cwd: String,
     pub duration_ms: u64,
-    pub exit_code:   i32,      // 0 = success, -1 = could not be determined
-    pub timestamp_ms: u64,     // Unix epoch in milliseconds
+    pub exit_code: i32,    // 0 = success, -1 = could not be determined
+    pub timestamp_ms: u64, // Unix epoch in milliseconds
 }
 
 const CMD_LOG_CAP: usize = 200;
@@ -37,8 +37,14 @@ pub(crate) fn record_cmd(label: &str, cwd: &str, duration_ms: u64, exit_code: i3
     if buf.len() >= CMD_LOG_CAP {
         buf.pop_front();
     }
-    buf.push_back(CmdLogEntry { id, label: label.to_string(), cwd: cwd.to_string(),
-                                duration_ms, exit_code, timestamp_ms });
+    buf.push_back(CmdLogEntry {
+        id,
+        label: label.to_string(),
+        cwd: cwd.to_string(),
+        duration_ms,
+        exit_code,
+        timestamp_ms,
+    });
 }
 
 /// Returns a snapshot (newest first) of the ring buffer.
@@ -254,9 +260,13 @@ pub(crate) fn sanitize_appimage_search_paths(cmd: &mut std::process::Command) {
 #[cfg(target_os = "macos")]
 pub(crate) fn macos_enriched_path() -> Option<String> {
     let current_path = std::env::var("PATH").unwrap_or_default();
-    let extras = ["/opt/homebrew/bin", "/opt/homebrew/sbin",
-                  "/usr/local/bin", "/usr/local/sbin",
-                  "/opt/local/bin"];
+    let extras = [
+        "/opt/homebrew/bin",
+        "/opt/homebrew/sbin",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/opt/local/bin",
+    ];
     let mut enriched = current_path.clone();
     let mut added = false;
     for extra in extras {
@@ -266,7 +276,11 @@ pub(crate) fn macos_enriched_path() -> Option<String> {
             added = true;
         }
     }
-    if added { Some(enriched) } else { None }
+    if added {
+        Some(enriched)
+    } else {
+        None
+    }
 }
 
 pub(crate) fn hidden_cmd(bin: &str) -> std::process::Command {
@@ -284,8 +298,12 @@ pub(crate) fn hidden_cmd(bin: &str) -> std::process::Command {
     // GitHub issue #48.
     for (var, fix) in appimage_env_fixes(&env_get) {
         match fix {
-            EnvFix::Restore(value) => { cmd.env(var, value); }
-            EnvFix::Remove         => { cmd.env_remove(var); }
+            EnvFix::Restore(value) => {
+                cmd.env(var, value);
+            }
+            EnvFix::Remove => {
+                cmd.env_remove(var);
+            }
         }
     }
     // Defensive: propagate auth tokens explicitly to every subprocess so
@@ -360,15 +378,19 @@ pub(crate) fn output_with_timeout(
             Some(status) => {
                 let stdout = stdout_thread.join().unwrap_or_default();
                 let stderr = stderr_thread.join().unwrap_or_default();
-                return Ok(std::process::Output { status, stdout, stderr });
+                return Ok(std::process::Output {
+                    status,
+                    stdout,
+                    stderr,
+                });
             }
             None if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait(); // reap — avoid a zombie
-                // Do NOT join the reader threads here: a child that spawned a
-                // grandchild holding the pipe open would never hit EOF, and
-                // joining would defeat the entire point of the timeout. They
-                // exit on their own at EOF; just drop the handles.
+                                      // Do NOT join the reader threads here: a child that spawned a
+                                      // grandchild holding the pipe open would never hit EOF, and
+                                      // joining would defeat the entire point of the timeout. They
+                                      // exit on their own at EOF; just drop the handles.
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
                     format!("timed out after {}s", timeout.as_secs()),
@@ -453,7 +475,12 @@ pub(crate) fn resolve_default_branch(cwd: &str, configured: Option<&str>) -> Str
 /// Returns the list of files that differ between two revs (names only).
 /// Shared between `commands::read::preview_merge` and the rebase preview in
 /// `commands::ops::*`.
-pub(crate) fn git_changed_files(git: &str, cwd: &str, base: &str, rev: &str) -> Result<Vec<String>, String> {
+pub(crate) fn git_changed_files(
+    git: &str,
+    cwd: &str,
+    base: &str,
+    rev: &str,
+) -> Result<Vec<String>, String> {
     let out = hidden_cmd(git)
         .args(["diff", "--name-only", base, rev])
         .current_dir(cwd)
@@ -595,10 +622,7 @@ mod tests {
             // default branch (Settings > Git > Default Branch) wins.
             let repo = TempRepo::new_trunk();
             repo.git_ok(&["branch", "main"]);
-            assert_eq!(
-                resolve_default_branch(&repo.cwd(), Some("trunk")),
-                "trunk"
-            );
+            assert_eq!(resolve_default_branch(&repo.cwd(), Some("trunk")), "trunk");
         }
 
         #[test]
@@ -641,10 +665,12 @@ mod tests {
     fn appimage_env_fixes_removes_polluted_var_without_orig() {
         // Inside an AppImage, a bundled LD_LIBRARY_PATH with no saved original
         // is dropped so the child falls back to the system default.
-        let env: HashMap<&str, &str> =
-            [("APPDIR", "/tmp/.mount_app"), ("LD_LIBRARY_PATH", "/tmp/.mount_app/usr/lib")]
-                .into_iter()
-                .collect();
+        let env: HashMap<&str, &str> = [
+            ("APPDIR", "/tmp/.mount_app"),
+            ("LD_LIBRARY_PATH", "/tmp/.mount_app/usr/lib"),
+        ]
+        .into_iter()
+        .collect();
         assert_eq!(
             appimage_env_fixes(&lookup(&env)),
             vec![("LD_LIBRARY_PATH", EnvFix::Remove)]
@@ -700,10 +726,9 @@ mod tests {
     #[test]
     fn appimage_path_fixes_leaves_clean_path_alone() {
         // Inside an AppImage but a host-only PATH → nothing to strip.
-        let env: HashMap<&str, &str> =
-            [("APPDIR", "/tmp/.mount_app"), ("PATH", "/usr/bin:/bin")]
-                .into_iter()
-                .collect();
+        let env: HashMap<&str, &str> = [("APPDIR", "/tmp/.mount_app"), ("PATH", "/usr/bin:/bin")]
+            .into_iter()
+            .collect();
         assert!(appimage_path_fixes(&lookup(&env)).is_empty());
     }
 
@@ -788,5 +813,3 @@ mod tests {
         assert!(appimage_path_fixes(&lookup(&env)).is_empty());
     }
 }
-
-

--- a/apps/desktop/src-tauri/src/git/libgit2.rs
+++ b/apps/desktop/src-tauri/src/git/libgit2.rs
@@ -29,7 +29,9 @@ pub(crate) fn libgit2_branch_ab(path: &str) -> (String, u32, u32, bool) {
         let head = repo.head().ok()?;
         let local_oid = head.target()?;
         let local_branch = head.shorthand()?;
-        let branch_ref = repo.find_branch(local_branch, git2::BranchType::Local).ok()?;
+        let branch_ref = repo
+            .find_branch(local_branch, git2::BranchType::Local)
+            .ok()?;
         let upstream = match branch_ref.upstream() {
             Ok(u) => u,
             Err(_) => return Some((0, 0, true)), // valid local branch, just no upstream
@@ -72,12 +74,15 @@ pub(crate) fn libgit2_wip_status(path: &str) -> (u32, u32, u32, Vec<String>) {
         Err(_) => return (0, 0, 0, Vec::new()),
     };
 
-    let staged_mask =
-        git2::Status::INDEX_NEW | git2::Status::INDEX_MODIFIED | git2::Status::INDEX_DELETED |
-        git2::Status::INDEX_RENAMED | git2::Status::INDEX_TYPECHANGE;
-    let unstaged_mask =
-        git2::Status::WT_MODIFIED | git2::Status::WT_DELETED |
-        git2::Status::WT_RENAMED | git2::Status::WT_TYPECHANGE;
+    let staged_mask = git2::Status::INDEX_NEW
+        | git2::Status::INDEX_MODIFIED
+        | git2::Status::INDEX_DELETED
+        | git2::Status::INDEX_RENAMED
+        | git2::Status::INDEX_TYPECHANGE;
+    let unstaged_mask = git2::Status::WT_MODIFIED
+        | git2::Status::WT_DELETED
+        | git2::Status::WT_RENAMED
+        | git2::Status::WT_TYPECHANGE;
 
     let mut staged_count = 0u32;
     let mut unstaged_count = 0u32;
@@ -140,7 +145,15 @@ fn format_iso8601(secs: i64, offset_min: i32) -> String {
     let off_abs = offset_min.unsigned_abs();
     format!(
         "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}{}{:02}:{:02}",
-        y, mo, d, h, mi, s, sign, off_abs / 60, off_abs % 60
+        y,
+        mo,
+        d,
+        h,
+        mi,
+        s,
+        sign,
+        off_abs / 60,
+        off_abs % 60
     )
 }
 

--- a/apps/desktop/src-tauri/src/git/parse.rs
+++ b/apps/desktop/src-tauri/src/git/parse.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
-use std::path::Path;
 use crate::git::cmd::git_cmd;
 use crate::types::{
     DiffHunk, DiffLine, FileLogEntry, FolderDiffNode, GhIssueRaw, GhPrDetailRaw, GhPrRaw,
     GhPrStatusCheck, Issue, MonorepoPackage, PullRequest, PullRequestDetail, RawFileChange,
     RepoTreeNode, ShortlogEntry,
 };
+use std::collections::HashMap;
+use std::path::Path;
 
 /// Aggregate a PR's individual status checks into a single rollup state.
 ///
@@ -47,7 +47,11 @@ pub(crate) fn rollup_status_checks(checks: &[GhPrStatusCheck]) -> String {
             }
         }
     }
-    if pending { "PENDING".to_string() } else { "SUCCESS".to_string() }
+    if pending {
+        "PENDING".to_string()
+    } else {
+        "SUCCESS".to_string()
+    }
 }
 
 pub(crate) fn parse_diff_hunks(stdout: &str) -> (Vec<DiffHunk>, Option<String>) {
@@ -122,8 +126,8 @@ pub(crate) fn parse_diff_hunks(stdout: &str) -> (Vec<DiffHunk>, Option<String>) 
                     new_line_no: None,
                 });
                 old_line_no += 1;
-            } else if line.starts_with(' ') {
-                let content = line[1..].to_string();
+            } else if let Some(stripped) = line.strip_prefix(' ') {
+                let content = stripped.to_string();
                 hunk.lines.push(DiffLine {
                     r#type: "context".to_string(),
                     content,
@@ -149,7 +153,11 @@ pub(crate) fn parse_name_status_z(s: &str) -> Vec<(String, String, Option<String
     let mut i = 0;
     while i < tokens.len() {
         let status_full = tokens[i];
-        let letter = status_full.chars().next().unwrap_or('M').to_ascii_uppercase();
+        let letter = status_full
+            .chars()
+            .next()
+            .unwrap_or('M')
+            .to_ascii_uppercase();
         if letter == 'R' || letter == 'C' {
             if i + 2 < tokens.len() {
                 let old = tokens[i + 1].to_string();
@@ -190,8 +198,16 @@ pub(crate) fn parse_numstat_z(s: &str) -> HashMap<String, (u32, u32, bool)> {
         let adds_str = parts[0];
         let dels_str = parts[1];
         let binary = adds_str == "-" && dels_str == "-";
-        let additions: u32 = if binary { 0 } else { adds_str.parse().unwrap_or(0) };
-        let deletions: u32 = if binary { 0 } else { dels_str.parse().unwrap_or(0) };
+        let additions: u32 = if binary {
+            0
+        } else {
+            adds_str.parse().unwrap_or(0)
+        };
+        let deletions: u32 = if binary {
+            0
+        } else {
+            dels_str.parse().unwrap_or(0)
+        };
         let path_part = if parts.len() >= 3 { parts[2] } else { "" };
         if path_part.is_empty() {
             let mut j = i + 1;
@@ -284,7 +300,11 @@ pub(crate) fn insert_segments(
             node.children.push(FolderDiffNode {
                 path: full_path.clone(),
                 name: seg.to_string(),
-                kind: if is_last_seg { "file".to_string() } else { "folder".to_string() },
+                kind: if is_last_seg {
+                    "file".to_string()
+                } else {
+                    "folder".to_string()
+                },
                 status: None,
                 old_path: None,
                 files_changed: 0,
@@ -309,7 +329,11 @@ pub(crate) fn insert_segments(
 }
 
 pub(crate) fn insert_change(root: &mut FolderDiffNode, change: &RawFileChange) {
-    let segments: Vec<&str> = change.new_path.split('/').filter(|s| !s.is_empty()).collect();
+    let segments: Vec<&str> = change
+        .new_path
+        .split('/')
+        .filter(|s| !s.is_empty())
+        .collect();
     if segments.is_empty() {
         return;
     }
@@ -377,16 +401,23 @@ pub(crate) fn parse_file_log_output(raw: &str) -> Vec<FileLogEntry> {
     let mut entries = Vec::new();
     for block in raw.split(sep) {
         let trimmed = block.trim();
-        if trimmed.is_empty() { continue; }
+        if trimmed.is_empty() {
+            continue;
+        }
         let parts: Vec<&str> = trimmed.splitn(6, '\n').collect();
-        if parts.len() < 5 { continue; }
+        if parts.len() < 5 {
+            continue;
+        }
         entries.push(FileLogEntry {
             hash_full: parts[0].trim().to_string(),
             hash: parts[1].trim().to_string(),
             author: parts[2].trim().to_string(),
             date: parts[3].trim().to_string(),
             message: parts[4].trim().to_string(),
-            body: parts.get(5).map(|s| s.trim().to_string()).unwrap_or_default(),
+            body: parts
+                .get(5)
+                .map(|s| s.trim().to_string())
+                .unwrap_or_default(),
         });
     }
     entries
@@ -396,7 +427,8 @@ pub(crate) fn gh_pr_detail_raw_to_detail(r: GhPrDetailRaw) -> PullRequestDetail 
     let comments = r.comments.len() as i64;
     let review_comments = r.reviews.len() as i64;
     let labels: Vec<String> = r.labels.into_iter().map(|l| l.name).collect();
-    let reviewers: Vec<String> = r.review_requests
+    let reviewers: Vec<String> = r
+        .review_requests
         .into_iter()
         .filter_map(|rr| rr.login)
         .collect();
@@ -455,10 +487,7 @@ pub(crate) fn parse_gh_pr_json(json: &str) -> Result<Vec<PullRequest>, String> {
             Ok(raw) => out.push(gh_pr_raw_to_pr(raw)),
             Err(e) => {
                 let number = v.get("number").and_then(|n| n.as_i64()).unwrap_or(-1);
-                eprintln!(
-                    "[parse_gh_pr_json] skipping PR #{}: {}",
-                    number, e
-                );
+                eprintln!("[parse_gh_pr_json] skipping PR #{}: {}", number, e);
             }
         }
     }
@@ -466,16 +495,14 @@ pub(crate) fn parse_gh_pr_json(json: &str) -> Result<Vec<PullRequest>, String> {
 }
 
 pub(crate) fn gh_pr_raw_to_pr(r: GhPrRaw) -> PullRequest {
-    let review_requested = r.review_requests
+    let review_requested = r
+        .review_requests
         .into_iter()
         .filter_map(|rr| rr.login)
         .collect();
     let checks_rollup = rollup_status_checks(&r.status_check_rollup);
     let comment_count = r.comments.len() as i64;
-    let author = r
-        .author
-        .and_then(|a| a.login)
-        .unwrap_or_default();
+    let author = r.author.and_then(|a| a.login).unwrap_or_default();
     PullRequest {
         number: r.number,
         title: r.title,
@@ -490,11 +517,7 @@ pub(crate) fn gh_pr_raw_to_pr(r: GhPrRaw) -> PullRequest {
         additions: r.additions,
         deletions: r.deletions,
         labels: r.labels.into_iter().map(|l| l.name).collect(),
-        assignees: r
-            .assignees
-            .into_iter()
-            .filter_map(|a| a.login)
-            .collect(),
+        assignees: r.assignees.into_iter().filter_map(|a| a.login).collect(),
         review_requested,
         review_decision: r.review_decision.unwrap_or_default(),
         merge_state_status: r.merge_state_status.unwrap_or_default(),
@@ -534,18 +557,21 @@ pub(crate) fn parse_gh_issue_json(json: &str) -> Result<Vec<Issue>, String> {
     }
     let raws: Vec<GhIssueRaw> = serde_json::from_str(trimmed)
         .map_err(|e| format!("Failed to parse gh issue list output: {}", e))?;
-    Ok(raws.into_iter().map(|r| Issue {
-        number: r.number,
-        title: r.title,
-        state: r.state,
-        author: r.author.login,
-        assignees: r.assignees.into_iter().map(|a| a.login).collect(),
-        labels: r.labels.into_iter().map(|l| l.name).collect(),
-        url: r.url,
-        created_at: r.created_at,
-        updated_at: r.updated_at,
-        milestone: r.milestone.map(|m| m.title).unwrap_or_default(),
-    }).collect())
+    Ok(raws
+        .into_iter()
+        .map(|r| Issue {
+            number: r.number,
+            title: r.title,
+            state: r.state,
+            author: r.author.login,
+            assignees: r.assignees.into_iter().map(|a| a.login).collect(),
+            labels: r.labels.into_iter().map(|l| l.name).collect(),
+            url: r.url,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+            milestone: r.milestone.map(|m| m.title).unwrap_or_default(),
+        })
+        .collect())
 }
 
 pub(crate) fn parse_shortlog_line(line: &str) -> Option<ShortlogEntry> {
@@ -676,7 +702,11 @@ pub(crate) fn repo_name_from_url(url: &str) -> Option<String> {
     }
 }
 
-pub(crate) fn find_workspace_packages(cwd: &str, config_content: &str, manager: &str) -> Vec<MonorepoPackage> {
+pub(crate) fn find_workspace_packages(
+    cwd: &str,
+    config_content: &str,
+    manager: &str,
+) -> Vec<MonorepoPackage> {
     match manager {
         "cargo" => find_cargo_packages(cwd, config_content),
         "go" => find_go_packages(cwd, config_content),
@@ -689,14 +719,18 @@ pub(crate) fn find_workspace_packages(cwd: &str, config_content: &str, manager: 
 
 // ─── pnpm / npm / yarn / turbo ────────────────────────────────────────────
 
-fn find_npm_or_pnpm_packages(cwd: &str, config_content: &str, manager: &str) -> Vec<MonorepoPackage> {
+fn find_npm_or_pnpm_packages(
+    cwd: &str,
+    config_content: &str,
+    manager: &str,
+) -> Vec<MonorepoPackage> {
     let mut globs: Vec<String> = Vec::new();
 
     if manager == "pnpm" {
         for line in config_content.lines() {
             let trimmed = line.trim();
-            if trimmed.starts_with("- ") {
-                let pattern = trimmed[2..].trim().trim_matches('\'').trim_matches('"');
+            if let Some(stripped) = trimmed.strip_prefix("- ") {
+                let pattern = stripped.trim().trim_matches('\'').trim_matches('"');
                 globs.push(pattern.to_string());
             }
         }
@@ -719,7 +753,7 @@ fn extract_npm_workspace_globs(content: &str) -> Vec<String> {
     // Try flat array form first: "workspaces": [ ... ]
     if let Some(start) = content.find("\"workspaces\"") {
         let rest = &content[start + 12..]; // skip `"workspaces"`
-        // skip whitespace + colon
+                                           // skip whitespace + colon
         let rest = rest.trim_start_matches(|c: char| c.is_whitespace() || c == ':');
         let rest = rest.trim_start();
         if rest.starts_with('[') {
@@ -736,7 +770,9 @@ fn extract_npm_workspace_globs(content: &str) -> Vec<String> {
             // Object form: "workspaces": { "packages": [...] }
             if let Some(pkg_start) = rest.find("\"packages\"") {
                 let sub = &rest[pkg_start + 10..];
-                let sub = sub.trim_start_matches(|c: char| c.is_whitespace() || c == ':').trim_start();
+                let sub = sub
+                    .trim_start_matches(|c: char| c.is_whitespace() || c == ':')
+                    .trim_start();
                 if sub.starts_with('[') {
                     if let Some(arr_end) = sub.find(']') {
                         let arr = &sub[1..arr_end];
@@ -777,12 +813,17 @@ fn expand_npm_globs(cwd: &str, globs: &[String]) -> Vec<MonorepoPackage> {
                         if let Ok(pkg_content) = std::fs::read_to_string(&pkg_json_path) {
                             let name = extract_json_string(&pkg_content, "name")
                                 .unwrap_or_else(|| entry.file_name().to_string_lossy().to_string());
-                            let version = extract_json_string(&pkg_content, "version")
-                                .unwrap_or_default();
-                            let rel_path = path.strip_prefix(cwd_path)
+                            let version =
+                                extract_json_string(&pkg_content, "version").unwrap_or_default();
+                            let rel_path = path
+                                .strip_prefix(cwd_path)
                                 .map(|p| p.to_string_lossy().to_string())
                                 .unwrap_or_else(|_| path.to_string_lossy().to_string());
-                            packages.push(MonorepoPackage { name, path: rel_path, version });
+                            packages.push(MonorepoPackage {
+                                name,
+                                path: rel_path,
+                                version,
+                            });
                         }
                     }
                 }
@@ -826,7 +867,8 @@ pub(crate) fn find_cargo_packages(cwd: &str, toml_content: &str) -> Vec<Monorepo
             if member_toml.exists() {
                 let (name, version) = if let Ok(content) = std::fs::read_to_string(&member_toml) {
                     let n = parse_toml_scalar(&content, "name").unwrap_or_else(|| {
-                        abs.file_name().map(|f| f.to_string_lossy().to_string())
+                        abs.file_name()
+                            .map(|f| f.to_string_lossy().to_string())
                             .unwrap_or_else(|| dir_rel.clone())
                     });
                     let v = parse_toml_scalar(&content, "version").unwrap_or_default();
@@ -835,10 +877,15 @@ pub(crate) fn find_cargo_packages(cwd: &str, toml_content: &str) -> Vec<Monorepo
                     (dir_rel.clone(), String::new())
                 };
                 // rel_path: use dir_rel (already relative)
-                let rel_path = abs.strip_prefix(cwd_path)
+                let rel_path = abs
+                    .strip_prefix(cwd_path)
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or(dir_rel);
-                packages.push(MonorepoPackage { name, path: rel_path, version });
+                packages.push(MonorepoPackage {
+                    name,
+                    path: rel_path,
+                    version,
+                });
             }
         }
     }
@@ -890,7 +937,11 @@ fn expand_cargo_glob(cwd: &str, pattern: &str) -> Vec<String> {
             Ok(p) => p,
             Err(_) => return Vec::new(),
         };
-        if abs.is_dir() { vec![pattern.to_string()] } else { Vec::new() }
+        if abs.is_dir() {
+            vec![pattern.to_string()]
+        } else {
+            Vec::new()
+        }
     }
 }
 
@@ -928,9 +979,7 @@ pub(crate) fn parse_toml_string_array(content: &str, key: &str) -> Vec<String> {
     let mut start_idx = None;
     for (i, line) in content.lines().enumerate() {
         let trimmed = line.trim();
-        if trimmed.starts_with(&needle) || trimmed.starts_with(&needle2)
-            || trimmed == key
-        {
+        if trimmed.starts_with(&needle) || trimmed.starts_with(&needle2) || trimmed == key {
             // Check it has `=`
             if trimmed.contains('=') {
                 // Find byte offset
@@ -962,11 +1011,16 @@ pub(crate) fn parse_toml_string_array(content: &str, key: &str) -> Vec<String> {
         match ch {
             '[' => {
                 depth += 1;
-                if depth == 1 { continue; } // skip the opening bracket
+                if depth == 1 {
+                    continue;
+                } // skip the opening bracket
             }
             ']' => {
                 depth -= 1;
-                if depth == 0 { found = true; break; }
+                if depth == 0 {
+                    found = true;
+                    break;
+                }
             }
             _ => {}
         }
@@ -979,13 +1033,14 @@ pub(crate) fn parse_toml_string_array(content: &str, key: &str) -> Vec<String> {
     }
     // Strip comment lines and inline comments, then split on commas.
     // Process line by line first so a comment line doesn't eat the next value.
-    let clean: String = buf.lines()
+    let clean: String = buf
+        .lines()
         .map(|line| {
             let l = line.trim();
             if l.starts_with('#') {
-                ""  // whole-line comment → drop
+                "" // whole-line comment → drop
             } else if let Some(ci) = l.find('#') {
-                &l[..ci]  // inline comment → keep left side
+                &l[..ci] // inline comment → keep left side
             } else {
                 l
             }
@@ -1047,7 +1102,11 @@ pub(crate) fn find_go_packages(cwd: &str, go_work_content: &str) -> Vec<Monorepo
     packages
 }
 
-fn go_work_dir_to_package(cwd: &str, cwd_path: &std::path::Path, dir: &str) -> Option<MonorepoPackage> {
+fn go_work_dir_to_package(
+    cwd: &str,
+    cwd_path: &std::path::Path,
+    dir: &str,
+) -> Option<MonorepoPackage> {
     use crate::git::cmd::safe_repo_path;
     // Normalise: `./foo` → `foo`, `./` → `.` → skip
     let rel = dir.trim_start_matches("./");
@@ -1061,13 +1120,19 @@ fn go_work_dir_to_package(cwd: &str, cwd_path: &std::path::Path, dir: &str) -> O
     if !abs.is_dir() {
         return None;
     }
-    let rel_path = abs.strip_prefix(cwd_path)
+    let rel_path = abs
+        .strip_prefix(cwd_path)
         .map(|p| p.to_string_lossy().to_string())
         .unwrap_or_else(|_| rel.to_string());
-    let name = abs.file_name()
+    let name = abs
+        .file_name()
         .map(|f| f.to_string_lossy().to_string())
         .unwrap_or_else(|| rel_path.clone());
-    Some(MonorepoPackage { name, path: rel_path, version: String::new() })
+    Some(MonorepoPackage {
+        name,
+        path: rel_path,
+        version: String::new(),
+    })
 }
 
 // ─── nx ───────────────────────────────────────────────────────────────────
@@ -1079,10 +1144,10 @@ pub(crate) fn find_nx_packages(cwd: &str, nx_json_content: &str) -> Vec<Monorepo
     let cwd_path = std::path::Path::new(cwd);
 
     // Detect custom layout dirs from nx.json
-    let apps_dir = extract_json_string(nx_json_content, "appsDir")
-        .unwrap_or_else(|| "apps".to_string());
-    let libs_dir = extract_json_string(nx_json_content, "libsDir")
-        .unwrap_or_else(|| "libs".to_string());
+    let apps_dir =
+        extract_json_string(nx_json_content, "appsDir").unwrap_or_else(|| "apps".to_string());
+    let libs_dir =
+        extract_json_string(nx_json_content, "libsDir").unwrap_or_else(|| "libs".to_string());
 
     let scan_dirs: Vec<String> = if apps_dir == libs_dir {
         vec![apps_dir]
@@ -1133,10 +1198,15 @@ pub(crate) fn find_nx_packages(cwd: &str, nx_json_content: &str) -> Vec<Monorepo
                 } else {
                     String::new()
                 };
-                let rel_path = path.strip_prefix(cwd_path)
+                let rel_path = path
+                    .strip_prefix(cwd_path)
                     .map(|p| p.to_string_lossy().to_string())
                     .unwrap_or_else(|_| path.to_string_lossy().to_string());
-                packages.push(MonorepoPackage { name, path: rel_path, version });
+                packages.push(MonorepoPackage {
+                    name,
+                    path: rel_path,
+                    version,
+                });
             }
         }
     }
@@ -1146,11 +1216,15 @@ pub(crate) fn find_nx_packages(cwd: &str, nx_json_content: &str) -> Vec<Monorepo
 }
 
 pub(crate) fn read_git_file(path: &Path) -> Option<String> {
-    std::fs::read_to_string(path).ok().map(|s| s.trim().to_string())
+    std::fs::read_to_string(path)
+        .ok()
+        .map(|s| s.trim().to_string())
 }
 
 pub(crate) fn read_git_u32(path: &Path) -> u32 {
-    read_git_file(path).and_then(|s| s.parse().ok()).unwrap_or(0)
+    read_git_file(path)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0)
 }
 
 pub(crate) fn has_unresolved_conflicts(cwd: &str) -> bool {
@@ -1218,43 +1292,71 @@ mod workspace_detection_tests {
     #[test]
     fn cargo_workspace_members_glob() {
         let dir = TempDir::new("cargo");
-        dir.write("Cargo.toml", r#"
+        dir.write(
+            "Cargo.toml",
+            r#"
 [workspace]
 members = ["crates/*"]
-"#);
-        dir.write("crates/foo/Cargo.toml", r#"
+"#,
+        );
+        dir.write(
+            "crates/foo/Cargo.toml",
+            r#"
 [package]
 name = "foo"
 version = "0.1.0"
-"#);
-        dir.write("crates/bar/Cargo.toml", r#"
+"#,
+        );
+        dir.write(
+            "crates/bar/Cargo.toml",
+            r#"
 [package]
 name = "bar"
 version = "0.2.0"
-"#);
+"#,
+        );
 
         let content = std::fs::read_to_string(dir.path.join("Cargo.toml")).unwrap();
         let pkgs = find_cargo_packages(dir.cwd(), &content);
         let names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"foo"), "expected 'foo' in {:?}", names);
         assert!(names.contains(&"bar"), "expected 'bar' in {:?}", names);
-        assert_eq!(pkgs.iter().find(|p| p.name == "foo").unwrap().version, "0.1.0");
-        assert_eq!(pkgs.iter().find(|p| p.name == "bar").unwrap().version, "0.2.0");
+        assert_eq!(
+            pkgs.iter().find(|p| p.name == "foo").unwrap().version,
+            "0.1.0"
+        );
+        assert_eq!(
+            pkgs.iter().find(|p| p.name == "bar").unwrap().version,
+            "0.2.0"
+        );
         // paths are repo-relative
         for pkg in &pkgs {
-            assert!(!pkg.path.starts_with('/'), "path should be relative: {}", pkg.path);
+            assert!(
+                !pkg.path.starts_with('/'),
+                "path should be relative: {}",
+                pkg.path
+            );
         }
     }
 
     #[test]
     fn cargo_workspace_literal_member() {
         let dir = TempDir::new("cargo-lit");
-        dir.write("Cargo.toml", r#"
+        dir.write(
+            "Cargo.toml",
+            r#"
 [workspace]
 members = ["packages/alpha", "packages/beta"]
-"#);
-        dir.write("packages/alpha/Cargo.toml", "[package]\nname = \"alpha\"\nversion = \"1.0.0\"\n");
-        dir.write("packages/beta/Cargo.toml", "[package]\nname = \"beta\"\nversion = \"2.0.0\"\n");
+"#,
+        );
+        dir.write(
+            "packages/alpha/Cargo.toml",
+            "[package]\nname = \"alpha\"\nversion = \"1.0.0\"\n",
+        );
+        dir.write(
+            "packages/beta/Cargo.toml",
+            "[package]\nname = \"beta\"\nversion = \"2.0.0\"\n",
+        );
 
         let content = std::fs::read_to_string(dir.path.join("Cargo.toml")).unwrap();
         let pkgs = find_cargo_packages(dir.cwd(), &content);
@@ -1266,19 +1368,31 @@ members = ["packages/alpha", "packages/beta"]
     #[test]
     fn cargo_workspace_exclude() {
         let dir = TempDir::new("cargo-excl");
-        dir.write("Cargo.toml", r#"
+        dir.write(
+            "Cargo.toml",
+            r#"
 [workspace]
 members = ["crates/*"]
 exclude = ["crates/skip"]
-"#);
-        dir.write("crates/keep/Cargo.toml", "[package]\nname = \"keep\"\nversion = \"0.1.0\"\n");
-        dir.write("crates/skip/Cargo.toml", "[package]\nname = \"skip\"\nversion = \"0.1.0\"\n");
+"#,
+        );
+        dir.write(
+            "crates/keep/Cargo.toml",
+            "[package]\nname = \"keep\"\nversion = \"0.1.0\"\n",
+        );
+        dir.write(
+            "crates/skip/Cargo.toml",
+            "[package]\nname = \"skip\"\nversion = \"0.1.0\"\n",
+        );
 
         let content = std::fs::read_to_string(dir.path.join("Cargo.toml")).unwrap();
         let pkgs = find_cargo_packages(dir.cwd(), &content);
         let names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"keep"));
-        assert!(!names.contains(&"skip"), "excluded member should not appear");
+        assert!(
+            !names.contains(&"skip"),
+            "excluded member should not appear"
+        );
     }
 
     #[test]
@@ -1287,7 +1401,10 @@ exclude = ["crates/skip"]
         // Cargo.toml that looks like a workspace but is actually malformed JSON-in-TOML
         let content = "[workspace\nmembers = [\n";
         let pkgs = find_cargo_packages(dir.cwd(), content);
-        assert!(pkgs.is_empty(), "malformed manifest should yield empty packages");
+        assert!(
+            pkgs.is_empty(),
+            "malformed manifest should yield empty packages"
+        );
     }
 
     // ── go.work ───────────────────────────────────────────────
@@ -1302,7 +1419,11 @@ exclude = ["crates/skip"]
         let pkgs = find_go_packages(dir.cwd(), go_work);
         let names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"api"), "expected 'api' in {:?}", names);
-        assert!(names.contains(&"shared"), "expected 'shared' in {:?}", names);
+        assert!(
+            names.contains(&"shared"),
+            "expected 'shared' in {:?}",
+            names
+        );
         // version is always empty for go
         for pkg in &pkgs {
             assert_eq!(pkg.version, "");
@@ -1355,13 +1476,20 @@ exclude = ["crates/skip"]
         let pkgs = find_nx_packages(dir.cwd(), &content);
         let names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
         assert!(names.contains(&"web"), "expected 'web' in {:?}", names);
-        assert!(names.contains(&"ui-lib"), "expected 'ui-lib' in {:?}", names);
+        assert!(
+            names.contains(&"ui-lib"),
+            "expected 'ui-lib' in {:?}",
+            names
+        );
     }
 
     #[test]
     fn nx_custom_workspace_layout() {
         let dir = TempDir::new("nx-custom");
-        dir.write("nx.json", r#"{"workspaceLayout":{"appsDir":"services","libsDir":"shared"}}"#);
+        dir.write(
+            "nx.json",
+            r#"{"workspaceLayout":{"appsDir":"services","libsDir":"shared"}}"#,
+        );
         dir.write("services/api/project.json", r#"{"name":"api"}"#);
         dir.write("shared/core/project.json", r#"{"name":"core"}"#);
 
@@ -1376,12 +1504,19 @@ exclude = ["crates/skip"]
     fn nx_package_json_fallback() {
         let dir = TempDir::new("nx-pkg");
         dir.write("nx.json", "{}");
-        dir.write("apps/dashboard/package.json", r#"{"name":"@acme/dashboard","version":"1.0.0"}"#);
+        dir.write(
+            "apps/dashboard/package.json",
+            r#"{"name":"@acme/dashboard","version":"1.0.0"}"#,
+        );
 
         let content = std::fs::read_to_string(dir.path.join("nx.json")).unwrap();
         let pkgs = find_nx_packages(dir.cwd(), &content);
         let names: Vec<&str> = pkgs.iter().map(|p| p.name.as_str()).collect();
-        assert!(names.contains(&"@acme/dashboard"), "expected '@acme/dashboard' in {:?}", names);
+        assert!(
+            names.contains(&"@acme/dashboard"),
+            "expected '@acme/dashboard' in {:?}",
+            names
+        );
     }
 
     // ── turbo ─────────────────────────────────────────────────
@@ -1390,9 +1525,18 @@ exclude = ["crates/skip"]
     fn turbo_reuses_package_json_workspaces() {
         let dir = TempDir::new("turbo");
         dir.write("turbo.json", r#"{"$schema":"...","pipeline":{}}"#);
-        dir.write("package.json", r#"{"name":"root","workspaces":["apps/*","packages/*"]}"#);
-        dir.write("apps/web/package.json", r#"{"name":"web","version":"0.1.0"}"#);
-        dir.write("packages/utils/package.json", r#"{"name":"utils","version":"1.0.0"}"#);
+        dir.write(
+            "package.json",
+            r#"{"name":"root","workspaces":["apps/*","packages/*"]}"#,
+        );
+        dir.write(
+            "apps/web/package.json",
+            r#"{"name":"web","version":"0.1.0"}"#,
+        );
+        dir.write(
+            "packages/utils/package.json",
+            r#"{"name":"utils","version":"1.0.0"}"#,
+        );
 
         let pkg_content = std::fs::read_to_string(dir.path.join("package.json")).unwrap();
         let pkgs = find_workspace_packages(dir.cwd(), &pkg_content, "turbo");
@@ -1415,7 +1559,10 @@ exclude = ["crates/skip"]
         // Here we just verify cargo packages are found correctly when cargo is used.
         let dir = TempDir::new("prec");
         dir.write("Cargo.toml", "[workspace]\nmembers = [\"crates/*\"]\n");
-        dir.write("crates/mylib/Cargo.toml", "[package]\nname = \"mylib\"\nversion = \"0.1.0\"\n");
+        dir.write(
+            "crates/mylib/Cargo.toml",
+            "[package]\nname = \"mylib\"\nversion = \"0.1.0\"\n",
+        );
 
         let content = std::fs::read_to_string(dir.path.join("Cargo.toml")).unwrap();
         let pkgs = find_cargo_packages(dir.cwd(), &content);
@@ -1431,15 +1578,21 @@ exclude = ["crates/skip"]
         let dir = TempDir::new("prec-detect");
         dir.write("pnpm-workspace.yaml", "packages:\n  - 'packages/*'\n");
         dir.write("Cargo.toml", "[workspace]\nmembers = [\"crates/*\"]\n");
-        dir.write("crates/mylib/Cargo.toml", "[package]\nname = \"mylib\"\nversion = \"0.1.0\"\n");
+        dir.write(
+            "crates/mylib/Cargo.toml",
+            "[package]\nname = \"mylib\"\nversion = \"0.1.0\"\n",
+        );
 
-        let info = tauri::async_runtime::block_on(
-            crate::commands::ops::detect_monorepo(dir.cwd().to_string()),
-        )
+        let info = tauri::async_runtime::block_on(crate::commands::ops::detect_monorepo(
+            dir.cwd().to_string(),
+        ))
         .expect("detect_monorepo should not error");
 
         assert!(info.is_monorepo, "should be detected as a monorepo");
-        assert_eq!(info.manager, "pnpm", "pnpm must win over cargo per locked precedence");
+        assert_eq!(
+            info.manager, "pnpm",
+            "pnpm must win over cargo per locked precedence"
+        );
     }
 
     // ── TOML parsing helpers ──────────────────────────────────
@@ -1462,8 +1615,14 @@ members = [
     #[test]
     fn parse_toml_scalar_basic() {
         let toml = "[package]\nname = \"my-crate\"\nversion = \"0.3.1\"\n";
-        assert_eq!(parse_toml_scalar(toml, "name"), Some("my-crate".to_string()));
-        assert_eq!(parse_toml_scalar(toml, "version"), Some("0.3.1".to_string()));
+        assert_eq!(
+            parse_toml_scalar(toml, "name"),
+            Some("my-crate".to_string())
+        );
+        assert_eq!(
+            parse_toml_scalar(toml, "version"),
+            Some("0.3.1".to_string())
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/src/git/repo_lock.rs
+++ b/apps/desktop/src-tauri/src/git/repo_lock.rs
@@ -106,7 +106,10 @@ mod tests {
     fn same_cwd_shares_one_lock() {
         let a = lock_for("/tmp/repo-a");
         let b = lock_for("/tmp/repo-a");
-        assert!(Arc::ptr_eq(&a, &b), "same cwd must resolve to the same lock");
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "same cwd must resolve to the same lock"
+        );
     }
 
     #[test]
@@ -167,6 +170,9 @@ mod tests {
     fn nonexistent_path_falls_back_to_raw_string_without_panic() {
         let a = lock_for("/gitwand-repolock-does-not-exist-1");
         let b = lock_for("/gitwand-repolock-does-not-exist-1");
-        assert!(Arc::ptr_eq(&a, &b), "same nonexistent path must still share one lock");
+        assert!(
+            Arc::ptr_eq(&a, &b),
+            "same nonexistent path must still share one lock"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,7 +1,7 @@
-pub(crate) mod git;
-pub(crate) mod types;
 pub(crate) mod commands;
+pub(crate) mod git;
 pub(crate) mod shell_env;
+pub(crate) mod types;
 
 pub(crate) use crate::types::*;
 // Used only by the `#[cfg(test)] mod tests` block below (parse_gh_pr_json,
@@ -12,41 +12,52 @@ pub(crate) use crate::types::*;
 pub(crate) use crate::git::*;
 
 use tauri::{Emitter, Manager};
-use tauri_plugin_global_shortcut::GlobalShortcutExt;
-#[cfg(not(debug_assertions))]
+#[cfg(feature = "telemetry")]
 use tauri_plugin_aptabase::EventTracker;
+use tauri_plugin_global_shortcut::GlobalShortcutExt;
 
-/// GitWand Desktop — Tauri backend
-///
-/// Most of the resolution logic runs in the frontend via @gitwand/core (TypeScript).
-/// This Rust backend handles:
-/// - Native file system access (reading conflicted files, browsing directories)
-/// - Git command execution
-/// - Window management
-///
-/// ─── Trust boundaries ──────────────────────────────────────
-///
-/// Tauri commands live on a trust boundary: inputs come from the webview,
-/// where they may originate from untrusted repo content (READMEs, PR bodies,
-/// file names). Categories of commands and their security invariants:
-///
-/// 1. **Filesystem read/write** (`read_file`, `write_file`, `list_dir`):
-///    - Paths are constrained under an explicit `cwd` root via `safe_repo_path`.
-///    - No `..` segments may escape the root.
-///
-/// 2. **Git command execution** (`get_conflicted_files`, diff/log/status, etc.):
-///    - Arguments are passed mechanically via `.arg()` — never interpolated
-///      into a shell string. Safe by construction against command injection.
-///    - `cwd` is used as `.current_dir()` for the process, so the git binary
-///      itself confines filesystem access to the repo.
-///
-/// 3. **External CLI execution** (`gh`, `claude`, editor): same rules as (2).
-///    `claude` runs with API-key env vars stripped to force the OAuth session.
-///
-/// 4. **Window / IPC events**: trusted frontend-only surface.
-///
-/// When adding a new command, classify it against one of these categories and
-/// reuse the helpers below.
+// Release builds MUST be built with `--features telemetry` (see
+// release.yml). Without it, `tauri-plugin-aptabase` is entirely absent
+// (it's an optional dependency, see Cargo.toml's [features] section), so a
+// release shipped without this flag would silently lose all analytics —
+// this turns that mistake into a build failure instead.
+#[cfg(all(not(debug_assertions), not(feature = "telemetry")))]
+compile_error!(
+    "release builds must be built with --features telemetry \
+     (see release.yml). A release without it silently loses all analytics."
+);
+
+// GitWand Desktop — Tauri backend
+//
+// Most of the resolution logic runs in the frontend via @gitwand/core (TypeScript).
+// This Rust backend handles:
+// - Native file system access (reading conflicted files, browsing directories)
+// - Git command execution
+// - Window management
+//
+// ─── Trust boundaries ──────────────────────────────────────
+//
+// Tauri commands live on a trust boundary: inputs come from the webview,
+// where they may originate from untrusted repo content (READMEs, PR bodies,
+// file names). Categories of commands and their security invariants:
+//
+// 1. **Filesystem read/write** (`read_file`, `write_file`, `list_dir`):
+//    - Paths are constrained under an explicit `cwd` root via `safe_repo_path`.
+//    - No `..` segments may escape the root.
+//
+// 2. **Git command execution** (`get_conflicted_files`, diff/log/status, etc.):
+//    - Arguments are passed mechanically via `.arg()` — never interpolated
+//      into a shell string. Safe by construction against command injection.
+//    - `cwd` is used as `.current_dir()` for the process, so the git binary
+//      itself confines filesystem access to the repo.
+//
+// 3. **External CLI execution** (`gh`, `claude`, editor): same rules as (2).
+//    `claude` runs with API-key env vars stripped to force the OAuth session.
+//
+// 4. **Window / IPC events**: trusted frontend-only surface.
+//
+// When adding a new command, classify it against one of these categories and
+// reuse the helpers below.
 
 // ─── Git read commands → commands/read.rs ─────────────────────
 // (git_status, git_diff, git_log, git_repo_state, git_show,
@@ -56,7 +67,6 @@ use tauri_plugin_aptabase::EventTracker;
 // `commands::read::*`. Internal helpers (libgit2_branch_status,
 // libgit2_file_statuses, compute_push_remote_via_cli, git_status_cli,
 // merge_file_preview) live there alongside their only callers.
-
 
 // `gh_*` commands (list_prs, create_pr, list_reviewer_candidates,
 // checkout_pr, merge_pr, pr_detail, pr_diff, pr_checks) migrated to
@@ -82,7 +92,6 @@ use tauri_plugin_aptabase::EventTracker;
 // gh_pr_checks → commands/gh.rs
 
 // ─── Read .gitwandrc ──────────────────────────────────────
-
 
 // ─── Claude Code CLI (piggyback on user's local install) ─────
 //
@@ -210,7 +219,9 @@ pub fn git_log_parity(
     // Command fns are now `async` (run off the UI thread). These `*_parity`
     // wrappers are sync entry points for the parity-probe example, so block on
     // the future here to keep their signatures unchanged.
-    tauri::async_runtime::block_on(commands::read::git_log(cwd, count, all, author, None, None, None, None))
+    tauri::async_runtime::block_on(commands::read::git_log(
+        cwd, count, all, author, None, None, None, None,
+    ))
 }
 
 pub fn git_branches_parity(cwd: String) -> Result<Vec<types::GitBranch>, String> {
@@ -242,8 +253,8 @@ pub fn scan_secrets_parity(
     cwd: String,
     config: serde_json::Value,
 ) -> Result<Vec<types::SecretFinding>, String> {
-    let config: types::SecretsScanConfig =
-        serde_json::from_value(config).map_err(|e| format!("invalid secrets scan config: {}", e))?;
+    let config: types::SecretsScanConfig = serde_json::from_value(config)
+        .map_err(|e| format!("invalid secrets scan config: {}", e))?;
     commands::secrets::scan_staged(&cwd, &config)
 }
 
@@ -251,11 +262,12 @@ pub fn scan_secrets_parity(
 
 /// Aptabase App Key for anonymous launch telemetry. This is a public client
 /// identifier (format `A-EU-*` / `A-US-*`), not a secret — same trust model
-/// as the previous public Umami website ID. Only used in release builds.
-#[cfg(not(debug_assertions))]
+/// as the previous public Umami website ID. Only used in release builds
+/// compiled with `--features telemetry`.
+#[cfg(feature = "telemetry")]
 const APTABASE_APP_KEY: &str = "A-EU-3954664786";
 
-#[cfg(not(debug_assertions))]
+#[cfg(feature = "telemetry")]
 /// Returns the anonymous install ID, creating it on first launch.
 ///
 /// Stored at `{data_local_dir}/gitwand/install_id` as a plain UUID v4.
@@ -338,9 +350,11 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_clipboard_manager::init());
 
-    // Anonymous launch telemetry (release builds only). Registered
-    // conditionally because APTABASE_APP_KEY is compiled out in debug.
-    #[cfg(not(debug_assertions))]
+    // Anonymous launch telemetry (release builds with --features telemetry
+    // only). Registered conditionally because APTABASE_APP_KEY and the
+    // tauri-plugin-aptabase dependency itself are both compiled out unless
+    // the `telemetry` feature is enabled.
+    #[cfg(feature = "telemetry")]
     let builder = builder.plugin(tauri_plugin_aptabase::Builder::new(APTABASE_APP_KEY).build());
 
     builder
@@ -349,18 +363,21 @@ pub fn run() {
             // to bring GitWand to the foreground from anywhere.
             use tauri_plugin_global_shortcut::ShortcutState;
             let handle = app.handle().clone();
-            app.global_shortcut().on_shortcut("CmdOrCtrl+Shift+G", move |_app, _shortcut, event| {
-                if event.state == ShortcutState::Pressed {
-                    // Show + focus the main window
-                    if let Some(window) = handle.get_webview_window("main") {
-                        let _ = window.show();
-                        let _ = window.unminimize();
-                        let _ = window.set_focus();
+            app.global_shortcut().on_shortcut(
+                "CmdOrCtrl+Shift+G",
+                move |_app, _shortcut, event| {
+                    if event.state == ShortcutState::Pressed {
+                        // Show + focus the main window
+                        if let Some(window) = handle.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.unminimize();
+                            let _ = window.set_focus();
+                        }
+                        // Emit event so frontend can react (e.g. open folder picker)
+                        let _ = handle.emit("global-shortcut-activate", ());
                     }
-                    // Emit event so frontend can react (e.g. open folder picker)
-                    let _ = handle.emit("global-shortcut-activate", ());
-                }
-            })?;
+                },
+            )?;
 
             // Anonymous launch telemetry via Aptabase — fire-and-forget.
             // Replaced Umami: Umami Cloud filters non-browser User-Agents and
@@ -371,8 +388,8 @@ pub fn run() {
             // install_id is a random UUID (not hardware-derived). The plugin
             // auto-captures OS, app version and locale, so only install_id is
             // sent as a custom property. track_event runs in the background.
-            // Skipped in debug builds.
-            #[cfg(not(debug_assertions))]
+            // Skipped unless built with --features telemetry.
+            #[cfg(feature = "telemetry")]
             {
                 let install_id = get_or_create_install_id();
                 let _ = app.track_event(
@@ -423,7 +440,6 @@ pub fn run() {
             commands::ops::git_delete_branch,
             commands::ops::git_delete_remote_branch,
             commands::ops::git_rename_branch,
-
             commands::ops::git_stash,
             commands::ops::git_stash_pop,
             commands::ops::open_in_editor,
@@ -960,11 +976,31 @@ mod tests {
         };
         let json = serde_json::to_string(&item).unwrap();
         // #[serde(rename_all = "camelCase")] must produce camelCase keys
-        assert!(json.contains("\"repoPath\""), "repo_path should serialize as repoPath, got: {}", json);
-        assert!(json.contains("\"repoName\""), "repo_name should serialize as repoName, got: {}", json);
-        assert!(!json.contains("\"repo_path\""), "snake_case must not appear: {}", json);
-        assert!(!json.contains("\"repo_name\""), "snake_case must not appear: {}", json);
-        assert!(json.contains("\"prs\""), "prs field must appear in JSON, got: {}", json);
+        assert!(
+            json.contains("\"repoPath\""),
+            "repo_path should serialize as repoPath, got: {}",
+            json
+        );
+        assert!(
+            json.contains("\"repoName\""),
+            "repo_name should serialize as repoName, got: {}",
+            json
+        );
+        assert!(
+            !json.contains("\"repo_path\""),
+            "snake_case must not appear: {}",
+            json
+        );
+        assert!(
+            !json.contains("\"repo_name\""),
+            "snake_case must not appear: {}",
+            json
+        );
+        assert!(
+            json.contains("\"prs\""),
+            "prs field must appear in JSON, got: {}",
+            json
+        );
     }
 
     #[test]
@@ -976,9 +1012,16 @@ mod tests {
             error: Some("gh: command not found".to_string()),
         };
         let json = serde_json::to_string(&item).unwrap();
-        assert!(json.contains("\"gh: command not found\""), "error message must appear in JSON");
+        assert!(
+            json.contains("\"gh: command not found\""),
+            "error message must appear in JSON"
+        );
         // error field itself should be camelCase (it's a single word, stays "error")
-        assert!(json.contains("\"error\":\"gh: command not found\""), "error key+value must appear together: {}", json);
+        assert!(
+            json.contains("\"error\":\"gh: command not found\""),
+            "error key+value must appear together: {}",
+            json
+        );
     }
 
     #[test]
@@ -1035,7 +1078,10 @@ mod tests {
         }]"#;
         let issues = parse_gh_issue_json(json).unwrap();
         assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].milestone, "", "milestone should be empty string when absent");
+        assert_eq!(
+            issues[0].milestone, "",
+            "milestone should be empty string when absent"
+        );
         assert!(issues[0].assignees.is_empty());
         assert!(issues[0].labels.is_empty());
     }
@@ -1046,8 +1092,12 @@ mod tests {
         fn extract(status_out: &str) -> Vec<String> {
             let mut seen = std::collections::HashSet::new();
             for line in status_out.lines() {
-                if line.len() < 4 { continue; }
-                if &line[0..2] == "??" { continue; }
+                if line.len() < 4 {
+                    continue;
+                }
+                if &line[0..2] == "??" {
+                    continue;
+                }
                 let path_part = &line[3..];
                 let path = if path_part.contains(" -> ") {
                     path_part.split(" -> ").last().unwrap_or(path_part).trim()
@@ -1077,7 +1127,10 @@ mod tests {
         assert_eq!(extract(" M \"new file.ts\"\n"), vec!["new file.ts"]);
 
         // Rename with spaces: new path, quotes stripped
-        assert_eq!(extract("R  \"old file.ts\" -> \"new file.ts\"\n"), vec!["new file.ts"]);
+        assert_eq!(
+            extract("R  \"old file.ts\" -> \"new file.ts\"\n"),
+            vec!["new file.ts"]
+        );
 
         // Deduplication
         assert_eq!(

--- a/apps/desktop/src-tauri/src/shell_env.rs
+++ b/apps/desktop/src-tauri/src/shell_env.rs
@@ -190,7 +190,10 @@ fn extract_gh_token(shell: &str) {
     }
 
     std::env::set_var("GH_TOKEN", &token);
-    eprintln!("[gitwand] GH_TOKEN preloaded from login shell (length={})", token.len());
+    eprintln!(
+        "[gitwand] GH_TOKEN preloaded from login shell (length={})",
+        token.len()
+    );
 }
 
 /// Spawn `$SHELL -l -c "glab auth status --show-token"` and propagate the
@@ -233,7 +236,10 @@ fn extract_glab_token(shell: &str) {
     };
 
     std::env::set_var("GITLAB_TOKEN", &token);
-    eprintln!("[gitwand] GITLAB_TOKEN preloaded from login shell (length={})", token.len());
+    eprintln!(
+        "[gitwand] GITLAB_TOKEN preloaded from login shell (length={})",
+        token.len()
+    );
 }
 
 /// Extract the token value from `glab auth status --show-token` output.
@@ -286,19 +292,28 @@ mod glab_token_tests {
     #[test]
     fn extracts_token_from_a_status_line() {
         let output = "gitlab.com\n  ✓ Logged in to gitlab.com as alice (keyring)\n  ✓ Token: glpat-abcdefghijklmnopqrst\n";
-        assert_eq!(parse_glab_token(output), Some("glpat-abcdefghijklmnopqrst".to_string()));
+        assert_eq!(
+            parse_glab_token(output),
+            Some("glpat-abcdefghijklmnopqrst".to_string())
+        );
     }
 
     #[test]
     fn strips_ansi_color_codes_around_the_token() {
         let output = "\u{1b}[32m✓\u{1b}[0m Token: \u{1b}[33mglpat-zzzzzzzzzzzzzzzzzzzz\u{1b}[0m\n";
-        assert_eq!(parse_glab_token(output), Some("glpat-zzzzzzzzzzzzzzzzzzzz".to_string()));
+        assert_eq!(
+            parse_glab_token(output),
+            Some("glpat-zzzzzzzzzzzzzzzzzzzz".to_string())
+        );
     }
 
     #[test]
     fn takes_the_first_token_line_when_multiple_hosts_are_configured() {
         let output = "gitlab.com\n  ✓ Token: glpat-firsthost0000000000\n\nself-hosted.example.com\n  ✓ Token: glpat-secondhost000000000\n";
-        assert_eq!(parse_glab_token(output), Some("glpat-firsthost0000000000".to_string()));
+        assert_eq!(
+            parse_glab_token(output),
+            Some("glpat-firsthost0000000000".to_string())
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/shell_env.rs
+++ b/apps/desktop/src-tauri/src/shell_env.rs
@@ -152,6 +152,13 @@ pub(crate) fn init_login_shell_env() {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn init_login_shell_env() {
+    // Linux/Windows: launchers (Gnome/KDE session manager, explorer.exe,
+    // the systemd user instance, etc.) typically already provide the full
+    // user env. No preload needed.
+}
+
 /// Spawn `$SHELL -l -c "gh auth token"` and propagate the result as `GH_TOKEN`.
 /// Bounded by a 3s timeout. Silent on any failure path.
 #[cfg(target_os = "macos")]
@@ -250,6 +257,12 @@ fn extract_glab_token(shell: &str) {
 /// the first one wins (current-context host is reported first). ANSI color
 /// codes are stripped first since glab colors this output even when it
 /// detects a non-tty stdout in some versions.
+///
+/// Only called from the macOS-only `extract_glab_token` above, so this (and
+/// `strip_ansi_codes` below) would be dead code on other platforms outside
+/// `#[cfg(test)]` — gated accordingly rather than `#[allow(dead_code)]`,
+/// since `glab_token_tests` below still needs it to compile on every OS.
+#[cfg(any(test, target_os = "macos"))]
 fn parse_glab_token(status_output: &str) -> Option<String> {
     for line in status_output.lines() {
         let stripped = strip_ansi_codes(line);
@@ -267,6 +280,7 @@ fn parse_glab_token(status_output: &str) -> Option<String> {
 /// Strip ANSI CSI escape sequences (`\x1b[...<final byte>`) from a line.
 /// Minimal hand-rolled version — avoids pulling in an ansi-stripping crate
 /// for a startup-only, non-hot-path parse of a few lines of CLI output.
+#[cfg(any(test, target_os = "macos"))]
 fn strip_ansi_codes(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
@@ -332,11 +346,4 @@ mod glab_token_tests {
         let output = "  ✓ Token: \n";
         assert_eq!(parse_glab_token(output), None);
     }
-}
-
-#[cfg(not(target_os = "macos"))]
-pub(crate) fn init_login_shell_env() {
-    // Linux/Windows: launchers (Gnome/KDE session manager, explorer.exe,
-    // the systemd user instance, etc.) typically already provide the full
-    // user env. No preload needed.
 }

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 // ─── Constants ─────────────────────────────────────────────────────
 

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -693,24 +693,24 @@ async function checkAndSaveIfResolved(filePath: string) {
 }
 
 /** Wrapped resolve handlers that auto-save when fully resolved */
-function handleResolveHunk(path: string, hunkIndex: number, choice: "ours" | "theirs" | "both" | "both-theirs-first") {
-  resolveHunkManual(path, hunkIndex, choice);
-  checkAndSaveIfResolved(path);
+async function handleResolveHunk(path: string, hunkIndex: number, choice: "ours" | "theirs" | "both" | "both-theirs-first") {
+  await resolveHunkManual(path, hunkIndex, choice);
+  await checkAndSaveIfResolved(path);
 }
 
-function handleResolveFile(path: string) {
-  resolveFile(path);
-  checkAndSaveIfResolved(path);
+async function handleResolveFile(path: string) {
+  await resolveFile(path);
+  await checkAndSaveIfResolved(path);
 }
 
-function handleResolveHunkCustom(path: string, hunkIndex: number, content: string) {
-  resolveHunkCustom(path, hunkIndex, content);
-  checkAndSaveIfResolved(path);
+async function handleResolveHunkCustom(path: string, hunkIndex: number, content: string) {
+  await resolveHunkCustom(path, hunkIndex, content);
+  await checkAndSaveIfResolved(path);
 }
 
-function handleResolveFileBulk(path: string, choice: "ours" | "theirs" | "both") {
-  resolveFileBulk(path, choice);
-  checkAndSaveIfResolved(path);
+async function handleResolveFileBulk(path: string, choice: "ours" | "theirs" | "both") {
+  await resolveFileBulk(path, choice);
+  await checkAndSaveIfResolved(path);
   memorizeToast.value = { path, strategy: choice };
 }
 
@@ -723,9 +723,9 @@ async function handleResolveTreeConflict(path: string, choice: "ours" | "theirs"
   }
 }
 
-function handleReconstructConflict(path: string) {
+async function handleReconstructConflict(path: string) {
   // Swap to reconstructed markers; the file now flows through the normal hunk UI.
-  reconstructAndResolve(path);
+  await reconstructAndResolve(path);
 }
 
 async function handleKeepWorkingTree(path: string) {
@@ -749,9 +749,9 @@ function dismissMemorizeToast() {
   memorizeToast.value = null;
 }
 
-function handleApplyFileMemory(path: string, entry: ResolutionMemoryEntry) {
-  applyMemoryToFile(path, entry);
-  checkAndSaveIfResolved(path);
+async function handleApplyFileMemory(path: string, entry: ResolutionMemoryEntry) {
+  await applyMemoryToFile(path, entry);
+  await checkAndSaveIfResolved(path);
 }
 
 // ─── Edit commit overlay ────────────────────────────────
@@ -2067,7 +2067,7 @@ async function onRebaseBannerAutoResolve() {
       }
       // Resolve this step.
       await mergeOpenPath(cwd);
-      resolveAll();
+      await resolveAll();
       await saveAllFiles();
       const resolved = mergeFiles.value
         .filter((f) => f.result.stats.totalConflicts === 0)

--- a/apps/desktop/src/CLAUDE.md
+++ b/apps/desktop/src/CLAUDE.md
@@ -104,7 +104,7 @@ const { t } = useI18n()
 
 ## Tests Vitest
 
-- Environnement : `jsdom`
+- Environnement : `node` par défaut (voir `vite.config.ts`) ; les fichiers qui touchent réellement le DOM (`document.`/`window.`/`HTMLElement`/`createElement`/`matchMedia`/`getComputedStyle`, ou un import transitif qui le fait) ajoutent `// @vitest-environment jsdom` en tête de fichier
 - Les composables ont leurs tests dans `composables/__tests__/`
 - Préférer les tests de composables aux tests de composants avec mocks lourds
 

--- a/apps/desktop/src/components/__tests__/CommitGraph.branchSlash.test.ts
+++ b/apps/desktop/src/components/__tests__/CommitGraph.branchSlash.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * CommitGraph.vue — ref-classification regression for #137.
  *

--- a/apps/desktop/src/components/__tests__/LaunchpadView.test.ts
+++ b/apps/desktop/src/components/__tests__/LaunchpadView.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * LaunchpadView.vue — UI smoke tests (Phase 2 / v2.29 sections rework).
  *

--- a/apps/desktop/src/components/__tests__/LlmTracePanel.test.ts
+++ b/apps/desktop/src/components/__tests__/LlmTracePanel.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * LlmTracePanel.vue — accept/reject action UI.
  *

--- a/apps/desktop/src/components/__tests__/MergeEditor-ai-sparkle.test.ts
+++ b/apps/desktop/src/components/__tests__/MergeEditor-ai-sparkle.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * Issue #133 (sub-issues 2 & 3) — the per-hunk "AI" resolve button used a
  * bespoke inline SVG + text label ("AI" / "AI…") with only a subtle opacity

--- a/apps/desktop/src/components/__tests__/MergeEditor.test.ts
+++ b/apps/desktop/src/components/__tests__/MergeEditor.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * MergeEditor.vue — minimap ResizeObserver regression guard.
  *

--- a/apps/desktop/src/components/__tests__/PrInlineDiff.test.ts
+++ b/apps/desktop/src/components/__tests__/PrInlineDiff.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * PrInlineDiff.vue — flat row model + virtualization (Task A2, v3.6.0).
  *

--- a/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
+++ b/apps/desktop/src/components/__tests__/RepoTabStrip.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * RepoTabStrip.vue — pointer-based drag-to-reorder regression guards.
  *

--- a/apps/desktop/src/components/__tests__/ResolutionPreviewPanel.test.ts
+++ b/apps/desktop/src/components/__tests__/ResolutionPreviewPanel.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * ResolutionPreviewPanel.vue — accept/reject action UI for any hunk the core
  * already auto-resolved (non_overlapping, one_side_change, whitespace_only, …).

--- a/apps/desktop/src/components/__tests__/ResolveAutoSummaryModal.test.ts
+++ b/apps/desktop/src/components/__tests__/ResolveAutoSummaryModal.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * ResolveAutoSummaryModal.vue — confirmation before "Résoudre auto" applies
  * every auto-resolved hunk in a file.

--- a/apps/desktop/src/components/__tests__/SecretsFindingsModal.test.ts
+++ b/apps/desktop/src/components/__tests__/SecretsFindingsModal.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * SecretsFindingsModal.vue — findings list + per-finding/per-pattern actions.
  *

--- a/apps/desktop/src/components/__tests__/StashManager-date.test.ts
+++ b/apps/desktop/src/components/__tests__/StashManager-date.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * Issue #151 — every stash rendered its date as the literal "Invalid Date".
  *

--- a/apps/desktop/src/components/__tests__/TokenMergePanel.test.ts
+++ b/apps/desktop/src/components/__tests__/TokenMergePanel.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * TokenMergePanel.vue — accept/reject action UI for proposed token-level merges.
  *

--- a/apps/desktop/src/composables/__tests__/useFileExplorer.test.ts
+++ b/apps/desktop/src/composables/__tests__/useFileExplorer.test.ts
@@ -1,3 +1,8 @@
+// @vitest-environment jsdom
+// resolveFileExplorerShortcut tests below construct `new KeyboardEvent(...)`
+// directly — a DOM global not covered by the plan's document./window./
+// HTMLElement/createElement/matchMedia/getComputedStyle grep, but a real DOM
+// dependency nonetheless.
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("@/utils/backend", () => ({

--- a/apps/desktop/src/composables/__tests__/usePrPanel-prereview.test.ts
+++ b/apps/desktop/src/composables/__tests__/usePrPanel-prereview.test.ts
@@ -1,3 +1,7 @@
+// @vitest-environment jsdom
+// usePrPanel pulls in usePrReviewQueue transitively, which reads
+// `document.hidden` at call time (visibility-gated queue, see
+// apps/desktop/CLAUDE.md "Polling" perf invariant) — needs a real `document`.
 /**
  * Task C3 (v3.6.0) — `usePrPanel` orchestration of the pre-review pass:
  * opt-in, cache-first, cancellable on PR switch.

--- a/apps/desktop/src/composables/__tests__/usePrReviewKeymap.test.ts
+++ b/apps/desktop/src/composables/__tests__/usePrReviewKeymap.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { resolvePrReviewShortcut, isEditableTarget } from "../usePrReviewKeymap";
 

--- a/apps/desktop/src/composables/__tests__/usePrReviewQueue.test.ts
+++ b/apps/desktop/src/composables/__tests__/usePrReviewQueue.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * Task C3 (v3.6.0) — bounded, cancellable, visibility-gated queue.
  */

--- a/apps/desktop/src/composables/__tests__/useReviewIntelligence.test.ts
+++ b/apps/desktop/src/composables/__tests__/useReviewIntelligence.test.ts
@@ -1,3 +1,7 @@
+// @vitest-environment jsdom
+// useReviewIntelligence drives usePrReviewQueue transitively, which reads
+// `document.hidden` at call time (visibility-gated queue, see
+// apps/desktop/CLAUDE.md "Polling" perf invariant) — needs a real `document`.
 /**
  * Task E2 (v3.6.0) — unified AI + static Intelligence orchestrator.
  */

--- a/apps/desktop/src/composables/__tests__/useSafeHtml.test.ts
+++ b/apps/desktop/src/composables/__tests__/useSafeHtml.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 /**
  * XSS regression tests for useSafeHtml.
  *

--- a/apps/desktop/src/composables/useGitWand.ts
+++ b/apps/desktop/src/composables/useGitWand.ts
@@ -1,5 +1,12 @@
 import { ref, computed } from "vue";
-import { resolve, resolveAsync, parseGitwandrc, parseConflictMarkers, type MergeResult, type ConflictHunk, type GitWandOptions, type MergePolicy, type LlmFallbackConfig } from "@gitwand/core";
+import { parseGitwandrc, type MergeResult, type ConflictHunk, type GitWandOptions, type MergePolicy, type LlmFallbackConfig } from "@gitwand/core";
+// `resolve`, `resolveAsync` and `parseConflictMarkers` are loaded lazily via
+// `engine()` (see ../utils/coreEngine.ts) — they pull in the classifier +
+// full pattern registry (~243 KB raw / ~73 KB gzip) and must stay out of the
+// boot chunk. `import type` below is erased at build time; it only gives us
+// `typeof parseConflictMarkers` for `RawConflictSegment` without a runtime import.
+import type { parseConflictMarkers } from "@gitwand/core";
+import { engine } from "../utils/coreEngine";
 import {
   pickFolder,
   getConflictedFiles,
@@ -358,7 +365,7 @@ export function useGitWand() {
       console.error("openFolder error:", err);
       error.value = err.message ?? "Erreur inconnue";
       // Fallback to demo data if dev server is not running
-      loadDemoData();
+      await loadDemoData();
     } finally {
       loading.value = false;
     }
@@ -378,7 +385,7 @@ export function useGitWand() {
     } catch (err: any) {
       console.error("openPath error:", err);
       error.value = err.message ?? "Erreur inconnue";
-      loadDemoData();
+      await loadDemoData();
     } finally {
       loading.value = false;
     }
@@ -479,6 +486,11 @@ export function useGitWand() {
         }
       : resolveOptions.value;
 
+    // Lazily load the engine once for this whole batch — memoized by
+    // `engine()`, so the dynamic import only actually happens on the very
+    // first conflict resolution of the app's lifetime.
+    const { resolveAsync, parseConflictMarkers } = await engine();
+
     const loaded: ConflictFile[] = await Promise.all(
       allPaths.map(async (filePath) => {
         const tc = treeMap.get(filePath);
@@ -577,7 +589,7 @@ export function useGitWand() {
   /**
    * Load demo conflicted files for development/preview.
    */
-  function loadDemoData() {
+  async function loadDemoData() {
     const demoFiles: Array<{ path: string; content: string }> = [
       {
         path: "src/components/Header.tsx",
@@ -667,6 +679,7 @@ export async function fetchUsers() {
       },
     ];
 
+    const { resolve } = await engine();
     files.value = demoFiles.map(({ path, content }) => ({
       path,
       content,
@@ -683,8 +696,9 @@ export async function fetchUsers() {
    * Handles mixed files (some auto-resolved, some not) by applying
    * auto-resolved hunks individually via replaceConflictByIndex.
    */
-  function resolveAll() {
+  async function resolveAll() {
     pushUndo();
+    const { resolve } = await engine();
     files.value = files.value.map((f) => {
       if (f.result.stats.autoResolved === 0) return f;
 
@@ -726,7 +740,7 @@ export async function fetchUsers() {
    * Otherwise, build a partial resolution: apply resolved hunks and keep
    * conflict markers for the remaining ones.
    */
-  function resolveFile(path: string) {
+  async function resolveFile(path: string) {
     const file = files.value.find((f) => f.path === path);
     if (!file) return;
 
@@ -736,6 +750,7 @@ export async function fetchUsers() {
     if (!newContent || newContent === file.content) return;
 
     pushUndo();
+    const { resolve } = await engine();
     const idx = files.value.indexOf(file);
     files.value[idx] = {
       ...file,
@@ -789,7 +804,7 @@ export async function fetchUsers() {
    * @param hunkIndex - Index of the hunk (0-based, in order of appearance)
    * @param choice - "ours" | "theirs" | "both" | "both-theirs-first"
    */
-  function resolveHunkManual(
+  async function resolveHunkManual(
     path: string,
     hunkIndex: number,
     choice: "ours" | "theirs" | "both" | "both-theirs-first",
@@ -866,6 +881,7 @@ export async function fetchUsers() {
     }
 
     const newContent = newLines.join("\n");
+    const { resolve } = await engine();
     const idx = files.value.indexOf(file);
     files.value[idx] = {
       ...file,
@@ -880,7 +896,7 @@ export async function fetchUsers() {
    * @param hunkIndex - Index of the hunk
    * @param customContent - The user-written replacement text
    */
-  function resolveHunkCustom(
+  async function resolveHunkCustom(
     path: string,
     hunkIndex: number,
     customContent: string,
@@ -890,6 +906,7 @@ export async function fetchUsers() {
 
     pushUndo();
     const newContent = replaceConflictByIndex(file.content, hunkIndex, customContent);
+    const { resolve } = await engine();
     const idx = files.value.indexOf(file);
     files.value[idx] = {
       ...file,
@@ -903,10 +920,10 @@ export async function fetchUsers() {
    * including complex/low-confidence hunks. Distinct from `resolveFile`
    * (which only applies the core's safe auto-resolutions). Reversible via undo.
    */
-  function resolveFileBulk(
+  async function resolveFileBulk(
     path: string,
     choice: "ours" | "theirs" | "both",
-  ): { applied: number; total: number } {
+  ): Promise<{ applied: number; total: number }> {
     const file = files.value.find((f) => f.path === path);
     if (!file) return { applied: 0, total: 0 };
 
@@ -921,6 +938,7 @@ export async function fetchUsers() {
 
     if (newContent !== file.content) {
       pushUndo();
+      const { resolve } = await engine();
       const idx = files.value.indexOf(file);
       files.value[idx] = {
         ...file,
@@ -949,11 +967,12 @@ export async function fetchUsers() {
   }
 
   /** Markerless file → swap to the reconstructed conflict content and resolve via the normal pipeline. */
-  function reconstructAndResolve(path: string): void {
+  async function reconstructAndResolve(path: string): Promise<void> {
     const file = files.value.find((f) => f.path === path);
     if (!file?.markerless) return;
     const newContent = file.markerless.reconstructed;
     pushUndo();
+    const { resolve } = await engine();
     const idx = files.value.indexOf(file);
     files.value[idx] = {
       path: file.path,
@@ -978,10 +997,10 @@ export async function fetchUsers() {
    * rule can't apply (e.g. "date-latest" but content is no longer a date) keep
    * their conflict markers and are reported via the returned counts.
    */
-  function applyMemoryToFile(
+  async function applyMemoryToFile(
     path: string,
     entry: ResolutionMemoryEntry,
-  ): { applied: number; total: number } {
+  ): Promise<{ applied: number; total: number }> {
     const file = files.value.find((f) => f.path === path);
     if (!file) return { applied: 0, total: 0 };
     // A "custom" rule is a verbatim blob bound to one hunk — applying it to every
@@ -999,6 +1018,7 @@ export async function fetchUsers() {
 
     if (newContent !== file.content) {
       pushUndo();
+      const { resolve } = await engine();
       const idx = files.value.indexOf(file);
       files.value[idx] = {
         ...file,

--- a/apps/desktop/src/composables/useMergePreview.ts
+++ b/apps/desktop/src/composables/useMergePreview.ts
@@ -13,7 +13,12 @@
 
 import { ref, computed } from "vue";
 import { previewMerge, previewRebase, previewCherryPick } from "../utils/backend.js";
-import { resolve } from "@gitwand/core";
+// `resolve` is loaded lazily via `engine()` — this composable sits on an
+// eager path (AppHeader → BranchSelector → useMergePreview, always mounted),
+// so a static import here would put the ~244 KB raw / ~73 KB gzip resolution
+// engine back in the boot chunk even after useGitWand.ts stopped doing so.
+// See ../utils/coreEngine.ts.
+import { engine } from "../utils/coreEngine.js";
 
 // ─── Opérations prédictibles (v2.20.0) ───────────────────
 //
@@ -100,6 +105,7 @@ export function useMergePreview(cwd: () => string) {
             ? await previewCherryPick(cwd(), ref_)
             : await previewMerge(cwd(), ref_);
 
+      const { resolve } = await engine();
       const files: PreviewFileResult[] = [];
 
       for (const raw of rawFiles) {

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -2,13 +2,22 @@
  * Vitest global setup — installs an in-memory Web Storage shim when
  * `localStorage`/`sessionStorage` are missing or non-functional.
  *
- * Two distinct gaps this covers, both of which land on the same fix:
+ * Three distinct gaps this covers, all landing on the same fix:
  * 1. Node.js v25 ships a `localStorage` global that only works when
  *    `--localstorage-file` is supplied. Without the flag the object exists
  *    but has no Storage methods (setItem/getItem/removeItem/clear/key/length).
  * 2. Under Vitest's plain "node" environment (the default since the
  *    jsdom -> node switch, see vite.config.ts), there is no jsdom-provided
  *    Storage implementation to fall back on at all.
+ * 3. Some Node versions (observed: v25 locally) define a global `Storage`
+ *    class alongside their `localStorage` stub, so `Storage.prototype` exists
+ *    for `vi.spyOn` to hook even before this file runs. Node 22 (CI's
+ *    matrix) has neither — `Storage` is undefined as a bare identifier,
+ *    which throws a ReferenceError the moment a test does
+ *    `vi.spyOn(Storage.prototype, "setItem")` (see usePrCache.test.ts). Expose
+ *    `InMemoryStorage` as the global `Storage` so that spy target exists
+ *    consistently across Node versions, and so it's the exact same
+ *    prototype our localStorage/sessionStorage instances are built from.
  *
  * This file is intentionally self-contained (pure JS, no jsdom dependency)
  * so it works identically whether a given test file runs in "node" or
@@ -58,6 +67,15 @@ function installStorageShimIfNeeded(key: "localStorage" | "sessionStorage") {
     writable: true,
     configurable: true,
   });
+}
+
+// Expose the constructor globally (as `Storage`) whenever it's missing, so
+// `vi.spyOn(Storage.prototype, "setItem")`-style tests work regardless of
+// Node version — see gap 3 above. Our localStorage/sessionStorage instances
+// below are always `InMemoryStorage`, so this is the exact prototype they
+// share; spying on it affects them too.
+if (typeof (globalThis as Record<string, unknown>).Storage !== "function") {
+  (globalThis as Record<string, unknown>).Storage = InMemoryStorage;
 }
 
 installStorageShimIfNeeded("localStorage");

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -1,13 +1,18 @@
 /**
- * Vitest global setup — replaces the Node.js v25 built-in `localStorage` stub
- * with a proper in-memory Web Storage implementation.
+ * Vitest global setup — installs an in-memory Web Storage shim when
+ * `localStorage`/`sessionStorage` are missing or non-functional.
  *
- * Node.js v25 ships a `localStorage` global that only works when
- * `--localstorage-file` is supplied. Without the flag the object exists but has
- * no Storage methods (setItem/getItem/removeItem/clear/key/length).
- * Vitest's jsdom environment does not override this built-in, so tests that rely
- * on localStorage fail. This setup file installs a spec-compliant in-memory
- * replacement on `globalThis` before every test file runs.
+ * Two distinct gaps this covers, both of which land on the same fix:
+ * 1. Node.js v25 ships a `localStorage` global that only works when
+ *    `--localstorage-file` is supplied. Without the flag the object exists
+ *    but has no Storage methods (setItem/getItem/removeItem/clear/key/length).
+ * 2. Under Vitest's plain "node" environment (the default since the
+ *    jsdom -> node switch, see vite.config.ts), there is no jsdom-provided
+ *    Storage implementation to fall back on at all.
+ *
+ * This file is intentionally self-contained (pure JS, no jsdom dependency)
+ * so it works identically whether a given test file runs in "node" or
+ * opts into "jsdom" via a `// @vitest-environment jsdom` docblock.
  */
 
 class InMemoryStorage implements Storage {
@@ -38,15 +43,22 @@ class InMemoryStorage implements Storage {
   }
 }
 
-// Replace the Node.js v25 built-in stub with a real in-memory implementation.
-Object.defineProperty(globalThis, "localStorage", {
-  value: new InMemoryStorage(),
-  writable: true,
-  configurable: true,
-});
+// Only install the shim when the existing global is absent or non-functional
+// (no `setItem`) — e.g. jsdom's own Storage implementation, when a test file
+// opts into `// @vitest-environment jsdom`, is left untouched.
+function installStorageShimIfNeeded(key: "localStorage" | "sessionStorage") {
+  const existing = (globalThis as Record<string, unknown>)[key] as
+    | Storage
+    | undefined;
+  if (existing && typeof existing.setItem === "function") {
+    return;
+  }
+  Object.defineProperty(globalThis, key, {
+    value: new InMemoryStorage(),
+    writable: true,
+    configurable: true,
+  });
+}
 
-Object.defineProperty(globalThis, "sessionStorage", {
-  value: new InMemoryStorage(),
-  writable: true,
-  configurable: true,
-});
+installStorageShimIfNeeded("localStorage");
+installStorageShimIfNeeded("sessionStorage");

--- a/apps/desktop/src/utils/coreEngine.ts
+++ b/apps/desktop/src/utils/coreEngine.ts
@@ -1,0 +1,26 @@
+/**
+ * Lazy, memoized loader for the `@gitwand/core` conflict-resolution engine.
+ *
+ * `@gitwand/core`'s heavy exports (`resolve`, `resolveAsync`, and everything
+ * they pull in transitively: `classifier.ts`, `patterns/` ~1443 lines,
+ * `resolver/` ~1511 lines, `structural/` ~965 lines, `refactoring/` ~1184
+ * lines, `resolvers/` ~5406 lines) used to be imported statically from
+ * `useGitWand.ts` and `useMergePreview.ts`. Because both composables sit on
+ * an eager path (`App.vue` → `useGitWand`; `AppHeader.vue` →
+ * `BranchSelector.vue` → `useMergePreview`), that static import put the
+ * entire engine — ~244 KB raw / ~73 KB gzip — in the boot chunk, parsed and
+ * JIT-compiled on every app start even when the user never opens a conflict.
+ *
+ * `engine()` defers that cost to the first actual resolution call and
+ * memoizes the module so repeat calls don't re-trigger the dynamic import.
+ * Light, self-contained exports (`parseGitwandrc` from `config.ts`,
+ * `summarizeTiers` from `stats/tiers.ts`, `extractImportSources` from
+ * `resolvers/imports.ts` — all zero-dependency leaf modules) stay statically
+ * imported at their call sites; only the exports that transitively require
+ * the classifier + pattern registry go through this loader.
+ */
+let _engine: typeof import("@gitwand/core") | null = null;
+
+export async function engine(): Promise<typeof import("@gitwand/core")> {
+  return (_engine ??= await import("@gitwand/core"));
+}

--- a/apps/desktop/tests/parity/probe.mjs
+++ b/apps/desktop/tests/parity/probe.mjs
@@ -7,7 +7,8 @@
  * Par défaut on cherche le binaire à
  * `src-tauri/target/debug/examples/parity-probe`, relatif à ce fichier.
  * L'env var `PARITY_PROBE` permet de surcharger le chemin (utile pour pointer
- * sur `target/release/examples/...` ou un binaire pré-build en CI).
+ * sur `target/ci/examples/...` — le profil léger utilisé par `perf.yml` — ou
+ * un binaire pré-build en CI).
  *
  * Le probe lit son JSON d'entrée sur stdin et écrit le résultat sur stdout.
  * On parse stdout en JSON — s'il contient une clé `error`, c'est que la

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -52,6 +52,14 @@ export default defineConfig({
     target: ["es2021", "chrome100", "safari14"],
     minify: !process.env.TAURI_DEBUG ? "esbuild" : false,
     sourcemap: !!process.env.TAURI_DEBUG,
+    // Emits dist/.vite/manifest.json, which perf/bundle-check.mjs reads to
+    // find the real entry chunk for index.html. Do NOT remove: bundle-check
+    // hard-fails without it. Before this flag, the main chunk was guessed
+    // by a `/^index-[a-z0-9_-]+\.js$/i` name match + size sort, which would
+    // silently measure the wrong file if a vendor chunk ever outgrew it
+    // (see docs/superpowers/specs/2026-08-18-dev-loop-ci-build-times-plan.md
+    // §0.3 item 13).
+    manifest: true,
     rollupOptions: {
       // Mark Node.js built-ins as external so Rollup can analyse
       // packages/core's node adapter (structural/parsers/adapters/node.ts)
@@ -62,11 +70,17 @@ export default defineConfig({
     },
   },
   test: {
-    environment: "jsdom",
-    // Patch globalThis.localStorage to use the jsdom Storage implementation.
-    // Node.js v25 ships a built-in `localStorage` stub that has no methods
-    // (setItem/getItem/clear) unless --localstorage-file is supplied. Vitest's
-    // jsdom environment does not override it, so we do so here.
+    // Default to "node": jsdom setup/teardown costs ~1s/file (measured:
+    // 95.85s cumulative "environment" time across 94 files vs 19.85s of
+    // actual test execution — see docs/superpowers/specs/
+    // 2026-08-18-dev-loop-ci-build-times-plan.md §3.1). Only the handful of
+    // files that actually touch document/window/HTMLElement opt back into
+    // jsdom via a `// @vitest-environment jsdom` docblock at the top of the
+    // file.
+    environment: "node",
+    // src/test-setup.ts installs an in-memory Storage shim (see that file)
+    // so that files relying on localStorage/sessionStorage keep working
+    // under the "node" environment without needing jsdom.
     setupFiles: ["src/test-setup.ts"],
     include: ["src/**/*.test.ts"],
     globals: false,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "scripts": {
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
-    "lint": "pnpm -r run lint",
     "clean": "pnpm -r run clean",
     "postinstall": "node scripts/fix-spawn-helper.mjs"
   },

--- a/packages/core/src/__tests__/secrets/scanner.test.ts
+++ b/packages/core/src/__tests__/secrets/scanner.test.ts
@@ -159,6 +159,47 @@ describe("v3.5.0 — scanSecrets", () => {
     const findings = scanSecrets(files, baseConfig());
     expect(findings.length).toBe(500);
   });
+
+  // ─── Non-regression: isIgnored/globRegex precompilation caches (perf) ──
+
+  it("finds only the non-ignored secrets across ~500 added lines with 5 custom ignore globs (mirrors the Rust non-regression test)", () => {
+    const config = baseConfig({
+      entropyThreshold: 4.0,
+      ignore: [
+        "vendor/**",
+        "*.snapshot.ts",
+        "fixtures/**",
+        "/^IGNOREME_.*$/",
+        "build-artifacts/**",
+      ],
+    });
+
+    // src/app.ts (300 lines): every 10th line plants a real AWS key (30 hits expected), every
+    // 10th-plus-5 line plants a high-entropy token matched by the `/^IGNOREME_.*$/` ignore
+    // literal (must be suppressed), the rest are inert comments.
+    const appLines = Array.from({ length: 300 }, (_, i) => {
+      if (i % 10 === 0) return `const key${i} = "AKIAABCDEFGHIJKLMNOP";`;
+      if (i % 10 === 5) {
+        return `IGNOREME_aB3xQ9mK2pL7vN5wR8tY1cB4fH6jD0s${String(i).padStart(3, "0")}`;
+      }
+      return `// comment line ${i}`;
+    });
+
+    // vendor/generated.ts (200 lines): all plant real AWS keys, but the whole path is ignored
+    // wholesale by the custom `vendor/**` glob — none of these must surface.
+    const vendorLines = Array.from(
+      { length: 200 },
+      (_, i) => `const secretKey${i} = "AKIAABCDEFGHIJKLMNOP";`,
+    );
+
+    const files = [fileWith("src/app.ts", appLines), fileWith("vendor/generated.ts", vendorLines)];
+
+    const findings = scanSecrets(files, config);
+
+    expect(findings.length).toBe(30);
+    expect(findings.every((f) => f.file === "src/app.ts")).toBe(true);
+    expect(findings.every((f) => f.patternId === "aws_access_key_id")).toBe(true);
+  });
 });
 
 describe("v3.5.0 — default generated-file ignore globs (D5)", () => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -159,8 +159,24 @@ export function matchGlob(pattern: string, filePath: string): boolean {
   return globRegex(normalizedPattern).test(normalizedPath);
 }
 
-/** Convertit un pattern glob en RegExp. */
+/**
+ * Cache module-level pattern glob → `RegExp` compilée. `matchGlob` est appelé une fois par
+ * valeur candidate dans le scanner de secrets (une fois par match de pattern, une fois par
+ * token d'entropie) et une fois par override lookup dans `effectivePolicyForFile` — sans ce
+ * cache, `globRegex` recompilait le même petit ensemble de patterns (12+ globs par défaut du
+ * scanner de secrets, overrides `.gitwandrc`) à chaque appel. Miroir du cache `CompiledIgnore`
+ * côté Rust (`apps/desktop/src-tauri/src/commands/secrets.rs`). `Map` pur JS — zéro dépendance
+ * Node.js, compatible browser (AGENTS.md « packages/core = zéro Node.js »). Borné par le nombre
+ * de patterns distincts réellement rencontrés (built-ins + config utilisateur) : pas de fuite
+ * mémoire dans l'usage actuel.
+ */
+const GLOB_REGEX_CACHE = new Map<string, RegExp>();
+
+/** Convertit un pattern glob en RegExp (mémoïsé — voir `GLOB_REGEX_CACHE`). */
 function globRegex(pattern: string): RegExp {
+  const cached = GLOB_REGEX_CACHE.get(pattern);
+  if (cached) return cached;
+
   // Échapper les caractères spéciaux regex, puis replacer les globs
   const escaped = pattern
     .replace(/[.+^${}()|[\]\\]/g, "\\$&") // échapper les caractères regex
@@ -169,7 +185,9 @@ function globRegex(pattern: string): RegExp {
     .replace(/\?/g, "[^/]")                // ? → un char sauf /
     .replace(/§DSTAR§/g, ".*");            // ** → tout (y compris /)
 
-  return new RegExp(`^${escaped}$`);
+  const re = new RegExp(`^${escaped}$`);
+  GLOB_REGEX_CACHE.set(pattern, re);
+  return re;
 }
 
 // ─── Effective policy ─────────────────────────────────────

--- a/packages/core/src/secrets/scanner.ts
+++ b/packages/core/src/secrets/scanner.ts
@@ -149,21 +149,42 @@ export function redact(match: string): string {
 }
 
 /**
+ * Cache module-level des littéraux `/.../ ` de `secrets.ignore[]`, clé par le corps de la
+ * regex (contenu entre les délimiteurs `/`). Sans ce cache, `isIgnored` recompilait
+ * `new RegExp(body)` pour CHAQUE valeur candidate — une fois par match de pattern, une fois
+ * par token d'entropie — sur chaque ligne ajoutée de chaque fichier du diff staged. `null`
+ * signifie « regex malformée » (jamais fatal, jamais matchante — même tolérance que le
+ * comportement try/catch d'origine). Miroir de `CompiledIgnore.regexes` côté Rust
+ * (`apps/desktop/src-tauri/src/commands/secrets.rs`). Le cache glob (`matchGlob`) est traité à
+ * part, dans `config.ts` (`GLOB_REGEX_CACHE`), au bénéfice de tous ses appelants.
+ */
+const IGNORE_VALUE_REGEX_CACHE = new Map<string, RegExp | null>();
+
+function compiledIgnoreValueRegex(body: string): RegExp | null {
+  const cached = IGNORE_VALUE_REGEX_CACHE.get(body);
+  if (cached !== undefined) return cached;
+  let re: RegExp | null;
+  try {
+    re = new RegExp(body);
+  } catch {
+    re = null;
+  }
+  IGNORE_VALUE_REGEX_CACHE.set(body, re);
+  return re;
+}
+
+/**
  * `true` si la valeur matchée ou le fichier doit être ignoré, d'après `.gitwandrc` `secrets.ignore[]`.
  * Une entrée `/.../ ` est un littéral regex testé contre la valeur matchée ; toute autre entrée
  * est un glob de chemin testé contre `path` (via `matchGlob`, le même moteur que les overrides de
- * politique de merge).
+ * politique de merge — mémoïsé, voir `config.ts` `GLOB_REGEX_CACHE`).
  */
 export function isIgnored(path: string, value: string, ignore: string[]): boolean {
   for (const entry of ignore) {
     if (entry.length >= 2 && entry.startsWith("/") && entry.endsWith("/")) {
       const body = entry.slice(1, -1);
-      try {
-        if (new RegExp(body).test(value)) return true;
-      } catch {
-        // Regex d'ignore malformée — on l'ignore silencieusement.
-        continue;
-      }
+      const re = compiledIgnoreValueRegex(body);
+      if (re && re.test(value)) return true;
     } else if (matchGlob(entry, path)) {
       return true;
     }


### PR DESCRIPTION
## Summary

Chore/perf pass targeting CI build time, local dev-loop speed, and runtime bundle/scanner performance. No product-facing surface. Full analysis and phase-by-phase rationale in `docs/superpowers/specs/2026-08-18-dev-loop-ci-build-times-plan.md`.

- **CI**: `ci.yml`'s `desktop` job (3 fully-signed release bundles per push, artifacts nobody consumed) → `rust-check` (fmt/clippy -D warnings/check/test, on PR too) + a path-filtered `bundle-smoke` job. Rust cache in all 3 workflows. Parity tests now run in CI. ~230 billed minutes saved per push to main.
- **Rust build profiles**: `[profile.ci]` (thin LTO) + `[profile.dev]` (lighter debug info, opt-level=1 on deps only) — `cargo build` after an edit: 20.76s → ~6.5s. Measured `cargo llvm-lines`/`--timings` to settle whether a `gitwand-git` crate split (from the original roadmap item) is worth it: **no** — `#[tauri::command]` monomorphization is smaller than `tokio`'s own share, and the root crate is only 3-12% of total build time.
- **Vitest**: default `environment: "node"` instead of global `jsdom` — `environment` time ~95.85s → ~17.5s avg, 706 tests unchanged.
- **Runtime perf**: secrets-scanner ignore-regex precompilation (~24x Rust / ~2.5x TS); `@gitwand/core`'s resolution engine lazy-loaded out of the boot chunk (main bundle 1033.89 KB → 848.64 KB raw), manually QA'd end-to-end via `pnpm dev:web`.
- **Dependency hygiene**: deduped `reqwest` via the `tauri-plugin-aptabase` fork (now matches `tauri-plugin-updater`'s `rustls` choice instead of `native-tls`/`openssl-sys`), 663 → 648 packages, `libssl-dev` removed from CI. `tauri-plugin-aptabase` gated behind an optional `telemetry` feature with a `compile_error!` guard against a silently-telemetry-less release build.
- **Dead config cleanup**: removed root `lint` script, fixed `bundle-check.mjs`'s main-chunk detection (now manifest-based, not a name-regex+size-sort that worked by coincidence).
- **Docs**: `CLAUDE.md` files resynced with the real repo state; `.vscode/settings.json` rust-analyzer target-dir isolation; un-gitignored `ROADMAP.md`.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --locked --all-targets -- -D warnings`, `cargo check --locked --all-targets`, `cargo test --locked` (218 tests + 1 doctest)
- [x] `cargo check --release` fails without `--features telemetry` (compile_error guard), `cargo check --release --features telemetry` passes
- [x] `pnpm test` at root: 60+3+1+94 files / 1057+34+12+706 tests, all green
- [x] `pnpm test:parity`: 8 files / 18 tests green
- [x] `pnpm build` + `node perf/bundle-check.mjs`: all budgets OK (main 829 KB / 900 KB budget)
- [x] Manual QA via `pnpm dev:web`: real merge conflict created, resolved via "Accept both", merge commit content verified correct
- [ ] **Before the next tagged release**: build with `--features telemetry`, launch, confirm an Aptabase event actually arrives (the fork exists specifically to fix two tokio panics on this path — issue #135)

disabled