### PR TITLE
feat(forge): detect Cursor Origin remotes, fix Azure commit URLs

### DIFF
--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -5691,8 +5691,13 @@ async function handleRequest(req, res) {
         if (!remoteUrl) {
           return jsonResponse(req, res, { error: "No remote found" }, 404);
         }
+        // Mirrors `detect_provider()` in src-tauri/src/git/parse.rs — keep the
+        // branch order identical. Locked by tests/parity/git-remote-info.test.mjs.
+        // Cursor Origin matches on `origin.cursor.com` (its git host) and NOT on
+        // a bare `cursor.com`, which is the web UI.
         let provider = "unknown";
         if (remoteUrl.includes("github.com")) provider = "github";
+        else if (remoteUrl.includes("origin.cursor.com")) provider = "cursor";
         else if (remoteUrl.includes("gitlab")) provider = "gitlab";
         else if (remoteUrl.includes("bitbucket")) provider = "bitbucket";
         else if (remoteUrl.includes("dev.azure.com") || remoteUrl.includes("visualstudio.com")) provider = "azure";

--- a/apps/desktop/src-tauri/examples/parity_probe.rs
+++ b/apps/desktop/src-tauri/examples/parity_probe.rs
@@ -34,8 +34,7 @@
 // la fn elle-même est `pub`. Voir le bloc "Parity probe re-exports" dans lib.rs.
 use gitwand_desktop_lib::{
     git_branches_parity, git_commit_submodule_changes_parity, git_log_parity,
-    git_remote_info_parity,
-    git_stash_list_parity, git_status_libgit2_parity, git_status_parity,
+    git_remote_info_parity, git_stash_list_parity, git_status_libgit2_parity, git_status_parity,
     git_submodule_branches_parity, scan_secrets_parity,
 };
 use serde_json::{json, Value};

--- a/apps/desktop/src-tauri/examples/parity_probe.rs
+++ b/apps/desktop/src-tauri/examples/parity_probe.rs
@@ -34,6 +34,7 @@
 // la fn elle-même est `pub`. Voir le bloc "Parity probe re-exports" dans lib.rs.
 use gitwand_desktop_lib::{
     git_branches_parity, git_commit_submodule_changes_parity, git_log_parity,
+    git_remote_info_parity,
     git_stash_list_parity, git_status_libgit2_parity, git_status_parity,
     git_submodule_branches_parity, scan_secrets_parity,
 };
@@ -125,6 +126,13 @@ fn main() -> ExitCode {
                 Err(code) => return code,
             };
             to_json(git_branches_parity(cwd))
+        }
+        "git-remote-info" => {
+            let cwd = match must_str("cwd") {
+                Ok(v) => v,
+                Err(code) => return code,
+            };
+            to_json(git_remote_info_parity(cwd))
         }
         "git-stash-list" => {
             let cwd = match must_str("cwd") {

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -3696,17 +3696,7 @@ pub(crate) async fn git_remote_info(cwd: String) -> Result<RemoteInfo, String> {
         }
 
         if let Some((name, url)) = origin.or(first) {
-            let provider = if url.contains("github.com") {
-                "github"
-            } else if url.contains("gitlab.com") || url.contains("gitlab") {
-                "gitlab"
-            } else if url.contains("bitbucket.org") || url.contains("bitbucket") {
-                "bitbucket"
-            } else if url.contains("dev.azure.com") || url.contains("visualstudio.com") {
-                "azure"
-            } else {
-                "unknown"
-            };
+            let provider = detect_provider(&url);
 
             let (owner, repo) = parse_remote_owner_repo(&url);
 

--- a/apps/desktop/src-tauri/src/git/parse.rs
+++ b/apps/desktop/src-tauri/src/git/parse.rs
@@ -526,6 +526,32 @@ pub(crate) fn gh_pr_raw_to_pr(r: GhPrRaw) -> PullRequest {
     }
 }
 
+/// Maps a git remote URL onto a forge identifier.
+///
+/// Extracted from `git_remote_info` so it is unit-testable and so the
+/// duplicated chain in `dev-server.mjs` has a single canonical shape to
+/// mirror. Returns `"unknown"` when no forge matches — callers treat that as
+/// "no forge integration", never as a silent GitHub fallback.
+///
+/// Cursor Origin (v3.8) is matched on its dedicated git host
+/// `origin.cursor.com`, NOT on a bare `cursor.com`: the latter is the web UI
+/// and would misfire on any URL merely containing it.
+pub(crate) fn detect_provider(url: &str) -> &'static str {
+    if url.contains("github.com") {
+        "github"
+    } else if url.contains("origin.cursor.com") {
+        "cursor"
+    } else if url.contains("gitlab.com") || url.contains("gitlab") {
+        "gitlab"
+    } else if url.contains("bitbucket.org") || url.contains("bitbucket") {
+        "bitbucket"
+    } else if url.contains("dev.azure.com") || url.contains("visualstudio.com") {
+        "azure"
+    } else {
+        "unknown"
+    }
+}
+
 pub(crate) fn parse_remote_owner_repo(url: &str) -> (String, String) {
     if let Some(colon_pos) = url.find(':') {
         if url.starts_with("git@") {
@@ -1654,5 +1680,80 @@ mod repo_tree_tests {
         assert_eq!(src.children[0].name, "lib.rs");
         assert_eq!(src.children[0].path, "src/lib.rs");
         assert_eq!(src.children[1].name, "main.rs");
+    }
+}
+
+#[cfg(test)]
+mod remote_provider_tests {
+    use super::{detect_provider, parse_remote_owner_repo};
+
+    #[test]
+    fn detects_cursor_origin_https_remote() {
+        assert_eq!(
+            detect_provider("https://origin.cursor.com/acme/checkout.git"),
+            "cursor"
+        );
+    }
+
+    #[test]
+    fn detects_cursor_origin_ssh_remote() {
+        assert_eq!(
+            detect_provider("git@origin.cursor.com:acme/checkout.git"),
+            "cursor"
+        );
+    }
+
+    #[test]
+    fn does_not_claim_unrelated_cursor_hosts() {
+        // Only the Origin git host counts. A bare cursor.com URL (the web UI,
+        // docs, or a repo merely *named* cursor.com) must not be misread as a
+        // forge remote.
+        assert_eq!(detect_provider("https://cursor.com/docs/origin"), "unknown");
+    }
+
+    #[test]
+    fn detects_the_four_preexisting_forges() {
+        assert_eq!(
+            detect_provider("https://github.com/acme/checkout.git"),
+            "github"
+        );
+        assert_eq!(
+            detect_provider("git@gitlab.com:acme/checkout.git"),
+            "gitlab"
+        );
+        assert_eq!(
+            detect_provider("https://git.acme.io/gitlab/acme/checkout.git"),
+            "gitlab"
+        );
+        assert_eq!(
+            detect_provider("https://bitbucket.org/acme/checkout.git"),
+            "bitbucket"
+        );
+        assert_eq!(
+            detect_provider("https://dev.azure.com/acme/proj/_git/checkout"),
+            "azure"
+        );
+        assert_eq!(
+            detect_provider("https://acme.visualstudio.com/proj/_git/checkout"),
+            "azure"
+        );
+        assert_eq!(
+            detect_provider("https://git.sr.ht/~acme/checkout"),
+            "unknown"
+        );
+    }
+
+    #[test]
+    fn parses_owner_and_repo_from_a_cursor_origin_remote() {
+        // Origin uses a GitHub-shaped path, so the generic parser already
+        // handles it — locked in here because the detection above depends on it.
+        assert_eq!(
+            parse_remote_owner_repo("https://origin.cursor.com/acme/checkout.git"),
+            ("acme".to_string(), "checkout".to_string())
+        );
+        assert_eq!(
+            parse_remote_owner_repo("git@origin.cursor.com:acme/checkout.git"),
+            ("acme".to_string(), "checkout".to_string())
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -228,6 +228,10 @@ pub fn git_branches_parity(cwd: String) -> Result<Vec<types::GitBranch>, String>
     tauri::async_runtime::block_on(commands::ops::git_branches(cwd, None))
 }
 
+pub fn git_remote_info_parity(cwd: String) -> Result<types::RemoteInfo, String> {
+    tauri::async_runtime::block_on(commands::ops::git_remote_info(cwd))
+}
+
 pub fn git_stash_list_parity(cwd: String) -> Result<Vec<types::StashEntry>, String> {
     tauri::async_runtime::block_on(commands::ops::git_stash_list(cwd))
 }

--- a/apps/desktop/src/components/PrDetailView.vue
+++ b/apps/desktop/src/components/PrDetailView.vue
@@ -378,7 +378,7 @@ function submitRequestReviewers() {
         </svg>
       </div>
       <span class="pdv-empty-label">{{ t('pr.detail.emptySelect') }}</span>
-      <button class="pdv-empty-new-btn" @click="p.showCreateForm.value = true">
+      <button v-if="p.prSupported.value" class="pdv-empty-new-btn" @click="p.showCreateForm.value = true">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" aria-hidden="true">
           <path d="M8 3v10M3 8h10" />
         </svg>

--- a/apps/desktop/src/components/PrListSidebar.vue
+++ b/apps/desktop/src/components/PrListSidebar.vue
@@ -14,6 +14,7 @@ import { computed, inject, onMounted, onBeforeUnmount, ref, watch } from "vue";
 import { PR_PANEL_KEY, isMergeConflict, type PrPanelState } from "../composables/usePrPanel";
 import { OPEN_SETTINGS_KEY } from "../composables/branchPickerBridge";
 import { useI18n } from "../composables/useI18n";
+import { openExternalUrl } from "../utils/backend";
 
 const { t } = useI18n();
 
@@ -213,8 +214,10 @@ function setUserFilter(mode: 'all' | 'assigned' | 'reviews') {
       </div>
     </header>
 
-    <!-- New PR CTA -->
+    <!-- New PR CTA — hidden on a forge with no PR integration (Cursor Origin):
+         the create form would open and then never be submittable. -->
     <button
+      v-if="panel.prSupported.value"
       class="pls-new-btn"
       :class="{ 'pls-new-btn--active': panel.showCreateForm.value }"
       @click="panel.showCreateForm.value = true"
@@ -232,7 +235,16 @@ function setUserFilter(mode: 'all' | 'assigned' | 'reviews') {
         <span class="pls-msg-hint">{{ t('pr.error.cliNotInstalledHint', panel.forgeLabel.value) }}</span>
         <button class="pls-msg-action" @click="openSettings('accounts')">{{ t('pr.error.openSettings') }}</button>
       </template>
-      <button class="pls-msg-action" @click="panel.loadPrs">{{ t('pr.error.retry') }}</button>
+      <!-- Forge detected but without a PR integration (Cursor Origin): the web
+           UI is the only way through, and Retry would never succeed. -->
+      <template v-else-if="panel.errorAction.value === 'open-forge-web' && panel.forgeWebUrl.value">
+        <button class="pls-msg-action" @click="openExternalUrl(panel.forgeWebUrl.value)">{{ t('pr.error.openForgeWeb') }}</button>
+      </template>
+      <button
+        v-if="panel.errorAction.value !== 'open-forge-web'"
+        class="pls-msg-action"
+        @click="panel.loadPrs"
+      >{{ t('pr.error.retry') }}</button>
     </div>
     <div
       v-if="panel.success.value"

--- a/apps/desktop/src/components/SettingsAccountsTab.vue
+++ b/apps/desktop/src/components/SettingsAccountsTab.vue
@@ -183,7 +183,10 @@ async function onRemove(id: string) {
 // ─── Display ─────────────────────────────────────────────────────────────────
 
 const forgeOrder: ForgeName[] = ["github", "gitlab", "bitbucket", "azure"];
-const forgeLabel: Record<ForgeName, string> = { github: "GitHub", gitlab: "GitLab", bitbucket: "Bitbucket", azure: "Azure DevOps", unknown: "Unknown" };
+// `forgeOrder` above intentionally omits `cursor`: Cursor Origin has no account
+// to connect (detection only), so it must never appear in the accounts UI. The
+// label is still required to satisfy Record<ForgeName, string>.
+const forgeLabel: Record<ForgeName, string> = { github: "GitHub", gitlab: "GitLab", bitbucket: "Bitbucket", azure: "Azure DevOps", cursor: "Cursor Origin", unknown: "Unknown" };
 const knownForges = computed(() => forgeOrder.filter((f) => (accountsByForge.value[f]?.length ?? 0) > 0));
 const totalAccounts = computed(() => accounts.value.length);
 </script>

--- a/apps/desktop/src/composables/__tests__/useLaunchpad-cursor.test.ts
+++ b/apps/desktop/src/composables/__tests__/useLaunchpad-cursor.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Today (Launchpad) must stay silent about Cursor Origin repos.
+ *
+ * `isForgeConnected()` returns false for any forge without an in-app account,
+ * so an Origin repo would land in `needsConnection` and render the banner
+ * "Connect your Cursor Origin account to see its pull requests and issues".
+ * That is a lie: there is no Origin account to connect, and connecting one
+ * would change nothing while the provider has no PR integration.
+ *
+ * Origin repos must therefore be dropped before the connection check, without
+ * firing a forge call.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { _resetPinsForTesting } from "../useLaunchpadPins";
+
+const listPRs = vi.fn();
+const listIssues = vi.fn();
+vi.mock("../forge/useForge", () => ({
+  forgeForRepo: vi.fn(async (cwd: string) => ({
+    name: cwd.includes("cursor") ? "cursor" : "github",
+    listPRs,
+    listIssues,
+  })),
+  // Mirrors production: only GitHub is connected without an explicit account.
+  isForgeConnected: vi.fn((forge: string) => forge === "github"),
+}));
+
+import { useLaunchpadPrs } from "../useLaunchpadPrs";
+import { useLaunchpadIssues } from "../useLaunchpadIssues";
+
+const PR = {
+  number: 1, title: "PR", state: "open", author: "me", branch: "f", base: "main",
+  draft: false, createdAt: "2026-01-01T00:00:00Z", updatedAt: "2026-01-01T00:00:00Z",
+  url: "https://x/1", additions: 0, deletions: 0, labels: [], assignees: [],
+  reviewRequested: [], reviewDecision: "", mergeStateStatus: "", checksRollup: "",
+  commentCount: 0,
+};
+
+describe("Today — Cursor Origin repos", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetPinsForTesting();
+    listPRs.mockReset();
+    listIssues.mockReset();
+    listPRs.mockImplementation(async () => [PR]);
+    listIssues.mockImplementation(async () => []);
+  });
+
+  it("never asks the user to connect a Cursor Origin account", async () => {
+    const lp = useLaunchpadPrs();
+    await lp.refresh([
+      { path: "/repo-gh", name: "gh" },
+      { path: "/repo-cursor", name: "origin-repo" },
+    ] as any);
+
+    expect(lp.needsConnection.value).not.toContain("cursor");
+  });
+
+  it("does not fire a forge call for a Cursor Origin repo", async () => {
+    const lp = useLaunchpadPrs();
+    await lp.refresh([
+      { path: "/repo-gh", name: "gh" },
+      { path: "/repo-cursor", name: "origin-repo" },
+    ] as any);
+
+    // Only the GitHub repo is fetched.
+    expect(listPRs).toHaveBeenCalledTimes(1);
+    expect(lp.allPrs.value).toHaveLength(1);
+  });
+
+  it("applies the same rule to the issues inbox", async () => {
+    const li = useLaunchpadIssues();
+    await li.refresh([
+      { path: "/repo-gh", name: "gh" },
+      { path: "/repo-cursor", name: "origin-repo" },
+    ] as any);
+
+    expect(li.needsConnection.value).not.toContain("cursor");
+  });
+});

--- a/apps/desktop/src/composables/__tests__/usePrPanel-forge-unsupported.test.ts
+++ b/apps/desktop/src/composables/__tests__/usePrPanel-forge-unsupported.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Cursor Origin (Phase 0) — a forge GitWand detects but has no PR integration
+ * for must produce an honest, actionable banner.
+ *
+ * `loadPrs()` classifies failures through a chain of substring matches. A
+ * typed `ForgeNotImplementedError` fell through that whole chain to the final
+ * `else`, which dumps the raw message — users would read
+ * "[ForgeProvider:cursor] listPRs() not yet implemented". Worse, the chain's
+ * first branch (CLI-missing) is loose enough that a differently-worded error
+ * could be misreported as "install the GitHub CLI", which would be actively
+ * wrong: no CLI install fixes this.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+
+const { listPRs, gitRemoteInfo } = vi.hoisted(() => ({
+  listPRs: vi.fn(),
+  gitRemoteInfo: vi.fn(),
+}));
+
+vi.mock("../../utils/backend", () => ({
+  gitRemoteInfo: (...args: unknown[]) => gitRemoteInfo(...args),
+  gitFileCount: vi.fn(async () => 0),
+  ghForkInfo: vi.fn(async () => ({ isFork: false, origin: "", parent: "" })),
+  ghPrFreshnessSignal: vi.fn(),
+  detectClaudeCli: vi.fn(async () => ({
+    found: false, path: "", version: "", logged_in: false, status: "not_found",
+  })),
+}));
+
+const forgeStub = vi.hoisted(() => ({
+  current: { name: "github", listPRs: (..._a: unknown[]) => Promise.resolve([]) },
+}));
+vi.mock("../forge/useForge", () => ({
+  forgeFromRemoteInfo: vi.fn(() => forgeStub.current),
+  githubProvider: { name: "github", listPRs: vi.fn(async () => []) },
+}));
+
+import { usePrPanel } from "../usePrPanel";
+import { _resetPrCacheForTesting } from "../usePrCache";
+import { ForgeNotImplementedError } from "../forge/types";
+
+describe("usePrPanel — forge detected but PR-unsupported (Cursor Origin)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    _resetPrCacheForTesting();
+    listPRs.mockReset();
+    gitRemoteInfo.mockReset();
+  });
+
+  /** Wires a Cursor Origin repo whose provider throws the typed error. */
+  async function cursorPanel() {
+    gitRemoteInfo.mockResolvedValue({
+      name: "origin",
+      url: "https://origin.cursor.com/acme/checkout.git",
+      provider: "cursor",
+      owner: "acme",
+      repo: "checkout",
+    });
+    forgeStub.current = {
+      name: "cursor",
+      listPRs: vi.fn(async () => {
+        throw new ForgeNotImplementedError("cursor", "listPRs");
+      }),
+    };
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+    await panel.loadPrs();
+    return panel;
+  }
+
+  it("names the forge instead of leaking the internal error", async () => {
+    const panel = await cursorPanel();
+    expect(panel.error.value).toContain("Cursor Origin");
+    expect(panel.error.value).not.toContain("ForgeProvider");
+    expect(panel.error.value).not.toContain("listPRs");
+  });
+
+  it("never blames a missing CLI, which no install would fix", async () => {
+    const panel = await cursorPanel();
+    expect(panel.error.value).not.toContain("CLI");
+    expect(panel.error.value).not.toContain("cli.github.com");
+    expect(panel.errorAction.value).not.toBe("open-settings");
+  });
+
+  it("offers the web UI as the way out", async () => {
+    const panel = await cursorPanel();
+    expect(panel.errorAction.value).toBe("open-forge-web");
+  });
+
+  it("targets the repo's Origin web page, built from the remote's owner/repo", async () => {
+    const panel = await cursorPanel();
+    expect(panel.forgeWebUrl.value).toBe("https://cursor.com/codebase/acme/checkout");
+  });
+
+  it("offers no web URL on a forge that has a working PR integration", async () => {
+    gitRemoteInfo.mockResolvedValue({
+      name: "origin", url: "https://github.com/o/r", provider: "github", owner: "o", repo: "r",
+    });
+    forgeStub.current = { name: "github", listPRs: vi.fn(async () => []) };
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+
+    expect(panel.forgeWebUrl.value).toBeNull();
+  });
+
+  it("reports the forge as PR-unsupported so the UI can hide affordances", async () => {
+    // Driven off the provider, NOT off an error having already happened: the
+    // "New PR" button must be gone on first paint, before any failed listPRs.
+    gitRemoteInfo.mockResolvedValue({
+      name: "origin",
+      url: "https://origin.cursor.com/acme/checkout.git",
+      provider: "cursor",
+      owner: "acme",
+      repo: "checkout",
+    });
+    forgeStub.current = { name: "cursor", listPRs: vi.fn(async () => []) };
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+
+    expect(panel.prSupported.value).toBe(false);
+  });
+
+  it("reports a working forge as PR-supported", async () => {
+    gitRemoteInfo.mockResolvedValue({
+      name: "origin", url: "https://github.com/o/r", provider: "github", owner: "o", repo: "r",
+    });
+    forgeStub.current = { name: "github", listPRs: vi.fn(async () => []) };
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+
+    expect(panel.prSupported.value).toBe(true);
+  });
+
+  it("leaves an ordinary GitHub failure classified as before", async () => {
+    gitRemoteInfo.mockResolvedValue({
+      name: "origin", url: "https://github.com/o/r", provider: "github", owner: "o", repo: "r",
+    });
+    forgeStub.current = {
+      name: "github",
+      listPRs: vi.fn(async () => {
+        throw new Error("Failed to run gh pr list (is gh installed?): No such file or directory (os error 2)");
+      }),
+    };
+    const panel = usePrPanel(ref("/repo"));
+    await panel.loadRemote();
+    await panel.loadPrs();
+
+    expect(panel.error.value).toContain("GitHub CLI");
+    expect(panel.errorAction.value).toBe("open-settings");
+  });
+});

--- a/apps/desktop/src/composables/forge/CursorProvider.ts
+++ b/apps/desktop/src/composables/forge/CursorProvider.ts
@@ -1,0 +1,204 @@
+/**
+ * @file forge/CursorProvider.ts
+ *
+ * Cursor Origin — detection-only ForgeProvider (Phase 0).
+ *
+ * Origin is Cursor's git forge (`origin.cursor.com`, early beta). Its git
+ * transport is plain git, so clone / fetch / push / pull, merges and the whole
+ * conflict-resolution engine already work on an Origin repo with zero code —
+ * they never go through a ForgeProvider.
+ *
+ * What does NOT work yet is the PR integration. Origin's REST API documents
+ * only the "Origin App" auth model (Ed25519 keypair → app JWT → 15-minute
+ * installation token), which is a poor fit for a desktop client and cannot
+ * even read repos mirrored inbound from GitHub. The pragmatic path — shelling
+ * out to the `origin` CLI, the way `gh.rs` does for GitHub — is deferred until
+ * Origin leaves beta and its API stops moving.
+ *
+ * **Why this file exists at all:** without it, `getProviderByUrl()` falls
+ * through to `githubProvider`, so an Origin repo fired `gh` CLI calls at
+ * `origin.cursor.com` and surfaced a bewildering GitHub auth error. Every
+ * method here throws a *typed* `ForgeNotImplementedError` instead, which
+ * `usePrPanel` turns into an honest "not supported yet" banner with a link to
+ * the repo on the web.
+ *
+ * Optional contract methods (`listIssues` — Origin has no issue tracker at all
+ * —, `listBranches`, `dismissReview`, `requestReviewers`) are deliberately
+ * *omitted* rather than stubbed, which is the contract's signal for "hide the
+ * affordance".
+ */
+
+import {
+  ForgeNotImplementedError,
+  type ForgeProvider,
+  type ForgeName,
+  type ListPRsOptions,
+  type CreatePRInput,
+  type SubmitReviewOptions,
+  type PullRequest,
+  type PullRequestDetail,
+  type CICheck,
+  type CIAnnotation,
+  type PrReviewComment,
+  type CreatePrCommentParams,
+  type PrReview,
+  type PrConflictPreview,
+  type PrHotspot,
+  type PrFileHistory,
+  type ReviewerCandidate,
+  type Account,
+} from "./types";
+export { CURSOR_WEB_BASE } from "./types";
+
+/**
+ * Origin's git host. Deliberately NOT a bare `cursor.com`: that is the web UI
+ * (`cursor.com/codebase/{owner}/{repo}`) and the docs site, so matching it
+ * would misread unrelated URLs as forge remotes.
+ *
+ * Kept in sync with `detect_provider()` in
+ * `src-tauri/src/git/parse.rs` and its mirror in `dev-server.mjs`.
+ */
+const ORIGIN_GIT_HOST = "origin.cursor.com";
+
+export class CursorProvider implements ForgeProvider {
+  readonly name: ForgeName = "cursor";
+
+  detectFromRemote(remoteUrl: string): boolean {
+    return remoteUrl.includes(ORIGIN_GIT_HOST);
+  }
+
+  /**
+   * No-op. Called unconditionally by the account-aware resolution path, so
+   * throwing here would break repo switching rather than just the PR panel.
+   */
+  setAccount(_account: Account | null): void {
+    // Intentionally empty — there is no Origin credential to bind yet.
+  }
+
+  /** Single throw site so every method reports the same typed error. */
+  private unsupported(method: string): never {
+    throw new ForgeNotImplementedError("cursor", method);
+  }
+
+  // ── Discovery ─────────────────────────────────────────────────────────────
+
+  getCurrentUser(_cwd: string): Promise<string> {
+    this.unsupported("getCurrentUser");
+  }
+
+  listReviewerCandidates(_cwd: string): Promise<ReviewerCandidate[]> {
+    this.unsupported("listReviewerCandidates");
+  }
+
+  // ── PR listing ────────────────────────────────────────────────────────────
+
+  listPRs(_cwd: string, _opts?: ListPRsOptions): Promise<PullRequest[]> {
+    this.unsupported("listPRs");
+  }
+
+  getPRCount(_cwd: string, _state?: string): Promise<number> {
+    this.unsupported("getPRCount");
+  }
+
+  getPRFiles(_cwd: string, _prNumber: number): Promise<string[]> {
+    this.unsupported("getPRFiles");
+  }
+
+  // ── PR detail ─────────────────────────────────────────────────────────────
+
+  getPR(_cwd: string, _number: number): Promise<PullRequestDetail> {
+    this.unsupported("getPR");
+  }
+
+  getPRDiff(_cwd: string, _number: number): Promise<string> {
+    this.unsupported("getPRDiff");
+  }
+
+  getCIChecks(_cwd: string, _number: number): Promise<CICheck[]> {
+    this.unsupported("getCIChecks");
+  }
+
+  getCheckAnnotations(_cwd: string, _number: number): Promise<CIAnnotation[]> {
+    this.unsupported("getCheckAnnotations");
+  }
+
+  // ── PR actions ────────────────────────────────────────────────────────────
+
+  createPR(_cwd: string, _input: CreatePRInput): Promise<PullRequest> {
+    this.unsupported("createPR");
+  }
+
+  mergePR(_cwd: string, _number: number, _method?: "merge" | "squash" | "rebase"): Promise<void> {
+    this.unsupported("mergePR");
+  }
+
+  checkoutPR(_cwd: string, _number: number): Promise<void> {
+    this.unsupported("checkoutPR");
+  }
+
+  convertDraftToReady(_cwd: string, _number: number): Promise<void> {
+    this.unsupported("convertDraftToReady");
+  }
+
+  // ── Comments ──────────────────────────────────────────────────────────────
+
+  listComments(_cwd: string, _prNumber: number): Promise<PrReviewComment[]> {
+    this.unsupported("listComments");
+  }
+
+  createComment(
+    _cwd: string,
+    _prNumber: number,
+    _params: CreatePrCommentParams
+  ): Promise<PrReviewComment> {
+    this.unsupported("createComment");
+  }
+
+  updateComment(
+    _cwd: string,
+    _commentId: number,
+    _body: string,
+    _prNumber?: number
+  ): Promise<void> {
+    this.unsupported("updateComment");
+  }
+
+  deleteComment(_cwd: string, _commentId: number, _prNumber?: number): Promise<void> {
+    this.unsupported("deleteComment");
+  }
+
+  // ── Reviews ───────────────────────────────────────────────────────────────
+
+  listReviews(_cwd: string, _prNumber: number): Promise<PrReview[]> {
+    this.unsupported("listReviews");
+  }
+
+  submitReview(
+    _cwd: string,
+    _prNumber: number,
+    _opts: SubmitReviewOptions
+  ): Promise<PrReview> {
+    this.unsupported("submitReview");
+  }
+
+  // ── Intelligence ──────────────────────────────────────────────────────────
+  //
+  // getConflictPreview/getHotspots are forge-agnostic (local git) and would
+  // technically run, but they are only ever reached from a PR that this
+  // provider cannot list. Throwing keeps the "no PR integration" story
+  // consistent rather than half-answering.
+
+  getConflictPreview(_cwd: string, _prNumber: number): Promise<PrConflictPreview> {
+    this.unsupported("getConflictPreview");
+  }
+
+  getHotspots(_cwd: string, _paths: string[]): Promise<PrHotspot[]> {
+    this.unsupported("getHotspots");
+  }
+
+  getFileHistory(_cwd: string, _paths: string[]): Promise<Record<string, PrFileHistory>> {
+    this.unsupported("getFileHistory");
+  }
+}
+
+export const cursorProvider = new CursorProvider();

--- a/apps/desktop/src/composables/forge/__tests__/CursorProvider.test.ts
+++ b/apps/desktop/src/composables/forge/__tests__/CursorProvider.test.ts
@@ -1,0 +1,95 @@
+/**
+ * CursorProvider — Cursor Origin detection-only provider (Phase 0).
+ *
+ * Origin is a real forge (git standard clone/push/pull works untouched), but
+ * GitWand has no PR integration for it yet. The point of this provider is to
+ * stop `getProviderByUrl()` from silently falling back to `githubProvider`,
+ * which made an Origin repo fire `gh` CLI calls at `origin.cursor.com` and
+ * surface an incomprehensible GitHub error.
+ *
+ * Every contract method must therefore fail with a *typed*
+ * `ForgeNotImplementedError` so the PR panel can render an honest
+ * "not supported yet" state instead of a raw error.
+ */
+import { describe, it, expect } from "vitest";
+import { CursorProvider } from "../CursorProvider";
+import { ForgeNotImplementedError, type ForgeProvider } from "../types";
+
+describe("CursorProvider — remote detection", () => {
+  const provider = new CursorProvider();
+
+  it("is named `cursor`", () => {
+    expect(provider.name).toBe("cursor");
+  });
+
+  it("claims Origin's git host over HTTPS and SSH", () => {
+    expect(provider.detectFromRemote("https://origin.cursor.com/acme/checkout.git")).toBe(true);
+    expect(provider.detectFromRemote("git@origin.cursor.com:acme/checkout.git")).toBe(true);
+  });
+
+  it("does not claim the Cursor web UI or unrelated forges", () => {
+    // `cursor.com/codebase/...` is the web UI, never a git remote.
+    expect(provider.detectFromRemote("https://cursor.com/codebase/acme/checkout")).toBe(false);
+    expect(provider.detectFromRemote("https://github.com/acme/checkout.git")).toBe(false);
+    expect(provider.detectFromRemote("git@gitlab.com:acme/checkout.git")).toBe(false);
+  });
+});
+
+describe("CursorProvider — every contract method is an honest unsupported error", () => {
+  const provider = new CursorProvider();
+
+  // One entry per *required* ForgeProvider method, with a minimal valid call.
+  const calls: Array<[string, () => unknown]> = [
+    ["getCurrentUser", () => provider.getCurrentUser("/repo")],
+    ["listReviewerCandidates", () => provider.listReviewerCandidates("/repo")],
+    ["listPRs", () => provider.listPRs("/repo", { state: "open" })],
+    ["getPRCount", () => provider.getPRCount("/repo", "open")],
+    ["getPRFiles", () => provider.getPRFiles("/repo", 1)],
+    ["getPR", () => provider.getPR("/repo", 1)],
+    ["getPRDiff", () => provider.getPRDiff("/repo", 1)],
+    ["getCIChecks", () => provider.getCIChecks("/repo", 1)],
+    ["getCheckAnnotations", () => provider.getCheckAnnotations("/repo", 1)],
+    ["createPR", () => provider.createPR("/repo", { title: "t", body: "b" })],
+    ["mergePR", () => provider.mergePR("/repo", 1)],
+    ["checkoutPR", () => provider.checkoutPR("/repo", 1)],
+    ["convertDraftToReady", () => provider.convertDraftToReady("/repo", 1)],
+    ["listComments", () => provider.listComments("/repo", 1)],
+    ["createComment", () => provider.createComment("/repo", 1, { body: "x" } as never)],
+    ["updateComment", () => provider.updateComment("/repo", 1, "x")],
+    ["deleteComment", () => provider.deleteComment("/repo", 1)],
+    ["listReviews", () => provider.listReviews("/repo", 1)],
+    ["submitReview", () => provider.submitReview("/repo", 1, { event: "COMMENT" })],
+    ["getConflictPreview", () => provider.getConflictPreview("/repo", 1)],
+    ["getHotspots", () => provider.getHotspots("/repo", ["a.ts"])],
+    ["getFileHistory", () => provider.getFileHistory("/repo", ["a.ts"])],
+  ];
+
+  for (const [method, call] of calls) {
+    it(`${method}() throws a typed ForgeNotImplementedError`, () => {
+      expect(call).toThrow(ForgeNotImplementedError);
+      try {
+        call();
+      } catch (err: any) {
+        expect(err.name).toBe("ForgeNotImplementedError");
+        expect(err.message).toContain("cursor");
+        expect(err.message).toContain(method);
+      }
+    });
+  }
+
+  it("setAccount is a no-op rather than a throw", () => {
+    // Called unconditionally by the account-aware resolution path in useForge;
+    // throwing here would break repo switching, not just the PR panel.
+    expect(() => provider.setAccount(null)).not.toThrow();
+  });
+
+  it("omits the optional methods entirely so callers hide those affordances", () => {
+    // The contract's "unsupported hides the action" path checks for absence, so
+    // probe through the interface type rather than the concrete class.
+    const contract: ForgeProvider = provider;
+    expect(contract.listIssues).toBeUndefined();
+    expect(contract.listBranches).toBeUndefined();
+    expect(contract.dismissReview).toBeUndefined();
+    expect(contract.requestReviewers).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/composables/forge/__tests__/useForge-cursor.test.ts
+++ b/apps/desktop/src/composables/forge/__tests__/useForge-cursor.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Forge registry routing for Cursor Origin.
+ *
+ * `getProviderByName()` ends in `?? githubProvider`, so an unregistered forge
+ * name is not an error — it silently becomes GitHub. That is exactly the bug
+ * Phase 0 fixes: an Origin repo used to route to `githubProvider` and fire
+ * `gh` CLI calls at `origin.cursor.com`.
+ *
+ * The non-GitHub providers are pre-warmed via `import().then()` at module init,
+ * hence the awaited tick before asserting.
+ */
+import { describe, it, expect, beforeAll, vi } from "vitest";
+
+vi.mock("../../../utils/backend", () => ({
+  gitRemoteInfo: vi.fn(),
+}));
+
+import { getProviderByName, getProviderByUrl, forgeFromRemoteInfo } from "../useForge";
+
+describe("forge registry — Cursor Origin routing", () => {
+  beforeAll(async () => {
+    // The pre-warm is `import().then()` at module init, so the registry is
+    // empty for the first few microtasks. Wait on a known-registered forge
+    // rather than a bare timeout, which raced.
+    await vi.waitFor(() => {
+      expect(getProviderByName("gitlab").name).toBe("gitlab");
+      expect(getProviderByName("azure").name).toBe("azure");
+    });
+  });
+
+  it("routes the `cursor` provider name to CursorProvider, not GitHub", () => {
+    expect(getProviderByName("cursor").name).toBe("cursor");
+  });
+
+  it("routes an origin.cursor.com remote URL to CursorProvider", () => {
+    expect(getProviderByUrl("https://origin.cursor.com/acme/checkout.git").name).toBe("cursor");
+  });
+
+  it("routes a RemoteInfo carrying provider=cursor to CursorProvider", () => {
+    expect(
+      forgeFromRemoteInfo({
+        provider: "cursor",
+        url: "https://origin.cursor.com/acme/checkout.git",
+      }).name
+    ).toBe("cursor");
+  });
+
+  it("still routes the pre-existing forges correctly", () => {
+    expect(getProviderByName("github").name).toBe("github");
+    expect(getProviderByName("gitlab").name).toBe("gitlab");
+    expect(getProviderByName("bitbucket").name).toBe("bitbucket");
+    expect(getProviderByName("azure").name).toBe("azure");
+  });
+});

--- a/apps/desktop/src/composables/forge/index.ts
+++ b/apps/desktop/src/composables/forge/index.ts
@@ -6,3 +6,4 @@ export * from "./useForge";
 export { GitHubProvider, githubProvider } from "./GitHubProvider";
 export { GitLabProvider, gitlabProvider } from "./GitLabProvider";
 export { BitbucketProvider, bitbucketProvider } from "./BitbucketProvider";
+export { CursorProvider, cursorProvider } from "./CursorProvider";

--- a/apps/desktop/src/composables/forge/types.ts
+++ b/apps/desktop/src/composables/forge/types.ts
@@ -89,7 +89,39 @@ export interface SubmitReviewOptions {
 
 // ─── Forge name discriminant ────────────────────────────────────────────────
 
-export type ForgeName = "github" | "gitlab" | "bitbucket" | "azure" | "unknown";
+export type ForgeName = "github" | "gitlab" | "bitbucket" | "azure" | "cursor" | "unknown";
+
+// ─── Forge web bases ────────────────────────────────────────────────────────
+
+/**
+ * Cursor Origin web UI base. Note the asymmetry with its git host
+ * (`origin.cursor.com`): repos are browsed at `cursor.com/codebase/{owner}/{repo}`.
+ * Lives here rather than in CursorProvider so `usePrPanel` can link out without
+ * pulling the provider into the main bundle.
+ */
+export const CURSOR_WEB_BASE = "https://cursor.com/codebase";
+
+// ─── Forge capabilities ─────────────────────────────────────────────────────
+
+/**
+ * Forges GitWand detects but has no PR/issue integration for.
+ *
+ * A forge lands here when its remote is recognised (so git operations, merges
+ * and conflict resolution all work) but no ForgeProvider can talk to its API
+ * yet. Callers use `forgeSupportsPRs()` to hide PR affordances up front rather
+ * than letting the user reach a dead end.
+ */
+const PR_UNSUPPORTED_FORGES: ReadonlySet<string> = new Set<ForgeName>(["cursor"]);
+
+/**
+ * Whether PR/issue affordances should be offered for `forge`.
+ *
+ * Deliberately independent of whether a call has already failed: the "New PR"
+ * button must be absent on first paint, not only after a failed `listPRs`.
+ */
+export function forgeSupportsPRs(forge: ForgeName | string): boolean {
+  return !PR_UNSUPPORTED_FORGES.has(forge);
+}
 
 // ─── ForgeProvider interface ─────────────────────────────────────────────────
 

--- a/apps/desktop/src/composables/forge/useForge.ts
+++ b/apps/desktop/src/composables/forge/useForge.ts
@@ -43,6 +43,10 @@ _cache.set("github", githubProvider);
 import("./GitLabProvider").then((m) => _cache.set("gitlab", m.gitlabProvider));
 import("./BitbucketProvider").then((m) => _cache.set("bitbucket", m.bitbucketProvider));
 import("./AzureProvider").then((m) => _cache.set("azure", m.azureProvider));
+// Cursor Origin: detection-only (no PR integration yet). Registering it is what
+// keeps `getProviderByName("cursor")` from falling through to githubProvider and
+// firing `gh` CLI calls at origin.cursor.com.
+import("./CursorProvider").then((m) => _cache.set("cursor", m.cursorProvider));
 
 /**
  * Retourne le ForgeProvider correspondant à un nom de forge déjà connu.

--- a/apps/desktop/src/composables/useCommitActions.ts
+++ b/apps/desktop/src/composables/useCommitActions.ts
@@ -24,6 +24,7 @@ import {
   gitDeleteRemoteTag,
   openExternalUrl,
 } from "../utils/backend";
+import { forgeCommitUrl } from "../utils/forgeUrls";
 import { useI18n } from "./useI18n";
 import { useTagSuggestion } from "./useTagSuggestion";
 import { useAIProvider } from "./useAIProvider";
@@ -360,16 +361,14 @@ export function useCommitActions(deps: Deps) {
     if (!cwd) return;
     try {
       const info = await gitRemoteInfo(cwd);
-      if (!info.owner || !info.repo) {
+      // No owner/repo check here: Azure DevOps carries its coordinates in the
+      // remote URL, not in owner/repo, so `forgeCommitUrl` is the single judge
+      // of whether a correct URL can be built.
+      const base = forgeCommitUrl(info, entry.hashFull);
+      if (!base) {
         repoError.value = t("commitCtx.noRemote");
         return;
       }
-      const base =
-        info.provider === "gitlab"
-          ? `https://gitlab.com/${info.owner}/${info.repo}/-/commit/${entry.hashFull}`
-          : info.provider === "bitbucket"
-            ? `https://bitbucket.org/${info.owner}/${info.repo}/commits/${entry.hashFull}`
-            : `https://github.com/${info.owner}/${info.repo}/commit/${entry.hashFull}`;
       void openExternalUrl(base);
     } catch {
       repoError.value = t("commitCtx.noRemote");

--- a/apps/desktop/src/composables/useLaunchpadIssues.ts
+++ b/apps/desktop/src/composables/useLaunchpadIssues.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from "vue";
 import type { WorkspaceRepoIssues, WorkspaceRepo, Issue } from "../utils/backend";
 import { forgeForRepo, isForgeConnected } from "./forge/useForge";
+import { forgeSupportsPRs } from "./forge/types";
 import type { ForgeName } from "./forge/types";
 import { useLaunchpadPins } from "./useLaunchpadPins";
 
@@ -114,6 +115,10 @@ export function useLaunchpadIssues() {
         const out = await Promise.all(
           resolved.map(async ({ repo, provider }): Promise<WorkspaceRepoIssuesWithForge | null> => {
             const forge = provider.name as ForgeName;
+            // Dropped BEFORE the connection check: `isForgeConnected` would file it
+            // under `needsConnection` and render a "connect your account" banner for a
+            // forge that has no account to connect.
+            if (!forgeSupportsPRs(forge)) return null;
             if (!isForgeConnected(forge)) {
               unconnected.add(forge);
               return null;

--- a/apps/desktop/src/composables/useLaunchpadPrs.ts
+++ b/apps/desktop/src/composables/useLaunchpadPrs.ts
@@ -1,6 +1,7 @@
 import { ref, computed } from "vue";
 import type { WorkspaceRepoPrs, WorkspaceRepo, PullRequest } from "../utils/backend";
 import { forgeForRepo, isForgeConnected } from "./forge/useForge";
+import { forgeSupportsPRs } from "./forge/types";
 import type { ForgeName } from "./forge/types";
 import { useLaunchpadPins } from "./useLaunchpadPins";
 
@@ -61,6 +62,10 @@ export function useLaunchpadPrs() {
         workspaceRepos.map(async (repo): Promise<WorkspaceRepoPrsWithForge | null> => {
           const provider = await forgeForRepo(repo.path);
           const forge = provider.name as ForgeName;
+          // Dropped BEFORE the connection check: `isForgeConnected` would file it
+          // under `needsConnection` and render a "connect your account" banner for a
+          // forge that has no account to connect.
+          if (!forgeSupportsPRs(forge)) return null;
           if (!isForgeConnected(forge)) {
             unconnected.add(forge);
             return null;

--- a/apps/desktop/src/composables/usePrPanel.ts
+++ b/apps/desktop/src/composables/usePrPanel.ts
@@ -29,7 +29,7 @@ import {
   type PrFreshnessSignal,
 } from "../utils/backend";
 import { forgeFromRemoteInfo, githubProvider } from "./forge/useForge";
-import { ForgeNotImplementedError } from "./forge/types";
+import { ForgeNotImplementedError, CURSOR_WEB_BASE, forgeSupportsPRs } from "./forge/types";
 import { usePrCache, listKey, detailKey } from "./usePrCache";
 import { whenIdle } from "../utils/idleSchedule";
 import { getPersistedDiffMode, type DiffMode } from "../utils/diffMode";
@@ -54,6 +54,7 @@ const FORGE_LABELS: Record<string, string> = {
   gitlab: "GitLab",
   bitbucket: "Bitbucket",
   azure: "Azure DevOps",
+  cursor: "Cursor Origin",
 };
 
 /**
@@ -126,6 +127,24 @@ export function usePrPanel(cwd: Ref<string>, opts: PrPanelOptions = {}) {
   /** Human-facing name of the active forge — used for "Open on …" labels. */
   const forgeLabel = computed(() => FORGE_LABELS[forge.value.name] ?? "Web");
 
+  /**
+   * Whether this repo's forge has a PR integration at all. Gates the "New PR"
+   * affordances, which would otherwise open a form that can never be submitted.
+   */
+  const prSupported = computed(() => forgeSupportsPRs(forge.value.name));
+
+  /**
+   * Repo URL on the forge's web UI, for the `open-forge-web` error action.
+   * `null` for forges with a working PR integration, which never need the
+   * escape hatch.
+   */
+  const forgeWebUrl = computed<string | null>(() => {
+    const info = remote.value;
+    if (!info?.owner || !info?.repo) return null;
+    if (info.provider === "cursor") return `${CURSOR_WEB_BASE}/${info.owner}/${info.repo}`;
+    return null;
+  });
+
   const prs = ref<PullRequest[]>([]);
   // ─── Dock badge count (cheap, independent of the badge-path list) ──────
   // Reflects the true total open-PR count via a single cheap forge call,
@@ -141,7 +160,7 @@ export function usePrPanel(cwd: Ref<string>, opts: PrPanelOptions = {}) {
   // Optional follow-up action surfaced alongside an error. `"open-settings"`
   // is set when the failure is actionable from Settings (e.g. gh CLI missing
   // but the user can add a GitHub account instead). Reset on every reload.
-  const errorAction = ref<"open-settings" | null>(null);
+  const errorAction = ref<"open-settings" | "open-forge-web" | null>(null);
   const success = ref<string | null>(null);
   const filterState = ref<"open" | "closed" | "all">("open");
   /** 'all' = no user filter | 'assigned' = assignees | 'reviews' = review_requested */
@@ -549,7 +568,14 @@ export function usePrPanel(cwd: Ref<string>, opts: PrPanelOptions = {}) {
         msg.includes("ENOENT") ||
         // Our own error prefix
         (msg.includes("gh") && msg.includes("installed"));
-      if (isGhMissing) {
+      if (err instanceof ForgeNotImplementedError) {
+        // A forge GitWand detects but has no PR integration for (Cursor Origin).
+        // MUST be classified before the substring chain below: `isGhMissing` is
+        // loose enough to claim a reworded message, and telling the user to
+        // install a CLI would be actively wrong since no install fixes this.
+        error.value = t("pr.error.forgeUnsupported", forgeLabel.value);
+        errorAction.value = "open-forge-web";
+      } else if (isGhMissing) {
         const info = CLI_MISSING_INFO[forge.value.name] ?? CLI_MISSING_INFO.github;
         error.value = t("pr.error.cliNotInstalled", info.cli, info.url);
         errorAction.value = "open-settings";
@@ -1460,7 +1486,7 @@ export function usePrPanel(cwd: Ref<string>, opts: PrPanelOptions = {}) {
   return {
     // State
     cwd,
-    remote, prs, loading, refreshing, error, errorAction, success, filterState, filterMode,
+    remote, prs, loading, refreshing, error, errorAction, forgeWebUrl, prSupported, success, filterState, filterMode,
     currentUser, currentUserLoading, currentUserError,
     showCreateForm, newPrTitle, newPrBody, newPrBase, newPrDraft, newPrReviewers, isCreating,
     forkInfo, newPrBaseRepo,

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -1062,6 +1062,8 @@ const en = {
       unknown: "Failed to load pull requests.",
       retry: "Retry",
       timedOut: "{0} took too long to respond — check your network or VPN, then retry.",
+      forgeUnsupported: "{0} pull requests aren't supported yet. Cloning, pushing, pulling and merging all work normally.",
+      openForgeWeb: "Open on the web",
     },
   },
 
@@ -1786,6 +1788,7 @@ const en = {
     gitlab: "GitLab",
     bitbucket: "Bitbucket",
     azure: "Azure DevOps",
+    cursor: "Cursor Origin",
     action: "Open Settings",
   },
 
@@ -2346,7 +2349,7 @@ const en = {
       historyTitle: "History",
       history: "Switch to the History tab in the sidebar to browse commits. Click a commit to inspect its diff. Use the Graph tab for a visual DAG.",
       remoteTitle: "Remotes",
-      remote: "GitWand supports GitHub, GitLab, and Bitbucket. The Sync button auto-detects push/pull state. Use \u201cOpen on Forge\u201d to jump to the web UI.",
+      remote: "GitWand supports GitHub, GitLab, Bitbucket and Azure DevOps for pull requests, and detects Cursor Origin remotes (git operations only, no PR integration yet). The Sync button auto-detects push/pull state. Use \u201cOpen on Forge\u201d to jump to the web UI.",
     },
     aiFeatures: {
       title: "AI features",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -1046,6 +1046,8 @@ const es: Locale = {
       unknown: "Error al cargar los pull requests.",
       retry: "Reintentar",
       timedOut: "{0} tardó demasiado en responder — revisa tu red o VPN y vuelve a intentarlo.",
+      forgeUnsupported: "Los pull requests de {0} aún no son compatibles. Clonar, hacer push, pull y merge funcionan con normalidad.",
+      openForgeWeb: "Abrir en la web",
     },
   },
 
@@ -1753,6 +1755,7 @@ const es: Locale = {
     gitlab: "GitLab",
     bitbucket: "Bitbucket",
     azure: "Azure DevOps",
+    cursor: "Cursor Origin",
     action: "Abrir Ajustes",
   },
 
@@ -2305,7 +2308,7 @@ const es: Locale = {
       historyTitle: "Historial",
       history: "Cambia a la pestaña Historial para navegar por los commits.",
       remoteTitle: "Remotos",
-      remote: "GitWand soporta GitHub, GitLab y Bitbucket.",
+      remote: "GitWand soporta GitHub, GitLab, Bitbucket y Azure DevOps para pull requests, y detecta los remotes de Cursor Origin (solo operaciones git, aún sin integración de PR).",
     },
     aiFeatures: {
       title: "Funciones de IA",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -1055,6 +1055,8 @@ const fr: Locale = {
       unknown: "Impossible de charger les pull requests.",
       retry: "Réessayer",
       timedOut: "{0} a mis trop de temps à répondre — vérifiez votre connexion ou VPN, puis réessayez.",
+      forgeUnsupported: "Les pull requests {0} ne sont pas encore prises en charge. Le clone, le push, le pull et les merges fonctionnent normalement.",
+      openForgeWeb: "Ouvrir sur le web",
     },
   },
 
@@ -1762,6 +1764,7 @@ const fr: Locale = {
     gitlab: "GitLab",
     bitbucket: "Bitbucket",
     azure: "Azure DevOps",
+    cursor: "Cursor Origin",
     action: "Ouvrir les Réglages",
   },
 
@@ -2315,7 +2318,7 @@ const fr: Locale = {
       historyTitle: "Historique",
       history: "Passez sur l'onglet Historique dans la sidebar pour parcourir les commits. Cliquez sur un commit pour inspecter son diff. Utilisez l'onglet Graphe pour une visualisation DAG.",
       remoteTitle: "Remotes",
-      remote: "GitWand supporte GitHub, GitLab et Bitbucket. Le bouton Sync détecte automatiquement l'état push/pull. Utilisez « Ouvrir sur la forge » pour accéder à l'interface web.",
+      remote: "GitWand supporte GitHub, GitLab, Bitbucket et Azure DevOps pour les pull requests, et détecte les remotes Cursor Origin (opérations git seulement, pas encore d'intégration PR). Le bouton Sync détecte automatiquement l'état push/pull. Utilisez « Ouvrir sur la forge » pour accéder à l'interface web.",
     },
     aiFeatures: {
       title: "Fonctionnalités AI",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -1047,6 +1047,8 @@ const ptBR: Locale = {
       unknown: "Falha ao carregar os pull requests.",
       retry: "Tentar novamente",
       timedOut: "{0} demorou demais para responder — verifique sua rede ou VPN e tente novamente.",
+      forgeUnsupported: "Os pull requests do {0} ainda não têm suporte. Clonar, fazer push, pull e merge funcionam normalmente.",
+      openForgeWeb: "Abrir na web",
     },
   },
 
@@ -1753,6 +1755,7 @@ const ptBR: Locale = {
     gitlab: "GitLab",
     bitbucket: "Bitbucket",
     azure: "Azure DevOps",
+    cursor: "Cursor Origin",
     action: "Abrir Configurações",
   },
 
@@ -2305,7 +2308,7 @@ const ptBR: Locale = {
       historyTitle: "Histórico",
       history: "Acesse a aba Histórico para navegar pelos commits.",
       remoteTitle: "Remotos",
-      remote: "GitWand suporta GitHub, GitLab e Bitbucket.",
+      remote: "GitWand suporta GitHub, GitLab, Bitbucket e Azure DevOps para pull requests, e detecta remotes do Cursor Origin (apenas operações git, ainda sem integração de PR).",
     },
     aiFeatures: {
       title: "Recursos de IA",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -1035,6 +1035,8 @@ const zhCN: Locale = {
       unknown: "加载 pull request 失败。",
       retry: "重试",
       timedOut: "{0} 响应超时 — 请检查网络或 VPN 后重试。",
+      forgeUnsupported: "尚不支持 {0} 的 pull request。克隆、推送、拉取和合并均可正常使用。",
+      openForgeWeb: "在网页中打开",
     },
   },
 
@@ -1740,6 +1742,7 @@ const zhCN: Locale = {
     gitlab: "GitLab",
     bitbucket: "Bitbucket",
     azure: "Azure DevOps",
+    cursor: "Cursor Origin",
     action: "打开设置",
   },
 
@@ -2290,7 +2293,7 @@ const zhCN: Locale = {
       historyTitle: "历史",
       history: "切换到侧边栏的历史标签浏览提交记录。",
       remoteTitle: "远程",
-      remote: "GitWand 支持 GitHub、GitLab 和 Bitbucket。",
+      remote: "GitWand 的 pull request 功能支持 GitHub、GitLab、Bitbucket 和 Azure DevOps，并可识别 Cursor Origin 远程仓库（仅支持 git 操作，尚无 PR 集成）。",
     },
     aiFeatures: {
       title: "AI 功能",

--- a/apps/desktop/src/utils/__tests__/forgeUrls.test.ts
+++ b/apps/desktop/src/utils/__tests__/forgeUrls.test.ts
@@ -1,0 +1,123 @@
+/**
+ * `forgeCommitUrl` — the "View on forge" target for a commit.
+ *
+ * Extracted from `useCommitActions.handleViewOnForge`, where it was an inline
+ * ternary chain, so the per-forge shapes are actually pinned by tests.
+ *
+ * Takes the whole remote rather than just owner/repo: Azure DevOps commit URLs
+ * need the org/project pair, which only the remote URL carries.
+ */
+import { describe, it, expect } from "vitest";
+import { forgeCommitUrl } from "../forgeUrls";
+
+const SHA = "abc1234def5678";
+
+/** Shorthand for the common `{provider, owner, repo, url}` shape. */
+const remote = (provider: string, owner: string, repo: string, url = "") => ({
+  provider,
+  owner,
+  repo,
+  url,
+});
+
+describe("forgeCommitUrl — GitHub, GitLab, Bitbucket", () => {
+  it("points at the commit", () => {
+    expect(forgeCommitUrl(remote("github", "acme", "checkout"), SHA)).toBe(
+      `https://github.com/acme/checkout/commit/${SHA}`
+    );
+    expect(forgeCommitUrl(remote("gitlab", "acme", "checkout"), SHA)).toBe(
+      `https://gitlab.com/acme/checkout/-/commit/${SHA}`
+    );
+    expect(forgeCommitUrl(remote("bitbucket", "acme", "checkout"), SHA)).toBe(
+      `https://bitbucket.org/acme/checkout/commits/${SHA}`
+    );
+  });
+});
+
+describe("forgeCommitUrl — Cursor Origin", () => {
+  it("degrades to the repo page", () => {
+    // Origin's commit-permalink path shape is not documented, and guessing
+    // `/commit/{sha}` risks a 404. The repo page always resolves.
+    expect(
+      forgeCommitUrl(
+        remote("cursor", "acme", "checkout", "https://origin.cursor.com/acme/checkout.git"),
+        SHA
+      )
+    ).toBe("https://cursor.com/codebase/acme/checkout");
+  });
+});
+
+describe("forgeCommitUrl — Azure DevOps", () => {
+  // Previously fell through to the GitHub shape, producing a github.com URL
+  // where the commit does not exist. The org/project pair is parsed out of the
+  // remote, mirroring `parse_azure_remote()` in src-tauri/src/commands/azure.rs.
+  const EXPECTED = `https://dev.azure.com/myorg/myproj/_git/myrepo/commit/${SHA}`;
+
+  it("handles the dev.azure.com shape", () => {
+    expect(
+      forgeCommitUrl(
+        remote("azure", "", "", "https://dev.azure.com/myorg/myproj/_git/myrepo"),
+        SHA
+      )
+    ).toBe(EXPECTED);
+  });
+
+  it("handles a userinfo prefix in the remote", () => {
+    expect(
+      forgeCommitUrl(
+        remote("azure", "", "", "https://myorg@dev.azure.com/myorg/myproj/_git/myrepo"),
+        SHA
+      )
+    ).toBe(EXPECTED);
+  });
+
+  it("handles the legacy visualstudio.com shape", () => {
+    expect(
+      forgeCommitUrl(
+        remote("azure", "", "", "https://myorg.visualstudio.com/myproj/_git/myrepo"),
+        SHA
+      )
+    ).toBe(EXPECTED);
+  });
+
+  it("drops the DefaultCollection segment", () => {
+    expect(
+      forgeCommitUrl(
+        remote("azure", "", "", "https://myorg.visualstudio.com/DefaultCollection/myproj/_git/myrepo"),
+        SHA
+      )
+    ).toBe(EXPECTED);
+  });
+
+  it("handles the SSH shape", () => {
+    expect(
+      forgeCommitUrl(
+        remote("azure", "", "", "git@ssh.dev.azure.com:v3/myorg/myproj/myrepo"),
+        SHA
+      )
+    ).toBe(EXPECTED);
+  });
+
+  it("tolerates a trailing .git", () => {
+    expect(
+      forgeCommitUrl(
+        remote("azure", "", "", "https://dev.azure.com/myorg/myproj/_git/myrepo.git"),
+        SHA
+      )
+    ).toBe(EXPECTED);
+  });
+
+  it("returns null rather than a wrong URL when the remote is unparseable", () => {
+    // Never silently fall back to the GitHub shape again.
+    expect(
+      forgeCommitUrl(remote("azure", "acme", "checkout", "https://dev.azure.com/nope"), SHA)
+    ).toBeNull();
+  });
+});
+
+describe("forgeCommitUrl — missing data", () => {
+  it("returns null when owner or repo is missing on a path-based forge", () => {
+    expect(forgeCommitUrl(remote("github", "", "checkout"), SHA)).toBeNull();
+    expect(forgeCommitUrl(remote("github", "acme", ""), SHA)).toBeNull();
+  });
+});

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -2263,7 +2263,7 @@ export async function gitAutocomplete(cwd: string, partial: string): Promise<str
 export interface RemoteInfo {
   name: string;
   url: string;
-  provider: "github" | "gitlab" | "bitbucket" | "azure" | "unknown";
+  provider: "github" | "gitlab" | "bitbucket" | "azure" | "cursor" | "unknown";
   owner: string;
   repo: string;
 }

--- a/apps/desktop/src/utils/forgeUrls.ts
+++ b/apps/desktop/src/utils/forgeUrls.ts
@@ -1,0 +1,129 @@
+/**
+ * @file utils/forgeUrls.ts
+ *
+ * Web-UI URL builders per forge. Extracted from an inline ternary chain in
+ * `useCommitActions.handleViewOnForge` so the per-forge path shapes are pinned
+ * by tests rather than buried in a handler.
+ */
+
+import { CURSOR_WEB_BASE } from "../composables/forge/types";
+
+/** The subset of `RemoteInfo` these builders need. */
+export interface ForgeRemote {
+  provider: string;
+  owner: string;
+  repo: string;
+  /** Raw remote URL. Required for Azure DevOps, which needs org + project. */
+  url: string;
+}
+
+/** Azure DevOps coordinates, which are a triple rather than an owner/repo pair. */
+interface AzureRepo {
+  org: string;
+  project: string;
+  repo: string;
+}
+
+/**
+ * Parse `(org, project, repo)` out of an Azure DevOps remote URL.
+ *
+ * Mirrors `parse_azure_remote()` in `src-tauri/src/commands/azure.rs` — keep the
+ * two in sync. Handles:
+ *   - `https://dev.azure.com/{org}/{project}/_git/{repo}`
+ *   - `https://{org}@dev.azure.com/{org}/{project}/_git/{repo}`
+ *   - `https://{org}.visualstudio.com/{project}/_git/{repo}`
+ *   - `https://{org}.visualstudio.com/DefaultCollection/{project}/_git/{repo}`
+ *   - `git@ssh.dev.azure.com:v3/{org}/{project}/{repo}`
+ */
+export function parseAzureRemote(url: string): AzureRepo | null {
+  const stripGit = (s: string) => s.replace(/\.git$/, "");
+
+  // SSH: git@ssh.dev.azure.com:v3/{org}/{project}/{repo}
+  const sshMarker = "ssh.dev.azure.com:";
+  const sshIdx = url.indexOf(sshMarker);
+  if (sshIdx !== -1) {
+    const rest = stripGit(url.slice(sshIdx + sshMarker.length).replace(/^v3\//, ""));
+    const parts = rest.split("/").filter(Boolean);
+    if (parts.length >= 3) {
+      return { org: parts[0], project: parts[1], repo: parts.slice(2).join("/") };
+    }
+    return null;
+  }
+
+  // HTTPS — strip the scheme, then any `user@` userinfo.
+  const afterScheme = url.includes("://") ? url.slice(url.indexOf("://") + 3) : url;
+  const at = afterScheme.indexOf("@");
+  const afterUserinfo = at === -1 ? afterScheme : afterScheme.slice(at + 1);
+
+  const slash = afterUserinfo.indexOf("/");
+  if (slash === -1) return null;
+  const host = afterUserinfo.slice(0, slash);
+  const path = stripGit(afterUserinfo.slice(slash + 1).replace(/\/+$/, ""));
+
+  const gitMarker = "/_git/";
+  const gitIdx = path.indexOf(gitMarker);
+  if (gitIdx === -1) return null;
+  const left = path.slice(0, gitIdx);
+  const repo = path.slice(gitIdx + gitMarker.length);
+  if (!repo) return null;
+
+  // dev.azure.com/{org}/{project}/_git/{repo}
+  if (host.toLowerCase() === "dev.azure.com") {
+    const segs = left.split("/").filter(Boolean);
+    if (segs.length >= 2) {
+      return { org: segs[0], project: segs.slice(1).join("/"), repo };
+    }
+    return null;
+  }
+
+  // {org}.visualstudio.com[/DefaultCollection]/{project}/_git/{repo}
+  const vsSuffix = ".visualstudio.com";
+  if (host.toLowerCase().endsWith(vsSuffix)) {
+    const org = host.slice(0, host.length - vsSuffix.length);
+    const segs = left
+      .split("/")
+      .filter((s) => s && s.toLowerCase() !== "defaultcollection");
+    if (org && segs.length > 0) {
+      return { org, project: segs.join("/"), repo };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Best web URL for viewing `sha` of `remote` on its forge, or `null` when no
+ * correct URL can be built. Callers surface their own "no remote" message
+ * rather than opening something wrong.
+ *
+ * An unrecognised provider falls back to the GitHub shape, which is the
+ * historical behaviour and is right for GitHub Enterprise-ish remotes that
+ * detection reports as `github`. Azure DevOps is explicitly handled rather than
+ * left to that fallback: it used to produce a `github.com` URL where the commit
+ * simply does not exist.
+ */
+export function forgeCommitUrl(remote: ForgeRemote, sha: string): string | null {
+  const { provider, owner, repo, url } = remote;
+
+  if (provider === "azure") {
+    const az = parseAzureRemote(url);
+    if (!az) return null;
+    return `https://dev.azure.com/${az.org}/${az.project}/_git/${az.repo}/commit/${sha}`;
+  }
+
+  if (!owner || !repo) return null;
+
+  switch (provider) {
+    case "gitlab":
+      return `https://gitlab.com/${owner}/${repo}/-/commit/${sha}`;
+    case "bitbucket":
+      return `https://bitbucket.org/${owner}/${repo}/commits/${sha}`;
+    case "cursor":
+      // Cursor Origin's commit-permalink shape is undocumented; guessing
+      // `/commit/{sha}` risks a 404, so degrade to the repo page, which always
+      // resolves. Upgrade once the permalink path is confirmed.
+      return `${CURSOR_WEB_BASE}/${owner}/${repo}`;
+    default:
+      return `https://github.com/${owner}/${repo}/commit/${sha}`;
+  }
+}

--- a/apps/desktop/tests/parity/fixtures.mjs
+++ b/apps/desktop/tests/parity/fixtures.mjs
@@ -93,6 +93,24 @@ export function fixtureClean() {
 }
 
 /**
+ * Fixture « remote Cursor Origin » : un commit, plus un remote `origin`
+ * pointant sur le host git d'Origin (`origin.cursor.com`).
+ *
+ * Aucun accès réseau : `git remote add` n'effectue aucune connexion, et
+ * `git remote -v` — la seule commande que `git_remote_info` exécute — lit
+ * uniquement `.git/config`.
+ */
+export function fixtureCursorOriginRemote() {
+  const cwd = mkTempRepo("gw-cursor-remote-");
+  commitFile(cwd, "README.md", "# Parity Fixture\n", "initial commit", 0);
+  execFileSync("git", [
+    "-C", cwd, "remote", "add", "origin",
+    "https://origin.cursor.com/acme/checkout.git",
+  ]);
+  return cwd;
+}
+
+/**
  * Fixture « dirty » : 3 commits, un fichier modifié non stagé, un nouveau
  * fichier untracked, un fichier stagé.
  *

--- a/apps/desktop/tests/parity/git-remote-info.test.mjs
+++ b/apps/desktop/tests/parity/git-remote-info.test.mjs
@@ -1,0 +1,37 @@
+/**
+ * Parity tests — `git_remote_info` (Rust) vs `/api/git-remote-info` (Node dev-server).
+ *
+ * Pourquoi ce fichier existe : la détection de forge depuis l'URL du remote est
+ * dupliquée mot pour mot entre `detect_provider()` (Rust) et la chaîne de
+ * `if/else` du dev-server. Rien ne les empêchait de divorcer — un forge ajouté
+ * d'un seul côté donnait un `provider` différent selon qu'on tourne en
+ * `pnpm dev` ou dans l'app buildée, donc un routage de ForgeProvider différent.
+ * Ce test verrouille l'accord sur les deux bouts.
+ */
+
+import { describe, it, beforeAll, afterAll } from "vitest";
+import { startDevServer } from "./dev-server-runner.mjs";
+import { assertParity } from "./harness.mjs";
+import { fixtureCursorOriginRemote } from "./fixtures.mjs";
+
+describe("parity: git-remote-info", () => {
+  /** @type {Awaited<ReturnType<typeof startDevServer>>} */
+  let dev;
+
+  beforeAll(async () => {
+    dev = await startDevServer();
+  }, 15_000);
+
+  afterAll(async () => {
+    await dev?.stop();
+  });
+
+  it("remote origin.cursor.com → provider `cursor` des deux côtés", async () => {
+    const cwd = fixtureCursorOriginRemote();
+    await assertParity(dev, {
+      command: "git-remote-info",
+      args: { cwd },
+      httpPath: `/api/git-remote-info?cwd=${encodeURIComponent(cwd)}`,
+    });
+  });
+});


### PR DESCRIPTION
## Why

[Cursor Origin](https://cursor.com/docs/origin) is Cursor's git forge, currently in early beta. GitWand has no PR integration for it, but its remotes were not even *recognised*: detection reported `unknown`, and `getProviderByName()` ends in `?? githubProvider`, so an Origin repo fired `gh` CLI calls at `origin.cursor.com` and surfaced a bewildering GitHub auth error.

This is **Phase 0: recognise Origin, do not integrate it.** Clone, push, pull, merges and the conflict-resolution engine already worked on an Origin repo and are untouched here, they are plain git and never go through a `ForgeProvider`. What this PR buys is that the core of GitWand becomes usable on Origin for almost nothing, and the PR panel says something true instead of failing weirdly.

Phase 1 (a real `OriginProvider`) is deliberately deferred. Origin's REST API documents only the "Origin App" auth model (Ed25519 keypair, app JWT, 15-minute installation tokens), a poor fit for a desktop client, and it cannot read repos mirrored inbound from GitHub. The pragmatic route is shelling out to the `origin` CLI the way `gh.rs` does for GitHub, worth building once Origin leaves beta and its API stops moving. Same reasoning `roadmap.md` already applies to the other forges: wait for real usage pressure.

## Detection

- `detect_provider()` extracted out of `git_remote_info` into `git/parse.rs` so it is unit-testable, mirrored in `dev-server.mjs`. Matches the dedicated git host `origin.cursor.com`, **not** a bare `cursor.com`, which is the web UI.
- `parse_remote_owner_repo` needed no change: Origin uses a GitHub-shaped path. A test locks that in, since the detection depends on it.
- **New parity coverage for `git-remote-info`**, which had none, even though the detection chain is duplicated verbatim between Rust and the Node dev-server. Nothing stopped the two from diverging, and a forge added on one side only would yield a different `provider`, hence different `ForgeProvider` routing, depending on whether you run `pnpm dev` or the built app. This test caught the drift during development, before `dev-server.mjs` was updated.

## CursorProvider

Detection-only provider: every required contract method throws a typed `ForgeNotImplementedError`. Optional methods (`listIssues`, `listBranches`, `dismissReview`, `requestReviewers`) are *omitted* rather than stubbed, which is the contract's existing signal for "hide the affordance". Origin has no issue tracker at all.

## Honest UI instead of dead ends

- `ForgeNotImplementedError` is classified **before** the substring chain in `loadPrs`. It previously reached the raw-message branch, so users read `[ForgeProvider:cursor] listPRs() not yet implemented`. Worse, that chain's first branch is loose enough that a reworded message could have been misreported as "install the GitHub CLI", which no install would fix.
- The error banner offers the repo on the web. Retry is hidden, it can never succeed.
- Both "New PR" buttons are hidden via `forgeSupportsPRs()`, driven off the **provider** rather than off an error already having happened, so they are absent on first paint and not merely after a failed `listPRs`. Without this, the user could fill in an entire PR form that can never be submitted.
- Today drops Origin repos before the `isForgeConnected` check, so no "Connect your Cursor Origin account" banner appears for an account that cannot exist. This shared helper also replaces two local copies of the same forge list.

## Azure DevOps commit URLs (pre-existing bug, fixed here)

"View on forge" built a `github.com` URL for an Azure repo, where the commit does not exist: `parse_remote_owner_repo` split `https://dev.azure.com/myorg/myproj/_git/myrepo` into owner `myorg` / repo `myproj/_git/myrepo`, then hit the GitHub fallback.

`forgeCommitUrl()` now takes the whole remote and resolves org/project through `parseAzureRemote()`, mirroring `parse_azure_remote()` in `commands/azure.rs`, covering all five documented shapes (`dev.azure.com`, `user@` userinfo, legacy `visualstudio.com`, the `DefaultCollection` segment, and SSH `v3/`). An unparseable Azure remote returns `null` rather than silently falling back to the GitHub shape.

## Verification

| Suite | Result |
|---|---|
| Frontend Vitest | 1011 tests, 115 files |
| Rust `cargo test --lib` | 223 tests |
| Parity (Rust vs dev-server) | 24 tests, 10 files |

All suites were run on the exact content of this commit.

Verified end to end in `pnpm dev:web` against two real local repos, one with an `origin.cursor.com` remote and one with a `dev.azure.com` remote, by intercepting `window.open`:

- Azure: `https://dev.azure.com/myorg/myproj/_git/myrepo/commit/c776bf75…` with the real SHA
- Origin: `https://cursor.com/codebase/acme/checkout`

On the Origin repo the PR panel's accessibility tree contains no "New PR" button at all, only "Open on the web". On GitWand itself and on the Azure repo both buttons are present, so no regression.

## Notes for the reviewer

- **Naming:** the internal `ForgeName` is `"cursor"`, not `"origin"`. `"origin"` is already the default git remote name, including three lines above the detection chain this PR touches (`if name == "origin"`). The UI label is "Cursor Origin".
- **Cursor commit permalinks:** "View on forge" points at the repo page, not the commit. Origin's commit-permalink path shape is undocumented and guessing `/commit/{sha}` risks a 404. Worth upgrading once confirmed.
- **`CHANGELOG.md` is intentionally untouched:** it is part of an unrelated work-in-progress in the working tree. `AGENTS.md` places the CHANGELOG entry at tag time, so this needs an `[Unreleased]` entry before the next tag.
- **Pre-existing `vue-tsc` error**, unrelated and not introduced here: `useCommitReview.ts(285): Property 'commitReview' does not exist on type 'GitWandrcConfig'`. It reproduces on `main` with this branch's changes removed, and comes from `@gitwand/core`.
- `PullRequestPanel.vue` has its own "New PR" button with local state and was left alone: the component is imported nowhere and is dead code, referenced only in comments.
