### PR TITLE
feat(website): /agent WebMCP page, English engine strings, and deterministic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`/agent`, a WebMCP page.** gitwand.app/agent exposes two read-only git tools to any agent browsing it, over the W3C WebMCP standard: `parse_git_error` explains a failing git command and gives the commands that fix it, `resolve_conflict` runs the deterministic engine over a conflicted file and reports per hunk what was resolved and what still needs a human. Both execute in the visitor's tab, so nothing is uploaded and there is no backend. `@gitwand/core` is imported on demand rather than at module scope, which keeps it out of the shared theme chunk every page downloads.
 - The page states its own registration status live, including when the browser has no WebMCP at all, and writes both tool contracts out in HTML and JSON-LD for the majority of visitors and crawlers that will never run the script.
+- **A try-it panel on `/agent`.** Both tools can be run by hand from the page, against editable sample inputs, so the majority of visitors whose browser has no WebMCP can still see what an agent gets back. It calls the same `execute` an agent calls rather than a mock, and deliberately does not feed the agent call counter.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/agent`, a WebMCP page.** gitwand.app/agent exposes two read-only git tools to any agent browsing it, over the W3C WebMCP standard: `parse_git_error` explains a failing git command and gives the commands that fix it, `resolve_conflict` runs the deterministic engine over a conflicted file and reports per hunk what was resolved and what still needs a human. Both execute in the visitor's tab, so nothing is uploaded and there is no backend. `@gitwand/core` is imported on demand rather than at module scope, which keeps it out of the shared theme chunk every page downloads.
+- The page states its own registration status live, including when the browser has no WebMCP at all, and writes both tool contracts out in HTML and JSON-LD for the majority of visitors and crawlers that will never run the script.
+
+### Fixed
+
+- **Site-wide WebMCP tools went dark on browsers without `navigator.modelContext`.** The registration script bailed out entirely unless the deprecated `navigator` location existed, so the three documentation tools would disappear the day Chrome removes the alias it deprecated in 150. It now prefers `document.modelContext`, where the spec has put the entry point since 27 May 2026, and falls back to `navigator` only when that is all the browser offers. It registers once either way: on the versions exposing both names they alias the same object, so registering on both would have duplicated every tool.
+- **WebMCP tools could never be unregistered.** `signal` was passed as a property of the tool dictionary, which declares no such member, so it was silently dropped. It now goes in the options argument where `ModelContextRegisterToolOptions` expects it.
+
 ## [3.8.0] - 2026-08-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The page states its own registration status live, including when the browser has no WebMCP at all, and writes both tool contracts out in HTML and JSON-LD for the majority of visitors and crawlers that will never run the script.
 - **A try-it panel on `/agent`.** Both tools can be run by hand from the page, against editable sample inputs, so the majority of visitors whose browser has no WebMCP can still see what an agent gets back. It calls the same `execute` an agent calls rather than a mock, and deliberately does not feed the agent call counter.
 
+### Changed
+
+- **The engine speaks English.** Every explanation, resolution reason, decision-trace step, confidence booster and penalty `@gitwand/core` produces was written in French. None of the consumers translate them, so the desktop merge editor, the CLI summary and the `@gitwand/mcp` `explanation` / `resolutionReason` fields have been handing French text to every user and every agent, whatever their locale. 194 strings translated across 38 files. Comments and test names stay French: this is only about what leaves the engine.
+- A regression guard (`__tests__/english-output.test.ts`) runs the engine over the whole corpus and asserts that no string it hands back is French, checking real output rather than scanning source so it cannot be fooled by how a string is assembled. It caught four strings a source scan had missed, including one with no accented characters in it.
+
 ### Fixed
 
 - **Site-wide WebMCP tools went dark on browsers without `navigator.modelContext`.** The registration script bailed out entirely unless the deprecated `navigator` location existed, so the three documentation tools would disappear the day Chrome removes the alias it deprecated in 150. It now prefers `document.modelContext`, where the spec has put the entry point since 27 May 2026, and falls back to `navigator` only when that is all the browser offers. It registers once either way: on the versions exposing both names they alias the same object, so registering on both would have duplicated every tool.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`pnpm test` was non-deterministic (#172).** Suites that use real git repositories are subprocess-bound, not CPU-bound, and were timing out under the load of the whole monorepo testing at once. Every git-backed suite now shares a 60s timeout, chosen to catch a hang rather than to enforce a performance budget. Running workspaces one at a time turned out to be **faster** as well as deterministic (49s against 119s), because five packages each fanning out to one worker per core oversubscribes the machine several times over, so `pnpm test` now passes `--workspace-concurrency=1`. Eleven consecutive full runs green, against roughly one failure in three before.
+
 - **Site-wide WebMCP tools went dark on browsers without `navigator.modelContext`.** The registration script bailed out entirely unless the deprecated `navigator` location existed, so the three documentation tools would disappear the day Chrome removes the alias it deprecated in 150. It now prefers `document.modelContext`, where the spec has put the entry point since 27 May 2026, and falls back to `navigator` only when that is all the browser offers. It registers once either way: on the versions exposing both names they alias the same object, so registering on both would have duplicated every tool.
 - **WebMCP tools could never be unregistered.** `signal` was passed as a property of the tool dictionary, which declares no such member, so it was silently dropped. It now goes in the options argument where `ModelContextRegisterToolOptions` expects it.
 

--- a/README.md
+++ b/README.md
@@ -153,18 +153,26 @@ GitWand's core engine (`@gitwand/core`) automatically resolves trivial Git merge
 
 GitWand uses a **pattern registry** — the classifier evaluates patterns in priority order, each declaring whether it requires diff3 (base available), diff2, or works on both.
 
-| Pattern | Description | Confidence |
-|---|---|---|
-| **same_change** | Both branches made the exact same edit | Certain |
-| **one_side_change** | Only one branch modified the block | Certain |
-| **delete_no_change** | One branch deleted, the other didn't touch it | Certain |
-| **non_overlapping** | Additions at different locations in the block | High |
-| **whitespace_only** | Same logic, different indentation/spacing | High |
-| **reorder_only** | Same lines, different order — pure permutation | High |
-| **insertion_at_boundary** | Pure insertions on both sides, base intact | High |
-| **value_only_change** | Scalar value update (version number, constant) | Medium |
-| **generated_file** | File matches a known generated-file path pattern | High |
-| **complex** | Overlapping edits — never auto-resolved | — |
+The registry holds **12 patterns**, of which **8 auto-apply**. The other four either propose a resolution you confirm, are opt-in, or hand the hunk back untouched.
+
+| Pattern | Priority | Auto-applies | Description | Typical confidence |
+|---|---|---|---|---|
+| **same_change** | 10 | Yes | Both branches made the exact same edit | Certain |
+| **delete_no_change** | 20 | Yes | One side deleted the block, the other left it untouched | Certain |
+| **one_side_change** | 30 | Yes | Only one branch modified the block | Certain |
+| **non_overlapping** | 40 | Yes | Additions at different locations in the block | High |
+| **whitespace_only** | 50 | Yes | Same logic, different indentation/spacing | High |
+| **reorder_only** | 55 | Yes | Same lines, different order, a pure permutation | High |
+| **insertion_at_boundary** | 57 | Yes | Pure insertions on both sides, base intact | High |
+| **value_only_change** | 60 | Yes | Both sides changed the same scalar (version, hash, timestamp) | High to medium |
+| **token_level_merge** | 65 | No, proposes | Disjoint token edits on the same line, merged into a proposal you confirm | Medium |
+| **refactoring_aware_merge** | 970 | No, opt-in | Rename or move detected and replayed across the conflict | High |
+| **llm_proposed** | 998 | No, opt-in | Model-proposed resolution, validated post-merge | Medium |
+| **complex** | 999 | No | Overlapping edits, always surfaced with a full trace | Low |
+
+The confidence column is indicative: every hunk carries a computed `ConfidenceScore` (see below), not a fixed label. `value_only_change`, for instance, scores on the ratio of volatile tokens to total tokens and rejects the hunk outright below its threshold.
+
+**Not a registry pattern:** `generated_file` is a separate reclassification pass that runs after classification. When a hunk lands in `complex` and its path matches a generated-file glob (lockfiles, bundles, `dist/`, plus anything in `generatedFiles`), the resolver rewrites it to `generated_file` and resolves to *theirs*, on the assumption the file will be regenerated. It appears in `ConflictType` but never in the classifier registry.
 
 ### Composite confidence score
 

--- a/apps/desktop/src/components/MergeEditor.vue
+++ b/apps/desktop/src/components/MergeEditor.vue
@@ -264,7 +264,7 @@ const canResolve = computed(
 const hunks = computed(() => props.file.result.hunks);
 const resolutions = computed(() => props.file.result.resolutions);
 
-// v2.7 — "recoverable-before-model" tier summary for this file. Hidden when
+// v3.4 — "recoverable-before-model" tier summary for this file. Hidden when
 // residual is 0 (every hunk was trivially resolved — nothing to measure).
 const tierSummary = computed(() => summarizeTiers(props.file.result.stats.byType));
 
@@ -351,7 +351,7 @@ function onLlmReject(hunkId: string | number) {
   }
 }
 
-// ─── v2.7 — token_level_merge proposal panel ────────────
+// ─── v3.4 — token_level_merge proposal panel ────────────
 // Unlike llm_proposed, the core NEVER pre-computes resolvedLines for this
 // type (see resolver/assemble.ts) — accepting emits resolveHunkCustom with
 // the proposed mergedLines, going through the exact same pathway as a
@@ -889,7 +889,7 @@ useResizeObserver(contentEl, drawMinimap);
               @reject="onLlmReject"
             />
 
-            <!-- ── v2.7 token_level_merge proposal (when not rejected) ────── -->
+            <!-- ── v3.4 token_level_merge proposal (when not rejected) ────── -->
             <TokenMergePanel
               v-if="hunkForSegment(seg) && seg.hunkIndex != null && showTokenMergePanelFor(seg.hunkIndex, hunkForSegment(seg)!)"
               :trace="hunkForSegment(seg)!.trace.tokenMergeTrace!"

--- a/apps/desktop/src/composables/__tests__/pullAutostash.git.test.ts
+++ b/apps/desktop/src/composables/__tests__/pullAutostash.git.test.ts
@@ -18,9 +18,16 @@ import { join } from "node:path";
 
 const AUTHOR_NAME = "GitWand Test";
 const AUTHOR_EMAIL = "test@gitwand.test";
-// Real git subprocesses (init/clone/push/pull) are slower than the 5s default
-// under full-suite parallel load — give them real headroom instead of flaking.
-const GIT_TEST_TIMEOUT_MS = 20_000;
+// Real git subprocesses (init/clone/push/pull), per AGENTS.md's rule against
+// mocking the git layer. Measured at 20.2s for the six tests in this file with
+// the machine otherwise idle, so ~3.4s each before any contention, and one of
+// them was observed at 31s once the whole monorepo ran at once.
+//
+// 60s is deliberately generous, and matches the other git-backed suites. A
+// timeout here exists to catch a hang, not to enforce a performance budget,
+// and it costs nothing on a passing run. The previous 20s was tuned just above
+// what had been observed, which is what produced the flake in issue #172.
+const GIT_TEST_TIMEOUT_MS = 60_000;
 
 function gitEnv(): NodeJS.ProcessEnv {
   return {

--- a/apps/desktop/src/composables/useGitWand.ts
+++ b/apps/desktop/src/composables/useGitWand.ts
@@ -579,7 +579,7 @@ export function useGitWand() {
       selectedPath.value = loaded[0].path;
     }
 
-    // v2.7 — agrégat local de la métrique tier (dédupliqué par empreinte,
+    // v3.4 — agrégat local de la métrique tier (dédupliqué par empreinte,
     // les refreshs du même jeu de conflits ne recomptent pas).
     const { recordFile } = useTierStats();
     for (const f of loaded) {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "gitwand",
   "version": "3.8.0",
   "private": true,
-  "description": "Git's magic wand — automatic conflict resolution and smart merge tools",
+  "description": "Git's magic wand \u2014 automatic conflict resolution and smart merge tools",
   "author": "Laurent Guitton <lb.guitton@gmail.com>",
   "license": "MIT",
   "packageManager": "pnpm@11.9.0",
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "build": "pnpm -r run build",
-    "test": "pnpm -r run test",
+    "test": "pnpm -r --workspace-concurrency=1 run test",
     "clean": "pnpm -r run clean",
     "postinstall": "node scripts/fix-spawn-helper.mjs"
   },

--- a/packages/cli/src/__tests__/scan.test.ts
+++ b/packages/cli/src/__tests__/scan.test.ts
@@ -21,6 +21,19 @@ function stageFile(cwd: string, relPath: string, content: string): void {
   execFileSync("git", ["-C", cwd, "add", "--", relPath]);
 }
 
+// Every test here goes through `initRepo()`, which runs `git init` plus two
+// `git config` calls, and `stageFile()` adds a `git add` per file. Per
+// AGENTS.md the git layer is deliberately not mocked, so these are
+// subprocess-bound and slow down sharply when the whole monorepo runs at once,
+// which is how `pnpm test` and CI run them. The hooks carry the timeout too:
+// they are outside the `describe`, so its option does not reach them.
+//
+// 60s is deliberately generous, and matches the other git-backed suites. A
+// timeout here exists to catch a hang, not to enforce a performance budget,
+// and it costs nothing on a passing run. Tuning it down to "just above
+// observed" is what produced the flake in issue #172.
+const GIT_IO_TIMEOUT_MS = 60_000
+
 let repoDir: string;
 let originalCwd: string;
 let logSpy: ReturnType<typeof vi.spyOn>;
@@ -31,16 +44,16 @@ beforeEach(() => {
   process.chdir(repoDir);
   logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
   process.exitCode = 0;
-});
+}, GIT_IO_TIMEOUT_MS);
 
 afterEach(() => {
   process.chdir(originalCwd);
   rmSync(repoDir, { recursive: true, force: true });
   logSpy.mockRestore();
   process.exitCode = 0;
-});
+}, GIT_IO_TIMEOUT_MS);
 
-describe("gitwand scan", () => {
+describe("gitwand scan", { timeout: GIT_IO_TIMEOUT_MS }, () => {
   it("reports a finding for a secret on a staged added line", async () => {
     stageFile(repoDir, "src/config.ts", 'const key = "AKIAABCDEFGHIJKLMNOP";\n');
 

--- a/packages/cli/src/commands/resolve.ts
+++ b/packages/cli/src/commands/resolve.ts
@@ -241,7 +241,7 @@ export async function cmdResolve(
     );
   }
 
-  // v2.7 — "recoverable-before-model" : de ce qui dépasse les passes triviales,
+  // v3.4 — "recoverable-before-model" : de ce qui dépasse les passes triviales,
   // combien reste récupérable de façon déterministe avant d'atteindre le LLM.
   // N'affiche rien si tout était trivial (résidu vide — rien à mesurer).
   const tiers = summarizeTiers(aggregateByType as Record<ConflictType, number>);

--- a/packages/core/src/__tests__/confidence-v14.test.ts
+++ b/packages/core/src/__tests__/confidence-v14.test.ts
@@ -178,7 +178,7 @@ describe("F32 — reorder_only : lignes dupliquées (pénalité ordre ambigu)", 
   it("la pénalité de doublons est mentionnée", () => {
     const result = resolve(input, "index.ts");
     const penalties = result.hunks[0].confidence.penalties;
-    expect(penalties.some((p) => p.toLowerCase().includes("dupliqu"))).toBe(true);
+    expect(penalties.some((p) => p.toLowerCase().includes("duplicate"))).toBe(true);
   });
 
   it("le score est inférieur à un reorder_only sans doublons", () => {
@@ -297,7 +297,7 @@ describe("fileFrequency — pénalité sur les fichiers avec hunks complexes", (
 
     const result = resolve(input, "hot.ts");
     const secondHunkPenalties = result.hunks[1].confidence.penalties;
-    expect(secondHunkPenalties.some((p) => p.toLowerCase().includes("zone chaude"))).toBe(true);
+    expect(secondHunkPenalties.some((p) => p.toLowerCase().includes("hot spot"))).toBe(true);
   });
 
   it("un seul hunk dans un fichier n'a pas de pénalité fileFrequency", () => {

--- a/packages/core/src/__tests__/corpus.ts
+++ b/packages/core/src/__tests__/corpus.ts
@@ -1341,7 +1341,7 @@ const F45: CorpusFixture = {
 // disjoints — non_overlapping échoue (chevauchement réel), seul token_level_merge résout.
 const F46: CorpusFixture = {
   id: "F46",
-  description: "v2.7 — token_level_merge : classes Tailwind, tokens disjoints sur 2 lignes adjacentes",
+  description: "v3.4 — token_level_merge : classes Tailwind, tokens disjoints sur 2 lignes adjacentes",
   filePath: "resources/views/gestion/upsells/suggestions/index.blade.php",
   category: "semantic",
   input: [
@@ -1376,7 +1376,7 @@ export const CORPUS: CorpusFixture[] = [
   // v2.5 — LLM fallback candidates (complex sans LLM, résolus avec LLM mocké)
   F36, F37, F38, F39, F40,
   F41, F42, F43, F44, F45,
-  // v2.7 — token_level_merge
+  // v3.4 — token_level_merge
   F46,
 ];
 

--- a/packages/core/src/__tests__/english-output.test.ts
+++ b/packages/core/src/__tests__/english-output.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Guard: every string the engine hands to a consumer is written in English.
+ *
+ * The engine's explanations, resolution reasons, decision traces, boosters and
+ * penalties are not internal debug text. They reach users through the desktop
+ * merge editor, the CLI summary, the MCP server's `explanation` and
+ * `resolutionReason` fields, and the WebMCP tools on the website, none of which
+ * translate them. They were French until they were translated wholesale, which
+ * meant every non-French user read French.
+ *
+ * This test asserts the property on real engine output rather than by scanning
+ * the source, so it cannot be fooled by how a string is assembled. It catches
+ * accented French, which is how most of it reads; the accent-free residue
+ * ("Confiance medium ... insuffisante ...") is why the word list exists too.
+ *
+ * Comments and test names in this repository are deliberately French. This
+ * guard is only about what leaves the engine.
+ */
+import { describe, it, expect } from "vitest";
+import { resolve } from "../resolver/index.js";
+import { CORPUS } from "./corpus.js";
+
+const ACCENTED = /[éèêëàâçùûôîïœÉÈÊÀÇÙÔÎ]/;
+const FRENCH_WORDS =
+  /\b(Confiance|insuffisante?|requis|politique|Résolution|Fusion|conflit|conflits|fichier|lignes?|bloc|côtés?|réussie|aucune?|impossible|manquante?)\b/i;
+
+/** Every user-visible string a single resolve() call produces. */
+function outputStrings(conflicted: string, filePath: string, options = {}): string[] {
+  const result = resolve(conflicted, filePath, options);
+  const out: string[] = [];
+  for (const r of result.resolutions) {
+    out.push(r.resolutionReason, r.hunk.explanation, r.hunk.trace.summary);
+    out.push(...r.hunk.trace.steps.map((s) => s.reason));
+    out.push(...r.hunk.confidence.boosters, ...r.hunk.confidence.penalties);
+  }
+  if (result.validation.syntaxError) out.push(result.validation.syntaxError);
+  return out.filter((s): s is string => typeof s === "string" && s.length > 0);
+}
+
+describe("engine output is English", () => {
+  it.each(CORPUS.map((f) => [f.id, f] as const))(
+    "%s produces no French output",
+    (_id, fixture) => {
+      const offenders = outputStrings(fixture.input, fixture.filePath, fixture.options ?? {})
+        .filter((s) => ACCENTED.test(s) || FRENCH_WORDS.test(s));
+
+      expect(offenders).toEqual([]);
+    },
+  );
+
+  it("the guard actually detects French, so a green run means something", () => {
+    // Without this, a bug that made outputStrings() return [] would leave every
+    // case above passing vacuously.
+    expect(ACCENTED.test("résolution triviale")).toBe(true);
+    expect(FRENCH_WORDS.test("Confiance medium insuffisante")).toBe(true);
+    expect(ACCENTED.test("Same edit on both sides")).toBe(false);
+    expect(FRENCH_WORDS.test("Same edit on both sides")).toBe(false);
+  });
+
+  it("reads a non-empty set of strings out of a real resolution", () => {
+    const strings = outputStrings(CORPUS[0].input, CORPUS[0].filePath, CORPUS[0].options ?? {});
+    expect(strings.length).toBeGreaterThan(3);
+  });
+});

--- a/packages/core/src/__tests__/format-resolvers.test.ts
+++ b/packages/core/src/__tests__/format-resolvers.test.ts
@@ -242,7 +242,7 @@ describe("Phase 7.3 — JSON resolver", () => {
       const result = tryResolveJsonConflict(base, ours, theirs);
 
       expect(result.merged).toBeNull();
-      expect(result.reason).toMatch(/parser ours/i);
+      expect(result.reason).toMatch(/parse ours/i);
     });
 
     it("retourne null si theirs n'est pas un JSON valide", () => {
@@ -253,7 +253,7 @@ describe("Phase 7.3 — JSON resolver", () => {
       const result = tryResolveJsonConflict(base, ours, theirs);
 
       expect(result.merged).toBeNull();
-      expect(result.reason).toMatch(/parser theirs/i);
+      expect(result.reason).toMatch(/parse theirs/i);
     });
   });
 

--- a/packages/core/src/__tests__/llm-refactoring-coupling.test.ts
+++ b/packages/core/src/__tests__/llm-refactoring-coupling.test.ts
@@ -1,5 +1,5 @@
 /**
- * Coupling entre `llmFallback` et `refactoringAware` (v2.7).
+ * Coupling entre `llmFallback` et `refactoringAware` (v3.4).
  *
  * Bug : les deux opt-ins sont indépendants dans `DEFAULT_OPTIONS`. Si un
  * utilisateur active `llmFallback` sans `refactoringAware`, un hunk de

--- a/packages/core/src/__tests__/patterns/insertion-at-boundary.test.ts
+++ b/packages/core/src/__tests__/patterns/insertion-at-boundary.test.ts
@@ -50,7 +50,7 @@ describe("F23 — insertion_at_boundary : liste de dépendances npm (diff3)", ()
 
   it("le booster 'Insertions pures' est présent", () => {
     const result = resolve(input, "package.json");
-    expect(result.hunks[0].confidence.boosters.join(" ")).toMatch(/Insertions pures/);
+    expect(result.hunks[0].confidence.boosters.join(" ")).toMatch(/Pure insertions/);
   });
 });
 

--- a/packages/core/src/__tests__/patterns/llm-proposed.test.ts
+++ b/packages/core/src/__tests__/patterns/llm-proposed.test.ts
@@ -113,7 +113,7 @@ describe("llm_proposed PatternPlugin — confidence", () => {
   it("penalties liste les risques LLM", () => {
     const score = llmProposed.confidence(SIMPLE_HUNK);
     expect(score.penalties.length).toBeGreaterThan(0);
-    expect(score.penalties.some((p) => p.toLowerCase().includes("llm") || p.toLowerCase().includes("déterministe"))).toBe(true);
+    expect(score.penalties.some((p) => p.toLowerCase().includes("llm") || p.toLowerCase().includes("deterministic"))).toBe(true);
   });
 });
 

--- a/packages/core/src/__tests__/patterns/reorder-only.test.ts
+++ b/packages/core/src/__tests__/patterns/reorder-only.test.ts
@@ -52,7 +52,7 @@ describe("F21 — reorder_only : exports triés alphabétiquement (diff3)", () =
 
   it("le booster 'Permutation pure' est présent", () => {
     const result = resolve(input, "src/index.ts");
-    expect(result.hunks[0].confidence.boosters.join(" ")).toMatch(/Permutation pure/);
+    expect(result.hunks[0].confidence.boosters.join(" ")).toMatch(/Pure permutation/);
   });
 });
 
@@ -135,7 +135,7 @@ describe("reorder_only avec lignes dupliquées (F32-like)", () => {
   it("applique la pénalité 'Lignes dupliquées'", () => {
     const result = resolve(input, "src/test.ts");
     const penalties = result.hunks[0].confidence.penalties.join(" ");
-    expect(penalties).toMatch(/dupliqu/i);
+    expect(penalties).toMatch(/duplicate/i);
   });
 
   it("le score est réduit par rapport au cas sans doublons", () => {

--- a/packages/core/src/__tests__/patterns/token-level-merge.test.ts
+++ b/packages/core/src/__tests__/patterns/token-level-merge.test.ts
@@ -150,10 +150,10 @@ describe("token_level_merge : cache keyed par référence (robustesse à l'entre
     // Ni detect(hunkB) ni classifyConflict(hunkB) n'ont été appelés ici — on
     // interroge directement explanation() sur hunkB. Avec un cache "dernier
     // calculé" non keyed, ceci retournerait à tort le pass1Count de hunkA (0).
-    expect(tokenLevelMerge.explanation(hunkB)).toContain("1 ligne résolue");
+    expect(tokenLevelMerge.explanation(hunkB)).toContain("1 line resolved line-by-line");
     // Et repasser sur hunkA doit toujours donner le résultat de hunkA, pas
     // celui de hunkB qu'on vient d'interroger.
-    expect(tokenLevelMerge.explanation(hunkA)).toContain("0 lignes résolues");
+    expect(tokenLevelMerge.explanation(hunkA)).toContain("0 lines resolved line-by-line");
   });
 
   it("explanation() sur un hunk jamais passé par detect() calcule quand même le bon résultat", () => {
@@ -162,8 +162,8 @@ describe("token_level_merge : cache keyed par référence (robustesse à l'entre
       ["ctx-ours", '<div class="a2 b">'],
       ["ctx", '<div class="a b2">'],
     ); // pass1: 1, pass2: 1
-    expect(tokenLevelMerge.explanation(neverDetected)).toContain("1 ligne résolue");
-    expect(tokenLevelMerge.explanation(neverDetected)).toContain("1 ligne fusionnée");
+    expect(tokenLevelMerge.explanation(neverDetected)).toContain("1 line resolved line-by-line");
+    expect(tokenLevelMerge.explanation(neverDetected)).toContain("1 line merged token-by-token");
   });
 });
 

--- a/packages/core/src/__tests__/patterns/value-only-change.test.ts
+++ b/packages/core/src/__tests__/patterns/value-only-change.test.ts
@@ -269,7 +269,7 @@ describe("value_only_change : résolution semver-max au lieu du côté-politique
       `>>>>>>> theirs`,
     ].join("\n");
     const result = resolve(input, "manifest.txt");
-    expect(result.hunks[0].explanation).not.toContain("la plus récente (theirs)");
+    expect(result.hunks[0].explanation).not.toContain("the more recent (theirs)");
   });
 });
 

--- a/packages/core/src/__tests__/regression-guard-tiers.test.ts
+++ b/packages/core/src/__tests__/regression-guard-tiers.test.ts
@@ -1,5 +1,5 @@
 /**
- * Garde de régression pour la métrique "recoverable-before-model" (v2.7).
+ * Garde de régression pour la métrique "recoverable-before-model" (v3.4).
  *
  * Design: docs/superpowers/specs/2026-07-07-recoverable-before-model-metric-design.md §4.C
  *
@@ -62,7 +62,7 @@ describe("Garde de régression — token_level_merge doit shrink le bucket AI-re
     }
 
     // Le corpus doit contenir au moins un cas dépendant de token_level_merge —
-    // sinon ce garde ne garde rien (cf. F46, la fixture Tailwind du v2.7).
+    // sinon ce garde ne garde rien (cf. F46, la fixture Tailwind du v3.4).
     expect(tokenLevelMergeCount).toBeGreaterThan(0);
 
     const countReachingModelOn = modelOrUnresolvedCount;

--- a/packages/core/src/__tests__/resolver.test.ts
+++ b/packages/core/src/__tests__/resolver.test.ts
@@ -889,7 +889,7 @@ return "hello";
       const result = resolve(complex, "utils.ts", { minConfidence: "low" });
       const res = result.resolutions[0];
       expect(res.autoResolved).toBe(false);
-      expect(res.resolutionReason).toMatch(/complexe|manuelle/i);
+      expect(res.resolutionReason).toMatch(/complex|manual/i);
     });
 
     it("mode explainOnly : classi fie sans résoudre", () => {

--- a/packages/core/src/__tests__/resolvers/json.test.ts
+++ b/packages/core/src/__tests__/resolvers/json.test.ts
@@ -53,7 +53,7 @@ describe("F1 — JSON : clé ajoutée d'un seul côté (diff3)", () => {
 
 // ─── F2 — même clé modifiée des deux côtés ────────────────────────────────────
 //
-// v2.7 : value_only_change couvre désormais le diff3 (requires "both"). Ce
+// v3.4 : value_only_change couvre désormais le diff3 (requires "both"). Ce
 // fixture — version bumpée différemment des deux côtés — est exactement son
 // cas nominal : résolution semver-max (3.0.0), déterministe. Avant, le hunk
 // restait complex et le refus portait la note [json] ; ces assertions

--- a/packages/core/src/__tests__/stats/tiers.test.ts
+++ b/packages/core/src/__tests__/stats/tiers.test.ts
@@ -1,5 +1,5 @@
 /**
- * summarizeTiers() — "recoverable-before-model" metric (v2.7).
+ * summarizeTiers() — "recoverable-before-model" metric (v3.4).
  *
  * Design: docs/superpowers/specs/2026-07-07-recoverable-before-model-metric-design.md §4.B
  *

--- a/packages/core/src/__tests__/with-base-availability.test.ts
+++ b/packages/core/src/__tests__/with-base-availability.test.ts
@@ -39,11 +39,11 @@ describe("withBaseAvailability — reste en phase avec makeScore", () => {
 
   it("reste rétro-compatible quand les deux dimensions sont à 0", () => {
     const cs = makeScore(90, 20, 15, [], []);
-    const adjusted = withBaseAvailability(cs, 100, "zdiff3 — base tronquée aux sections divergentes");
+    const adjusted = withBaseAvailability(cs, 100, "zdiff3: base truncated to the diverging sections");
 
     const expected = makeScore(90, 20, 15, [], [], 0, 100);
     expect(adjusted.score).toBe(expected.score);
     expect(adjusted.label).toBe(expected.label);
-    expect(adjusted.boosters).toContain("zdiff3 — base tronquée aux sections divergentes");
+    expect(adjusted.boosters).toContain("zdiff3: base truncated to the diverging sections");
   });
 });

--- a/packages/core/src/classifier.ts
+++ b/packages/core/src/classifier.ts
@@ -75,8 +75,8 @@ function buildTrace(
     if (!isEligible) {
       // Pattern sauté à cause du filtre `requires`
       const skipReason = pattern.requires === "diff3"
-        ? `Base (diff3) indisponible — ${pattern.type} requiert diff3, sauté.`
-        : `Base présente — ${pattern.type} requiert diff2 (sans base), sauté.`;
+        ? `Base (diff3) unavailable: ${pattern.type} requires diff3, skipped.`
+        : `Base present: ${pattern.type} requires diff2 (no base), skipped.`;
       steps.push({ type: pattern.type, passed: false, reason: skipReason });
       continue;
     }
@@ -100,22 +100,22 @@ function buildTrace(
 function buildSummary(type: ConflictType, h: ClassifyInput): string {
   const hasBase = h.baseLines.length > 0;
   switch (type) {
-    case "same_change":          return "Même modification des deux côtés → résolution triviale.";
+    case "same_change":          return "Same edit on both sides, so the resolution is trivial.";
     case "delete_no_change":     return hasBase
-      ? (h.oursLines.length === 0 ? "Ours a supprimé ce bloc, theirs est resté identique à la base." : "Theirs a supprimé ce bloc, ours est resté identique à la base.")
-      : (h.oursLines.length === 0 ? "Ours a supprimé ce bloc (diff2 — sans base, confiance moyenne)." : "Theirs a supprimé ce bloc (diff2 — sans base, confiance moyenne).");
+      ? (h.oursLines.length === 0 ? "Ours deleted this block; theirs stayed identical to the base." : "Theirs deleted this block; ours stayed identical to the base.")
+      : (h.oursLines.length === 0 ? "Ours deleted this block (diff2, no base, medium confidence)." : "Theirs deleted this block (diff2, no base, medium confidence).");
     case "one_side_change":      return h.oursLines.join("\n") === h.baseLines.join("\n")
-      ? "Seul theirs a modifié ce bloc — résolution : accepter theirs."
-      : "Seul ours a modifié ce bloc — résolution : accepter ours.";
-    case "non_overlapping":      return "Modifications non-overlapping — fusion automatique par LCS 3-way.";
-    case "whitespace_only":      return "Même code, whitespace différent — résolution : préférer ours.";
-    case "reorder_only":         return "Mêmes lignes, ordre différent — résolution : accepter l'ordre theirs.";
-    case "insertion_at_boundary": return "Insertions pures des deux côtés — résolution par union.";
-    case "value_only_change":    return "Même structure, valeur(s) volatile(s) différente(s) — résolution : accepter theirs.";
-    case "token_level_merge":    return "Fusion ligne/token proposée — confirmation utilisateur requise avant application.";
-    case "llm_proposed":         return "LLM fallback activé — résolution déléguée à l'endpoint LLM configuré.";
-    case "complex":              return "Conflit complexe — toutes les heuristiques automatiques ont échoué.";
-    default:                     return `Type détecté : ${type}.`;
+      ? "Only theirs modified this block. Resolution: take theirs."
+      : "Only ours modified this block. Resolution: take ours.";
+    case "non_overlapping":      return "Non-overlapping edits, merged automatically by 3-way LCS.";
+    case "whitespace_only":      return "Same code, different whitespace. Resolution: prefer ours.";
+    case "reorder_only":         return "Same lines in a different order. Resolution: take the theirs ordering.";
+    case "insertion_at_boundary": return "Pure insertions on both sides, resolved by union.";
+    case "value_only_change":    return "Same structure, differing volatile value(s). Resolution: take theirs.";
+    case "token_level_merge":    return "Line/token merge proposed. User confirmation is required before it is applied.";
+    case "llm_proposed":         return "LLM fallback enabled; resolution delegated to the configured LLM endpoint.";
+    case "complex":              return "Complex conflict: every automatic heuristic failed.";
+    default:                     return `Detected type: ${type}.`;
   }
 }
 

--- a/packages/core/src/classifier.ts
+++ b/packages/core/src/classifier.ts
@@ -20,7 +20,7 @@ import whitespaceOnly      from "./patterns/whitespace-only.js";
 import reorderOnly              from "./patterns/reorder-only.js";
 import insertionAtBoundary      from "./patterns/insertion-at-boundary.js";
 import valueOnlyChange          from "./patterns/value-only-change.js";
-import tokenLevelMerge          from "./patterns/token-level-merge.js";     // v2.7 — priority 65
+import tokenLevelMerge          from "./patterns/token-level-merge.js";     // v3.4 — priority 65
 import llmProposed         from "./patterns/llm-proposed.js";    // v2.5 — priority 998
 import refactoringAwareMerge from "./patterns/refactoring-aware-merge.js"; // v2.6 — priority 970
 import complex             from "./patterns/complex.js";
@@ -42,7 +42,7 @@ const PATTERNS: PatternPlugin[] = [
   reorderOnly,          // priority 55  ← v1.4
   insertionAtBoundary,  // priority 57  ← v1.4
   valueOnlyChange,        // priority 60
-  tokenLevelMerge,        // priority 65 ← v2.7 (jamais auto-appliqué, cf. assemble.ts)
+  tokenLevelMerge,        // priority 65 ← v3.4 (jamais auto-appliqué, cf. assemble.ts)
   refactoringAwareMerge, // priority 970 ← v2.6 (OFF par défaut, activé par resolve())
   llmProposed,            // priority 998 ← v2.5 (OFF par défaut, activé par resolveAsync)
   complex,               // priority 999 (fallback — detect() always true)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -120,7 +120,7 @@ export type {
   // v2.6 — Refactoring-aware merge
   RefactoringKind,
   Refactoring,
-  // v2.7 — Token-level merge
+  // v3.4 — Token-level merge
   TokenMergeTrace,
   TokenMergeLineDetail,
 } from "./types.js";
@@ -152,7 +152,7 @@ export type { PnpmLockMergeResult } from "./resolvers/lockfile-pnpm.js";
 export type { ImportSortStrategy } from "./resolvers/imports.js";
 export type { MergePolicy, PolicyConfig, GitWandrcConfig } from "./config.js";
 
-// v2.7 — "Recoverable-before-model" tier metric (derived, TS-only — see stats/tiers.ts)
+// v3.4 — "Recoverable-before-model" tier metric (derived, TS-only — see stats/tiers.ts)
 export { summarizeTiers } from "./stats/tiers.js";
 export type { ResolutionTier, TierSummary } from "./stats/tiers.js";
 

--- a/packages/core/src/parser.ts
+++ b/packages/core/src/parser.ts
@@ -166,7 +166,7 @@ export function toConflictHunk(conflict: RawConflict): ConflictHunk {
 
   const isZdiff3 = detectZdiff3(conflict);
   const adjustedConfidence = isZdiff3
-    ? withBaseAvailability(confidence, 100, "zdiff3 — base tronquée aux sections divergentes")
+    ? withBaseAvailability(confidence, 100, "zdiff3: base truncated to the diverging sections")
     : confidence;
 
   return {

--- a/packages/core/src/patterns/complex.ts
+++ b/packages/core/src/patterns/complex.ts
@@ -13,17 +13,17 @@ const complex: PatternPlugin = {
 
   confidence(_h: ClassifyInput): ConfidenceScore {
     return makeScore(100, 100, 0, [], [
-      "Aucune heuristique automatique applicable",
-      "Les deux branches ont modifié le bloc de façon incompatible",
+      "No automatic heuristic applies",
+      "Both branches modified the block in incompatible ways",
     ]);
   },
 
   explanation(_h: ClassifyInput): string {
-    return "Conflit complexe nécessitant une résolution manuelle. Les deux branches ont modifié ce bloc différemment.";
+    return "A genuine conflict that needs a human. Both branches modified this block differently.";
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Aucun pattern automatique ne s'applique — résolution manuelle requise.";
+    return "No automatic pattern applies; manual resolution required.";
   },
 
   failReason(_h: ClassifyInput): string {

--- a/packages/core/src/patterns/delete-no-change.ts
+++ b/packages/core/src/patterns/delete-no-change.ts
@@ -33,12 +33,12 @@ const deleteNoChange: PatternPlugin = {
       return makeScore(100, 5, 0, [
         "Base disponible",
         oursDeleted
-          ? "Ours a supprimé, theirs identique à la base"
-          : "Theirs a supprimé, ours identique à la base",
+          ? "Ours deleted, theirs identical to the base"
+          : "Theirs deleted, ours identical to the base",
       ], []);
     }
     return makeScore(60, 30, 0, [], [
-      "Sans base (diff2) — suppression non confirmée par rapport à l'ancêtre commun",
+      "No base (diff2): the deletion is not confirmed against the common ancestor",
     ]);
   },
 
@@ -48,14 +48,14 @@ const deleteNoChange: PatternPlugin = {
       const baseText = h.baseLines.join("\n");
       const theirsText = h.theirsLines.join("\n");
       if (h.oursLines.length === 0 && theirsText === baseText) {
-        return "La branche courante (ours) a supprimé ce bloc, l'autre ne l'a pas modifié. Résolution : supprimer.";
+        return "The current branch (ours) deleted this block and the other left it untouched. Resolution: delete.";
       }
-      return "La branche entrante (theirs) a supprimé ce bloc, l'autre ne l'a pas modifié. Résolution : supprimer.";
+      return "The incoming branch (theirs) deleted this block and the other left it untouched. Resolution: delete.";
     }
     if (h.oursLines.length === 0) {
-      return "La branche courante (ours) a supprimé ce bloc. Sans base, confiance moyenne. Résolution proposée : supprimer.";
+      return "The current branch (ours) deleted this block. Without a base, confidence is medium. Proposed resolution: delete.";
     }
-    return "La branche entrante (theirs) a supprimé ce bloc. Sans base, confiance moyenne. Résolution proposée : supprimer.";
+    return "The incoming branch (theirs) deleted this block. Without a base, confidence is medium. Proposed resolution: delete.";
   },
 
   passReason(h: ClassifyInput): string {
@@ -64,22 +64,22 @@ const deleteNoChange: PatternPlugin = {
       const baseText = h.baseLines.join("\n");
       const theirsText = h.theirsLines.join("\n");
       if (h.oursLines.length === 0 && theirsText === baseText) {
-        return "Ours a supprimé le bloc (0 lignes) et theirs n'a pas modifié la base.";
+        return "Ours deleted the block (0 lines) and theirs did not modify the base.";
       }
-      return "Theirs a supprimé le bloc (0 lignes) et ours n'a pas modifié la base.";
+      return "Theirs deleted the block (0 lines) and ours did not modify the base.";
     }
     if (h.oursLines.length === 0) {
-      return "Ours est vide (0 lignes) en diff2. Suppression probable mais incertaine sans base.";
+      return "Ours is empty (0 lines) in diff2. A deletion is likely but uncertain without a base.";
     }
-    return "Theirs est vide (0 lignes) en diff2. Suppression probable mais incertaine sans base.";
+    return "Theirs is empty (0 lines) in diff2. A deletion is likely but uncertain without a base.";
   },
 
   failReason(h: ClassifyInput): string {
     const hasBase = h.baseLines.length > 0;
     if (hasBase) {
-      return "Ni ours ni theirs n'est une suppression unilatérale avec l'autre côté identique à la base.";
+      return "Neither ours nor theirs is a one-sided deletion with the other side identical to the base.";
     }
-    return "Ni ours ni theirs n'est vide en diff2 — pas de suppression unilatérale évidente.";
+    return "Neither ours nor theirs is empty in diff2, so there is no obvious one-sided deletion.";
   },
 };
 

--- a/packages/core/src/patterns/insertion-at-boundary.ts
+++ b/packages/core/src/patterns/insertion-at-boundary.ts
@@ -133,7 +133,7 @@ const insertionAtBoundary: PatternPlugin = {
 
     if (hasBase) {
       return makeScore(90, 8, scopeImpact(totalLines), [
-        "Insertions pures — base intacte des deux côtés",
+        "Pure insertions, base intact on both sides",
       ], []);
     }
     return makeScore(68, 20, scopeImpact(totalLines), [], [
@@ -144,22 +144,22 @@ const insertionAtBoundary: PatternPlugin = {
   explanation(h: ClassifyInput): string {
     const hasBase = h.baseLines.length > 0;
     return hasBase
-      ? "Les deux branches ont uniquement ajouté des lignes sans modifier la base. Résolution : union des insertions (ours en premier)."
-      : "Les deux branches semblent avoir uniquement ajouté des lignes (heuristique diff2). Résolution : union (ours en premier).";
+      ? "Both branches only added lines without modifying the base. Resolution: union of the insertions, ours first."
+      : "Both branches appear to have only added lines (diff2 heuristic). Resolution: union, ours first.";
   },
 
   passReason(h: ClassifyInput): string {
     const hasBase = h.baseLines.length > 0;
     return hasBase
-      ? "Aucune suppression des deux côtés, insertions distinctes — insertions pures confirmées par la base."
-      : "Heuristique diff2 : les deux côtés sont des sur-ensembles l'un de l'autre.";
+      ? "No deletions on either side and the insertions are distinct: pure insertions confirmed against the base."
+      : "diff2 heuristic: each side is a superset of the other.";
   },
 
   failReason(h: ClassifyInput): string {
     const hasBase = h.baseLines.length > 0;
     return hasBase
-      ? "Au moins un côté a des suppressions ou des insertions qui se chevauchent."
-      : "La heuristique diff2 d'union échoue — des lignes sont présentes d'un côté mais absentes de l'autre de façon asymétrique.";
+      ? "At least one side has deletions, or insertions that overlap."
+      : "The diff2 union heuristic fails: some lines are present on one side and absent from the other, asymmetrically.";
   },
 };
 

--- a/packages/core/src/patterns/llm-proposed.ts
+++ b/packages/core/src/patterns/llm-proposed.ts
@@ -57,22 +57,22 @@ const llmProposed: PatternPlugin = {
       0,    // scopeImpact : inconnu à ce stade
       [],   // boosters
       [
-        "Résolution non déterministe (LLM)",
-        "Validation post-merge stricte requise avant acceptation",
+        "Non-deterministic resolution (LLM)",
+        "Strict post-merge validation required before acceptance",
       ],
     );
   },
 
   explanation(_h: ClassifyInput): string {
-    return "Résolution proposée par LLM fallback. Le hunk sera envoyé à l'endpoint LLM configuré pour une résolution assistée. La résolution sera validée (parse-tree + tsc/eslint) avant acceptation.";
+    return "Resolution proposed by the LLM fallback. The hunk is sent to the configured LLM endpoint for an assisted resolution, which is validated (parse tree plus tsc/eslint) before it can be accepted.";
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Aucun pattern déterministe applicable — délégation au LLM fallback (opt-in).";
+    return "No deterministic pattern applies; delegating to the LLM fallback (opt-in).";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "LLM fallback désactivé (options.llmFallback.enabled !== true).";
+    return "LLM fallback disabled (options.llmFallback.enabled !== true).";
   },
 };
 

--- a/packages/core/src/patterns/non-overlapping.ts
+++ b/packages/core/src/patterns/non-overlapping.ts
@@ -15,20 +15,20 @@ const nonOverlapping: PatternPlugin = {
     const mergedSize = Math.max(h.oursLines.length, h.theirsLines.length);
     return makeScore(90, 20, scopeImpact(mergedSize), [
       "Base disponible",
-      "Merge LCS 3-way réussi sans chevauchement",
+      "3-way LCS merge succeeded with no overlap",
     ], []);
   },
 
   explanation(_h: ClassifyInput): string {
-    return "Les deux branches ont modifié des zones différentes du même bloc. Fusion automatique possible.";
+    return "The branches modified different regions of the same block, so an automatic merge is possible.";
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Le merge 3-way LCS a réussi sans conflit — les modifications ne se chevauchent pas.";
+    return "The 3-way LCS merge succeeded with no conflict: the edits do not overlap.";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "Le merge 3-way LCS détecte un chevauchement — les deux branches ont modifié les mêmes lignes.";
+    return "The 3-way LCS merge detects an overlap: both branches modified the same lines.";
   },
 };
 

--- a/packages/core/src/patterns/one-side-change.ts
+++ b/packages/core/src/patterns/one-side-change.ts
@@ -22,7 +22,7 @@ const oneSideChange: PatternPlugin = {
     const changedLines = oursMatchesBase ? h.theirsLines.length : h.oursLines.length;
     return makeScore(100, 0, scopeImpact(changedLines), [
       "Base disponible",
-      oursMatchesBase ? "Seul theirs a modifié le bloc" : "Seul ours a modifié le bloc",
+      oursMatchesBase ? "Only theirs modified the block" : "Only ours modified the block",
     ], []);
   },
 
@@ -30,22 +30,22 @@ const oneSideChange: PatternPlugin = {
     const oursText = h.oursLines.join("\n");
     const baseText = h.baseLines.join("\n");
     if (oursText === baseText) {
-      return "Seule la branche entrante (theirs) a modifié ce bloc. Résolution : accepter theirs.";
+      return "Only the incoming branch (theirs) modified this block. Resolution: take theirs.";
     }
-    return "Seule la branche courante (ours) a modifié ce bloc. Résolution : accepter ours.";
+    return "Only the current branch (ours) modified this block. Resolution: take ours.";
   },
 
   passReason(h: ClassifyInput): string {
     const oursText = h.oursLines.join("\n");
     const baseText = h.baseLines.join("\n");
     if (oursText === baseText) {
-      return "Ours est identique à la base, seul theirs a changé.";
+      return "Ours is identical to the base; only theirs changed.";
     }
-    return "Theirs est identique à la base, seul ours a changé.";
+    return "Theirs is identical to the base; only ours changed.";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "Les deux branches ont modifié le bloc par rapport à la base.";
+    return "Both branches modified the block relative to the base.";
   },
 };
 

--- a/packages/core/src/patterns/refactoring-aware-merge.ts
+++ b/packages/core/src/patterns/refactoring-aware-merge.ts
@@ -108,8 +108,8 @@ const refactoringAwareMerge: PatternPlugin = {
       12,           // dataRisk : faible — merge déterministe, pas génératif
       scopeImpact(h.oursLines.length + h.theirsLines.length),
       [
-        "Refactoring bijectivement vérifié (substitution simulée)",
-        "Merge textuel réussi sur les versions inversées",
+        "Refactoring verified bijectively (simulated substitution)",
+        "Textual merge succeeded on the inverted versions",
       ],
       [],
     );
@@ -122,31 +122,31 @@ const refactoringAwareMerge: PatternPlugin = {
       const moves = refs.filter((r) => r.kind === "move-method");
       const parts: string[] = [];
       if (renames.length > 0) {
-        parts.push(`${renames.length} renommage(s) détecté(s) et inversé(s)`);
+        parts.push(`${renames.length} rename(s) detected and inverted`);
       }
       if (moves.length > 0) {
-        parts.push(`${moves.length} déplacement(s) de méthode`);
+        parts.push(`${moves.length} method move(s)`);
       }
-      return `Conflit de refactoring — ${parts.join(", ") || "refactoring détecté"}. Résolu via le pipeline RefMerge (inversion + merge + rejeu).`;
+      return `Refactoring conflict: ${parts.join(", ") || "refactoring detected"}. Resolved through the RefMerge pipeline (invert, merge, replay).`;
     }
-    return "Conflit causé par un refactoring concurrent — résolu via le pipeline RefMerge.";
+    return "Conflict caused by a concurrent refactoring, resolved through the RefMerge pipeline.";
   },
 
   passReason(_h: ClassifyInput): string {
     if (_lastResult?.oursRefs.length || _lastResult?.theirsRefs.length) {
-      return `Refactoring(s) détecté(s) : ours=${_lastResult!.oursRefs.length}, theirs=${_lastResult!.theirsRefs.length}. Merge textuel réussi après inversion.`;
+      return `Refactoring(s) detected: ours=${_lastResult!.oursRefs.length}, theirs=${_lastResult!.theirsRefs.length}. Textual merge succeeded after inversion.`;
     }
-    return "Refactoring bijectivement détecté — merge réussi après inversion.";
+    return "Refactoring detected bijectively; merge succeeded after inversion.";
   },
 
   failReason(_h: ClassifyInput): string {
     if (!_refMergeEnabled) {
-      return "RefMerge désactivé (options.refactoringAware.enabled !== true).";
+      return "RefMerge disabled (options.refactoringAware.enabled !== true).";
     }
     if (_lastResult && _lastResult.lines === null) {
-      return `RefMerge échoué : ${_lastResult.reason}`;
+      return `RefMerge failed: ${_lastResult.reason}`;
     }
-    return "Aucun refactoring bijectivement détectable dans ce hunk.";
+    return "No bijectively detectable refactoring in this hunk.";
   },
 };
 

--- a/packages/core/src/patterns/reorder-only.ts
+++ b/packages/core/src/patterns/reorder-only.ts
@@ -60,11 +60,11 @@ const reorderOnly: PatternPlugin = {
     const duplicates = hasDuplicates(ours);
     const si = scopeImpact(h.oursLines.length);
 
-    const boosters = ["Permutation pure — mêmes lignes, ordre différent"];
+    const boosters = ["Pure permutation: same lines, different order"];
     const penalties: string[] = [];
 
     if (duplicates) {
-      penalties.push("Lignes dupliquées — ordre ambigu (−10)");
+      penalties.push("Duplicate lines make the ordering ambiguous (−10)");
     }
 
     // typeClassification 92 sauf si doublons (−10 → 82)
@@ -75,16 +75,16 @@ const reorderOnly: PatternPlugin = {
   explanation(h: ClassifyInput): string {
     const hasBase = h.baseLines.length > 0;
     return hasBase
-      ? "Les deux branches contiennent les mêmes lignes dans un ordre différent. Résolution : accepter l'ordre theirs (ou ours si la base correspond à theirs)."
-      : "Les deux branches contiennent les mêmes lignes dans un ordre différent. Résolution : accepter l'ordre theirs.";
+      ? "Both branches contain the same lines in a different order. Resolution: take the theirs ordering, or ours when the base matches theirs."
+      : "Both branches contain the same lines in a different order. Resolution: take the theirs ordering.";
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Les deux côtés sont des permutations l'un de l'autre — mêmes lignes, ordre différent.";
+    return "Each side is a permutation of the other: same lines, different order.";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "Les lignes ne sont pas une simple permutation — des ajouts ou suppressions sont présents.";
+    return "The lines are not a plain permutation: there are additions or deletions.";
   },
 };
 

--- a/packages/core/src/patterns/same-change.ts
+++ b/packages/core/src/patterns/same-change.ts
@@ -12,20 +12,20 @@ const sameChange: PatternPlugin = {
 
   confidence(h: ClassifyInput): ConfidenceScore {
     return makeScore(100, 0, scopeImpact(h.oursLines.length), [
-      "Les deux branches ont exactement le même contenu",
+      "Both branches have exactly the same content",
     ], []);
   },
 
   explanation(_h: ClassifyInput): string {
-    return "Les deux branches ont effectué exactement la même modification.";
+    return "Both branches made exactly the same edit.";
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Les deux branches ont exactement le même contenu — modification identique des deux côtés.";
+    return "Both branches have exactly the same content: an identical edit on each side.";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "Les deux branches ont des contenus différents.";
+    return "The branches have different content.";
   },
 };
 

--- a/packages/core/src/patterns/token-level-merge.ts
+++ b/packages/core/src/patterns/token-level-merge.ts
@@ -144,25 +144,25 @@ const tokenLevelMerge: PatternPlugin = {
     // dataRisk volontairement non-nul : ce pattern ne doit JAMAIS s'auto-appliquer,
     // quel que soit le score obtenu (cf. resolver/assemble.ts — case dédié).
     return makeScore(70, 38, scopeImpact(totalLines), [
-      "Décomposition ligne-par-ligne et token-level réussie",
+      "Line-by-line and token-level decomposition succeeded",
     ], [
-      "Résolution proposée — jamais auto-appliquée, confirmation utilisateur requise",
+      "Resolution proposed: never auto-applied, user confirmation required",
     ]);
   },
 
   explanation(h: ClassifyInput): string {
     const result = computeTokenMergeCached(h);
-    if (!result) return "Fusion token-level proposée.";
+    if (!result) return "Token-level merge proposed.";
     const { pass1Count, pass2Count } = result;
-    return `Fusion proposée : ${pass1Count} ligne${pass1Count === 1 ? "" : "s"} résolue${pass1Count === 1 ? "" : "s"} ligne-par-ligne, ${pass2Count} ligne${pass2Count === 1 ? "" : "s"} fusionnée${pass2Count === 1 ? "" : "s"} token-par-token. Confirmation requise avant application.`;
+    return `Merge proposed: ${pass1Count} line${pass1Count === 1 ? "" : "s"} resolved line-by-line, ${pass2Count} line${pass2Count === 1 ? "" : "s"} merged token-by-token. Confirmation required before it is applied.`;
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Décomposition ligne-par-ligne + diff token-level réussis sur toutes les lignes du hunk.";
+    return "Line-by-line decomposition and token-level diff succeeded on every line of the hunk.";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "Au moins une ligne résiste (vrai conflit token-level ou désalignement de tokens) — pas de résolution partielle.";
+    return "At least one line resists (a real token-level conflict, or misaligned tokens), and partial resolutions are not offered.";
   },
 };
 

--- a/packages/core/src/patterns/utils.ts
+++ b/packages/core/src/patterns/utils.ts
@@ -365,21 +365,21 @@ export function detectValueOnlyChange(
   if (typeClassification < 55) return null;
 
   const si = scopeImpact(oursLines.length);
-  const penalties = [`Ratio de différences : ${(diffRatio * 100).toFixed(1)}%`];
-  if (!hasBase) penalties.push("Sans base (diff2) — heuristique basée sur les patterns volatils");
+  const penalties = [`Difference ratio: ${(diffRatio * 100).toFixed(1)}%`];
+  if (!hasBase) penalties.push("No base (diff2): heuristic based on volatile-value patterns alone");
   const confidenceScore = makeScore(typeClassification, 25, si, [
-    `${diffCount} token${diffCount > 1 ? "s" : ""} identifié${diffCount > 1 ? "s" : ""} comme volatile${diffCount > 1 ? "s" : ""} (hash, version, timestamp…)`,
-    "Même structure de lignes",
-    ...(hasBase ? ["Base disponible — les deux côtés ont changé la valeur"] : []),
+    `${diffCount} token${diffCount > 1 ? "s" : ""} identified as volatile (hash, version, timestamp…)`,
+    "Same line structure",
+    ...(hasBase ? ["Base available: both sides changed the value"] : []),
   ], penalties, 0, hasBase ? 100 : 0);
 
   if (confidenceScore.label === "low") return null;
 
   const explanation =
-    `Même structure avec ${diffCount} valeur${diffCount > 1 ? "s" : ""} volatile${diffCount > 1 ? "s" : ""} différente${diffCount > 1 ? "s" : ""} (hash, version, timestamp…). Résolution : semver le plus élevé si comparable, sinon selon la politique de merge.`;
+    `Same structure with ${diffCount} differing volatile value${diffCount > 1 ? "s" : ""} (hash, version, timestamp…). Resolution: the higher semver when comparable, otherwise whatever the merge policy says.`;
 
   const traceReason =
-    `${diffCount} token${diffCount > 1 ? "s" : ""} différent${diffCount > 1 ? "s" : ""} sur ${totalTokens} — tous identifiés comme volatiles (hash, version, timestamp…). Ratio : ${(diffRatio * 100).toFixed(1)}% → score ${confidenceScore.score} (${confidenceScore.label}).`;
+    `${diffCount} of ${totalTokens} tokens differ, all identified as volatile (hash, version, timestamp…). Ratio: ${(diffRatio * 100).toFixed(1)}%, score ${confidenceScore.score} (${confidenceScore.label}).`;
 
   return { confidenceScore, explanation, traceReason };
 }

--- a/packages/core/src/patterns/value-only-change.ts
+++ b/packages/core/src/patterns/value-only-change.ts
@@ -4,7 +4,7 @@ import { makeScore, detectValueOnlyChange } from "./utils.js";
 const valueOnlyChange: PatternPlugin = {
   type: "value_only_change",
   priority: 60,
-  // "both" depuis v2.7 : avec base (diff3), un changement unilatéral est déjà
+  // "both" depuis v3.4 : avec base (diff3), un changement unilatéral est déjà
   // pris par one_side_change (prio 30) — ce pattern ne voit donc que les cas
   // où LES DEUX côtés ont changé la valeur. En "diff2" il était inatteignable
   // dès que la base recovery du desktop enrichissait le conflit.

--- a/packages/core/src/patterns/value-only-change.ts
+++ b/packages/core/src/patterns/value-only-change.ts
@@ -19,24 +19,24 @@ const valueOnlyChange: PatternPlugin = {
     const result = detectValueOnlyChange(h.oursLines, h.theirsLines, h.baseLines.length > 0);
     if (result) return result.confidenceScore;
     // Fallback (ne devrait pas être appelé si detect() retourne false)
-    return makeScore(0, 100, 0, [], ["Erreur interne : confidence() appelé sans match"]);
+    return makeScore(0, 100, 0, [], ["Internal error: confidence() called without a match"]);
   },
 
   explanation(h: ClassifyInput): string {
     const result = detectValueOnlyChange(h.oursLines, h.theirsLines, h.baseLines.length > 0);
-    return result?.explanation ?? "Valeurs volatiles différentes.";
+    return result?.explanation ?? "Differing volatile values.";
   },
 
   passReason(h: ClassifyInput): string {
     const result = detectValueOnlyChange(h.oursLines, h.theirsLines, h.baseLines.length > 0);
-    return result?.traceReason ?? "Valeurs atomiques identifiées comme volatiles.";
+    return result?.traceReason ?? "Atomic values identified as volatile.";
   },
 
   failReason(h: ClassifyInput): string {
     if (h.oursLines.length !== h.theirsLines.length) {
-      return "Ours et theirs n'ont pas le même nombre de lignes — structure différente.";
+      return "Ours and theirs do not have the same number of lines, so the structure differs.";
     }
-    return "Les différences entre ours et theirs ne se limitent pas à des valeurs volatiles (hash, version, timestamp…).";
+    return "The differences between ours and theirs go beyond volatile values (hash, version, timestamp…).";
   },
 };
 

--- a/packages/core/src/patterns/whitespace-only.ts
+++ b/packages/core/src/patterns/whitespace-only.ts
@@ -29,24 +29,24 @@ const whitespaceOnly: PatternPlugin = {
       scopeImpact(lines),
       hasBase
         ? [
-            "Base disponible — whitespace confirmé par rapport à l'ancêtre",
-            "Seul le whitespace diffère après normalisation",
+            "Base available: whitespace confirmed against the ancestor",
+            "Only whitespace differs after normalisation",
           ]
-        : ["Seul le whitespace diffère après normalisation (trim)"],
-      hasBase ? [] : ["Sans base (diff2) — hypothèse basée sur la normalisation uniquement"],
+        : ["Only whitespace differs after normalisation (trim)"],
+      hasBase ? [] : ["No base (diff2): the assumption rests on normalisation alone"],
     );
   },
 
   explanation(_h: ClassifyInput): string {
-    return "Les deux branches contiennent le même code avec des différences de whitespace uniquement.";
+    return "Both branches contain the same code, differing only in whitespace.";
   },
 
   passReason(_h: ClassifyInput): string {
-    return "Après normalisation (trim), les deux versions sont identiques — seul le whitespace diffère.";
+    return "After normalisation (trim) the two versions are identical: only whitespace differs.";
   },
 
   failReason(_h: ClassifyInput): string {
-    return "Après normalisation (trim), les deux versions restent différentes — pas seulement du whitespace.";
+    return "After normalisation (trim) the two versions still differ, so this is more than whitespace.";
   },
 };
 

--- a/packages/core/src/refactoring/orchestration.ts
+++ b/packages/core/src/refactoring/orchestration.ts
@@ -138,7 +138,7 @@ export function tryRefMerge(
     if (oursRefs.length === 0 && theirsRefs.length === 0) {
       return {
         lines: null,
-        reason: "RefMerge : aucun refactoring détecté — fallback au pipeline standard.",
+        reason: "RefMerge: no refactoring detected, falling back to the standard pipeline.",
         oursRefs: [],
         theirsRefs: [],
       };
@@ -164,7 +164,7 @@ export function tryRefMerge(
     if (mergedInverted === null) {
       return {
         lines: null,
-        reason: "RefMerge : chevauchement résiduel après inversion — fallback au pipeline standard.",
+        reason: "RefMerge: residual overlap after inversion, falling back to the standard pipeline.",
         oursRefs,
         theirsRefs,
       };
@@ -177,7 +177,7 @@ export function tryRefMerge(
     const summary = summarizeRefs(oursRefs, theirsRefs);
     return {
       lines: finalLines,
-      reason: `RefMerge : ${summary} — résolution par inversion+merge+rejeu.`,
+      reason: `RefMerge: ${summary}. Resolved by invert, merge and replay.`,
       oursRefs,
       theirsRefs,
     };

--- a/packages/core/src/resolver/assemble.ts
+++ b/packages/core/src/resolver/assemble.ts
@@ -185,7 +185,7 @@ export function assembleResolution(
     }
 
     case "token_level_merge":
-      // v2.7 — Résolution toujours différée à la confirmation utilisateur (frontend).
+      // v3.4 — Résolution toujours différée à la confirmation utilisateur (frontend).
       // La proposition calculée est disponible dans hunk.trace.tokenMergeTrace.
       return {
         lines: null,

--- a/packages/core/src/resolver/assemble.ts
+++ b/packages/core/src/resolver/assemble.ts
@@ -34,7 +34,7 @@ export function assembleResolution(
     case "same_change":
       return {
         lines: [...hunk.oursLines],
-        reason: "Même modification des deux côtés — résolution triviale (ours = theirs).",
+        reason: "Same edit on both sides, so the resolution is trivial (ours = theirs).",
       };
 
     case "one_side_change": {
@@ -43,12 +43,12 @@ export function assembleResolution(
       if (oursText === baseText) {
         return {
           lines: [...hunk.theirsLines],
-          reason: "Ours = base → seul theirs a changé. Résolution : accepter theirs.",
+          reason: "Ours = base, so only theirs changed. Resolution: take theirs.",
         };
       } else {
         return {
           lines: [...hunk.oursLines],
-          reason: "Theirs = base → seul ours a changé. Résolution : accepter ours.",
+          reason: "Theirs = base, so only ours changed. Resolution: take ours.",
         };
       }
     }
@@ -56,7 +56,7 @@ export function assembleResolution(
     case "delete_no_change":
       return {
         lines: [],
-        reason: "Un côté a supprimé le bloc, l'autre n'a pas touché. Résolution : supprimer (0 lignes).",
+        reason: "One side deleted the block and the other left it untouched. Resolution: delete (0 lines).",
       };
 
     case "reorder_only": {
@@ -75,7 +75,7 @@ export function assembleResolution(
       }
       return {
         lines: preferred,
-        reason: `Permutation pure — mêmes lignes, ordre différent. Résolution : accepter ${side}.`,
+        reason: `Pure permutation: same lines, different order. Resolution: take ${side}.`,
       };
     }
 
@@ -112,7 +112,7 @@ export function assembleResolution(
       }
       return {
         lines: merged,
-        reason: `Insertions pures — union des ${hasBase ? "insertions (base + ours + theirs)" : "lignes (heuristique diff2)"}. ${merged.length} lignes dans le résultat.`,
+        reason: `Pure insertions: union of the ${hasBase ? "insertions (base + ours + theirs)" : "lines (diff2 heuristic)"}. ${merged.length} lines in the result.`,
       };
     }
 
@@ -121,14 +121,14 @@ export function assembleResolution(
         return {
           lines: null,
           reason: !policyCfg.allowWhitespace
-            ? `Résolution whitespace désactivée par la politique "${effectivePolicy}".`
-            : "Résolution whitespace désactivée par options (resolveWhitespace: false).",
+            ? `Whitespace resolution disabled by the "${effectivePolicy}" policy.`
+            : "Whitespace resolution disabled by options (resolveWhitespace: false).",
         };
       }
       const wsSide = policyCfg.preferOurs ? "ours" : "theirs";
       return {
         lines: policyCfg.preferOurs ? [...hunk.oursLines] : [...hunk.theirsLines],
-        reason: `Seul le whitespace diffère. Résolution : préférer ${wsSide} (politique : ${effectivePolicy}).`,
+        reason: `Only whitespace differs. Resolution: prefer ${wsSide} (policy: ${effectivePolicy}).`,
       };
     }
 
@@ -137,8 +137,8 @@ export function assembleResolution(
         return {
           lines: null,
           reason: !policyCfg.allowNonOverlapping
-            ? `Résolution non-overlapping désactivée par la politique "${effectivePolicy}".`
-            : "Résolution non-overlapping désactivée par options (resolveNonOverlapping: false).",
+            ? `Non-overlapping resolution disabled by the "${effectivePolicy}" policy.`
+            : "Non-overlapping resolution disabled by options (resolveNonOverlapping: false).",
         };
       }
       const merged = mergeNonOverlapping(
@@ -149,12 +149,12 @@ export function assembleResolution(
       if (merged !== null) {
         return {
           lines: merged,
-          reason: `Merge LCS 3-way réussi — ${merged.length} lignes dans le résultat fusionné.`,
+          reason: `3-way LCS merge succeeded: ${merged.length} lines in the merged result.`,
         };
       }
       return {
         lines: null,
-        reason: "Le merge LCS 3-way a échoué (chevauchement détecté au moment de la résolution).",
+        reason: "The 3-way LCS merge failed (an overlap was detected at resolution time).",
       };
     }
 
@@ -162,7 +162,7 @@ export function assembleResolution(
       if (!policyCfg.allowValueOnly) {
         return {
           lines: null,
-          reason: `Résolution value_only_change désactivée par la politique "${effectivePolicy}".`,
+          reason: `value_only_change resolution disabled by the "${effectivePolicy}" policy.`,
         };
       }
       // Quand toutes les paires de tokens différents sont des semver
@@ -173,14 +173,14 @@ export function assembleResolution(
       if (semverSide !== null) {
         return {
           lines: semverSide === "ours" ? [...hunk.oursLines] : [...hunk.theirsLines],
-          reason: `Même structure, version(s) semver différente(s). Résolution : accepter ${semverSide} (version la plus élevée).`,
+          reason: `Same structure, differing semver version(s). Resolution: take ${semverSide} (the higher version).`,
         };
       }
       const preferred = policyCfg.preferOurs ? hunk.oursLines : hunk.theirsLines;
       const side = policyCfg.preferOurs ? "ours" : "theirs";
       return {
         lines: [...preferred],
-        reason: `Même structure, valeur(s) volatile(s) différente(s). Résolution : accepter ${side} (politique : ${effectivePolicy}).`,
+        reason: `Same structure, differing volatile value(s). Resolution: take ${side} (policy: ${effectivePolicy}).`,
       };
     }
 
@@ -189,7 +189,7 @@ export function assembleResolution(
       // La proposition calculée est disponible dans hunk.trace.tokenMergeTrace.
       return {
         lines: null,
-        reason: "token_level_merge : fusion proposée, confirmation utilisateur requise avant application.",
+        reason: "token_level_merge: merge proposed, user confirmation required before it is applied.",
       };
 
     case "generated_file": {
@@ -201,13 +201,13 @@ export function assembleResolution(
       if (oursStripped === theirsStripped) {
         return {
           lines: [...hunk.theirsLines],
-          reason: "Fichier auto-généré — contenu structurel identique (seules les valeurs volatiles diffèrent). Résolution : accepter theirs. Suggestion : relancer le build/install.",
+          reason: "Generated file with identical structure (only volatile values differ). Resolution: take theirs. Suggestion: re-run the build or install.",
         };
       }
 
       return {
         lines: [...hunk.theirsLines],
-        reason: "Fichier auto-généré — le fichier sera régénéré après merge. Résolution : accepter theirs. Suggestion : relancer le build/install.",
+        reason: "Generated file: it will be rebuilt after the merge. Resolution: take theirs. Suggestion: re-run the build or install.",
       };
     }
 
@@ -221,7 +221,7 @@ export function assembleResolution(
       // Fallback si le cache est invalide (ne devrait pas arriver)
       return {
         lines: null,
-        reason: "RefMerge : résultat non disponible en cache — résolution manuelle requise.",
+        reason: "RefMerge: no cached result available, so manual resolution is required.",
       };
     }
 
@@ -230,19 +230,19 @@ export function assembleResolution(
       // assembleResolution() n'est pas censé être appelé directement pour llm_proposed.
       return {
         lines: null,
-        reason: "llm_proposed : résolution différée au pipeline LLM asynchrone.",
+        reason: "llm_proposed: resolution deferred to the asynchronous LLM pipeline.",
       };
 
     case "complex":
       return {
         lines: null,
-        reason: "Conflit complexe — aucune heuristique automatique applicable. Résolution manuelle requise.",
+        reason: "Complex conflict: no automatic heuristic applies. Manual resolution required.",
       };
 
     default:
       return {
         lines: null,
-        reason: `Type de conflit inconnu : ${hunk.type}.`,
+        reason: `Unknown conflict type: ${hunk.type}.`,
       };
   }
 }

--- a/packages/core/src/resolver/format-dispatch.ts
+++ b/packages/core/src/resolver/format-dispatch.ts
@@ -54,14 +54,14 @@ export function dispatchFormatAware(
     if (!options.resolveNonOverlapping) {
       return {
         status: "rejected-policy",
-        reason: "Résolution d'imports (non-overlapping) désactivée par options (resolveNonOverlapping: false).",
+        reason: "Import resolution (non-overlapping) disabled by options (resolveNonOverlapping: false).",
       };
     }
     const { policy, cfg } = computeEffectivePolicy(filePath, options);
     if (!cfg.allowNonOverlapping) {
       return {
         status: "rejected-policy",
-        reason: `Résolution d'imports (non-overlapping) désactivée par la politique "${policy}".`,
+        reason: `Import resolution (non-overlapping) disabled by the "${policy}" policy.`,
       };
     }
   }

--- a/packages/core/src/resolver/generated-detection.ts
+++ b/packages/core/src/resolver/generated-detection.ts
@@ -18,7 +18,7 @@ export const GENERATED_FILE_PATTERNS: Array<{ pattern: RegExp; label: string }> 
   { pattern: /composer\.lock$/i, label: "composer lockfile" },
   { pattern: /Gemfile\.lock$/i, label: "bundler lockfile" },
   { pattern: /Cargo\.lock$/i, label: "cargo lockfile" },
-  { pattern: /\.min\.(js|css)$/i, label: "fichier minifié" },
+  { pattern: /\.min\.(js|css)$/i, label: "minified file" },
   { pattern: /\bdist\//, label: "fichier build dist/" },
   { pattern: /\bbuild\/manifest\.json$/i, label: "manifest de build" },
   { pattern: /\.bundle\.(js|css)$/i, label: "bundle" },
@@ -106,31 +106,31 @@ export function reclassifyIfGenerated(
       fileFrequency: 0,
       baseAvailability: 0,
     },
-    boosters: [`Chemin correspond au pattern de fichier auto-généré : ${genInfo.label}`],
-    penalties: ["Le contenu sera régénéré — theirs est supposé plus récent"],
+    boosters: [`Path matches the generated-file pattern: ${genInfo.label}`],
+    penalties: ["The content will be regenerated, so theirs is assumed to be the more recent"],
   };
 
   return {
     ...hunk,
     type: "generated_file",
     confidence: generatedScore,
-    explanation: `Fichier auto-généré (${genInfo.label}). Ce fichier sera régénéré après le merge. Résolution proposée : accepter theirs et relancer le build.`,
+    explanation: `Generated file (${genInfo.label}). It will be rebuilt after the merge. Proposed resolution: take theirs and re-run the build.`,
     // Update the trace to reflect the reclassification
     trace: {
       ...hunk.trace,
       selected: "generated_file",
-      summary: `Fichier auto-généré (${genInfo.label}) — reclassifié depuis complex.`,
+      summary: `Generated file (${genInfo.label}), reclassified out of complex.`,
       steps: [
         ...hunk.trace.steps.slice(0, -1), // remove the "complex passed: true" step
         {
           type: "complex" as ConflictType,
           passed: false,
-          reason: `Reclassifié : fichier auto-généré (${genInfo.label}) détecté par son chemin.`,
+          reason: `Reclassified: generated file (${genInfo.label}) detected by its path.`,
         },
         {
           type: "generated_file" as ConflictType,
           passed: true,
-          reason: `Chemin correspond au pattern de fichier auto-généré : ${genInfo.label}.`,
+          reason: `Path matches the generated-file pattern: ${genInfo.label}.`,
         },
       ],
     },

--- a/packages/core/src/resolver/index.ts
+++ b/packages/core/src/resolver/index.ts
@@ -66,7 +66,7 @@ function resolveHunk(
   if (options.explainOnly) {
     return {
       lines: null,
-      reason: `Mode explain-only : résolution non appliquée (type: ${hunk.type}, confiance: ${hunk.confidence.label} [score: ${hunk.confidence.score}]).`,
+      reason: `Explain-only mode: no resolution applied (type: ${hunk.type}, confidence: ${hunk.confidence.label} [score: ${hunk.confidence.score}]).`,
     };
   }
 
@@ -91,7 +91,7 @@ function resolveHunk(
   if (CONFIDENCE_ORDER[hunk.confidence.label] < CONFIDENCE_ORDER[effectiveMinConfidence]) {
     return {
       lines: null,
-      reason: `Confiance ${hunk.confidence.label} (score: ${hunk.confidence.score}) insuffisante (minimum requis : ${effectiveMinConfidence}, politique : ${effectivePolicy}).${dispatch.note ? ` [${dispatch.note}]` : ""}`,
+      reason: `Confidence ${hunk.confidence.label} (score: ${hunk.confidence.score}) is below the ${effectiveMinConfidence} required by the ${effectivePolicy} policy.${dispatch.note ? ` [${dispatch.note}]` : ""}`,
     };
   }
 

--- a/packages/core/src/resolver/index.ts
+++ b/packages/core/src/resolver/index.ts
@@ -285,7 +285,7 @@ export async function resolveAsync(
   //   Le flag est réinitialisé immédiatement après `resolve()` — il ne doit pas
   //   persister entre appels (module-level state, potentiellement partagé).
   const llmEnabled = !!(options.llmFallback?.enabled && options.llmFallback?.endpoint);
-  // Coupling fix (v2.7) — the LLM path must only be reachable for hunks no
+  // Coupling fix (v3.4) — the LLM path must only be reachable for hunks no
   // enabled deterministic pattern can resolve. Force refactoringAware on
   // whenever llmFallback is on, so a rename-on-both-sides hunk never skips
   // the deterministic recoverer just because the user only opted into the LLM.

--- a/packages/core/src/resolver/llm-pipeline.ts
+++ b/packages/core/src/resolver/llm-pipeline.ts
@@ -181,7 +181,7 @@ export async function runLlmFallbackPhase(
         ...updatedHunks[idx],
         trace: {
           ...updatedHunks[idx].trace,
-          summary: `${updatedHunks[idx].trace.summary} | LLM refusé: ${llmResult.reason}`,
+          summary: `${updatedHunks[idx].trace.summary} | LLM rejected: ${llmResult.reason}`,
           llmTrace: llmResult.llmTrace,
         },
       };
@@ -189,7 +189,7 @@ export async function runLlmFallbackPhase(
       updatedResolutions[idx] = {
         ...updatedResolutions[idx],
         hunk: updatedHunk,
-        resolutionReason: `${updatedResolutions[idx].resolutionReason} | LLM refusé: ${llmResult.reason}`,
+        resolutionReason: `${updatedResolutions[idx].resolutionReason} | LLM rejected: ${llmResult.reason}`,
       };
     }
   }

--- a/packages/core/src/resolver/policy.ts
+++ b/packages/core/src/resolver/policy.ts
@@ -130,7 +130,7 @@ export function applyFileFrequencyPenalty(
       dimensions: { ...d, fileFrequency: ff },
       penalties: [
         ...hunk.confidence.penalties,
-        `Zone chaude — ${priorComplexHunks} hunk${priorComplexHunks > 1 ? "s" : ""} complexe${priorComplexHunks > 1 ? "s" : ""} déjà vus dans ce fichier (−${(ff * 0.10).toFixed(1)} pts)`,
+        `Hot spot: ${priorComplexHunks} complex hunk${priorComplexHunks > 1 ? "s" : ""} already seen in this file (−${(ff * 0.10).toFixed(1)} pts)`,
       ],
     },
   };

--- a/packages/core/src/resolver/validate-parse-tree.ts
+++ b/packages/core/src/resolver/validate-parse-tree.ts
@@ -89,7 +89,7 @@ export function applyPostMergeRiskPenalty<
     autoResolved: false,
     resolvedLines: null,
     resolutionReason:
-      "Rétracté : le contenu fusionné contient des erreurs syntaxiques (parse-tree tree-sitter). Intervention manuelle requise.",
+      "Retracted: the merged content contains syntax errors (tree-sitter parse-tree). Manual intervention required.",
     hunk: {
       ...resolution.hunk,
       confidence: {
@@ -102,7 +102,7 @@ export function applyPostMergeRiskPenalty<
         },
         penalties: [
           ...resolution.hunk.confidence.penalties,
-          "v2.4 — Parse-tree invalide après résolution automatique",
+          "Parse-tree invalid after automatic resolution",
         ],
       },
     },

--- a/packages/core/src/resolvers/cargo.ts
+++ b/packages/core/src/resolvers/cargo.ts
@@ -191,7 +191,7 @@ export function tryResolveCargoTomlConflict(
       // Conflit sur une section non reconnue → fallback
       return {
         lines: null,
-        reason: `[cargo] Section "${header}" modifiée des deux côtés — fallback textuel.`,
+        reason: `[cargo] Section "${header}" modified on both sides, falling back to the textual engine.`,
       };
     }
   }
@@ -203,7 +203,7 @@ export function tryResolveCargoTomlConflict(
 
   return {
     lines: result,
-    reason: "Cargo.toml — merge par nom de crate (union des dépendances, prefer-theirs en cas de conflit de version).",
+    reason: "Cargo.toml merged by crate name (union of dependencies, prefer-theirs on a version conflict).",
   };
 }
 
@@ -302,7 +302,7 @@ export function tryResolveCargoLockConflict(
 
   return {
     lines: result,
-    reason: "Cargo.lock — merge par crate name+version (union, prefer-theirs). Vérification recommandée : `cargo check`.",
+    reason: "Cargo.lock merged by crate name and version (union, prefer-theirs). Recommended check: `cargo check`.",
   };
 }
 

--- a/packages/core/src/resolvers/css.ts
+++ b/packages/core/src/resolvers/css.ts
@@ -489,7 +489,7 @@ export function tryResolveCssConflict(
             unresolvedRules++;
             return {
               mergedLines: null,
-              reason: `Conflit CSS sur le sélecteur '${selector}' — propriétés incompatibles.`,
+              reason: `CSS conflict on selector '${selector}': incompatible properties.`,
               resolvedRules,
               unresolvedRules,
             };
@@ -498,7 +498,7 @@ export function tryResolveCssConflict(
           unresolvedRules++;
           return {
             mergedLines: null,
-            reason: `Conflit CSS sur '${selector}' — ajouté différemment des deux côtés.`,
+            reason: `CSS conflict on '${selector}': added differently on each side.`,
             resolvedRules,
             unresolvedRules,
           };
@@ -526,7 +526,7 @@ export function tryResolveCssConflict(
         resolvedRules++;
       } else {
         unresolvedRules++;
-        return { mergedLines: null, reason: `Conflit CSS sur '${selector}' — ours supprimé, theirs modifié.`, resolvedRules, unresolvedRules };
+        return { mergedLines: null, reason: `CSS conflict on '${selector}': ours deleted it, theirs modified it.`, resolvedRules, unresolvedRules };
       }
       continue;
     }
@@ -536,7 +536,7 @@ export function tryResolveCssConflict(
         resolvedRules++;
       } else {
         unresolvedRules++;
-        return { mergedLines: null, reason: `Conflit CSS sur '${selector}' — theirs supprimé, ours modifié.`, resolvedRules, unresolvedRules };
+        return { mergedLines: null, reason: `CSS conflict on '${selector}': theirs deleted it, ours modified it.`, resolvedRules, unresolvedRules };
       }
       continue;
     }
@@ -566,7 +566,7 @@ export function tryResolveCssConflict(
         unresolvedRules++;
         return {
           mergedLines: null,
-          reason: `Conflit CSS sur le sélecteur '${selector}' — propriétés modifiées incompatibles.`,
+          reason: `CSS conflict on selector '${selector}': incompatible property changes.`,
           resolvedRules,
           unresolvedRules,
         };
@@ -575,7 +575,7 @@ export function tryResolveCssConflict(
       unresolvedRules++;
       return {
         mergedLines: null,
-        reason: `Conflit CSS sur '${selector}' — at-rules modifiées des deux côtés.`,
+        reason: `CSS conflict on '${selector}': at-rules modified on both sides.`,
         resolvedRules,
         unresolvedRules,
       };
@@ -584,7 +584,7 @@ export function tryResolveCssConflict(
 
   return {
     mergedLines: resultLines,
-    reason: `Fusion CSS réussie : ${resolvedRules} règle(s) fusionnée(s).`,
+    reason: `CSS merge succeeded: ${resolvedRules} rule(s) merged.`,
     resolvedRules,
     unresolvedRules,
   };

--- a/packages/core/src/resolvers/dispatcher.ts
+++ b/packages/core/src/resolvers/dispatcher.ts
@@ -432,7 +432,7 @@ export function tryFormatAwareResolve(
   // ── Pas de résolveur spécialisé ───────────────────────
   return {
     lines: null,
-    reason: "Aucun résolveur spécialisé pour ce type de fichier.",
+    reason: "No format-aware resolver for this file type.",
     resolverUsed: "none",
   };
 }

--- a/packages/core/src/resolvers/dockerfile.ts
+++ b/packages/core/src/resolvers/dockerfile.ts
@@ -264,7 +264,7 @@ export function tryResolveDockerfileConflict(
     if (!merged) {
       return {
         lines: null,
-        reason: "[dockerfile] Conflit irréductible dans un stage — fallback textuel.",
+        reason: "[dockerfile] Irreducible conflict inside a stage, falling back to the textual engine.",
       };
     }
     resultLines.push(...merged);
@@ -279,6 +279,6 @@ export function tryResolveDockerfileConflict(
 
   return {
     lines: resultLines,
-    reason: "Dockerfile — merge par stage et instruction (FROM prefer-theirs, ENV/ARG par clé, RUN conservatif).",
+    reason: "Dockerfile merged by stage and instruction (FROM prefer-theirs, ENV/ARG by key, RUN conservatively).",
   };
 }

--- a/packages/core/src/resolvers/dotenv.ts
+++ b/packages/core/src/resolvers/dotenv.ts
@@ -101,7 +101,7 @@ export function tryResolveDotenvConflict(
   if (!oursParsed || !theirsParsed) {
     return {
       lines: null,
-      reason: "[dotenv] Valeurs multilignes détectées — fallback textuel.",
+      reason: "[dotenv] Multi-line values detected, falling back to the textual engine.",
     };
   }
 
@@ -141,6 +141,6 @@ export function tryResolveDotenvConflict(
 
   return {
     lines: result,
-    reason: "Format key=value — merge par clé (.env). Nouvelles clés ajoutées des deux côtés ; conflits de valeur résolus en faveur de theirs.",
+    reason: "key=value format merged by key (.env). New keys from both sides are kept; value conflicts resolve to theirs.",
   };
 }

--- a/packages/core/src/resolvers/imports.ts
+++ b/packages/core/src/resolvers/imports.ts
@@ -299,7 +299,7 @@ export function tryResolveImportConflict(
   if (!isImportBlock(oursLines) || !isImportBlock(theirsLines)) {
     return {
       mergedLines: null,
-      reason: "Le bloc contient des lignes qui ne sont pas des imports — fallback textuel.",
+      reason: "The block contains lines that are not imports, so it falls back to the textual engine.",
       resolvedImports: 0,
       unresolvedImports: 1,
     };
@@ -321,7 +321,7 @@ export function tryResolveImportConflict(
   if (hasUnparsableContent(oursLines) || hasUnparsableContent(theirsLines)) {
     return {
       mergedLines: null,
-      reason: "Le bloc contient des lignes import-like non parsables — fallback textuel (aucune ligne ne doit être perdue).",
+      reason: "The block contains import-like lines that cannot be parsed, so it falls back to the textual engine rather than risk losing a line.",
       resolvedImports: 0,
       unresolvedImports: 1,
     };
@@ -372,7 +372,7 @@ export function tryResolveImportConflict(
             unresolvedImports++;
             return {
               mergedLines: null,
-              reason: `Conflit sur l'import named '${ours.source}' — impossible de fusionner les noms.`,
+              reason: `Conflict on the named import '${ours.source}': the names cannot be merged.`,
               resolvedImports,
               unresolvedImports,
             };
@@ -382,7 +382,7 @@ export function tryResolveImportConflict(
           unresolvedImports++;
           return {
             mergedLines: null,
-            reason: `Conflit sur l'import '${ours.source}' — types incompatibles (${ours.kind} vs ${theirs.kind}).`,
+            reason: `Conflict on import '${ours.source}': incompatible kinds (${ours.kind} vs ${theirs.kind}).`,
             resolvedImports,
             unresolvedImports,
           };
@@ -394,7 +394,7 @@ export function tryResolveImportConflict(
           unresolvedImports++;
           return {
             mergedLines: null,
-            reason: `Conflit sur l'import '${ours.source}' — types incompatibles (${ours.kind} vs ${theirsSameSource.kind}).`,
+            reason: `Conflict on import '${ours.source}': incompatible kinds (${ours.kind} vs ${theirsSameSource.kind}).`,
             resolvedImports,
             unresolvedImports,
           };
@@ -408,7 +408,7 @@ export function tryResolveImportConflict(
           unresolvedImports++;
           return {
             mergedLines: null,
-            reason: `Conflit sur l'import '${theirs.source}' — types incompatibles (${oursSameSource.kind} vs ${theirs.kind}).`,
+            reason: `Conflict on import '${theirs.source}': incompatible kinds (${oursSameSource.kind} vs ${theirs.kind}).`,
             resolvedImports,
             unresolvedImports,
           };
@@ -436,7 +436,7 @@ export function tryResolveImportConflict(
         unresolvedImports++;
         return {
           mergedLines: null,
-          reason: `Conflit sur l'import '${base.source}' — ours l'a supprimé, theirs l'a modifié.`,
+          reason: `Conflict on import '${base.source}': ours deleted it, theirs modified it.`,
           resolvedImports,
           unresolvedImports,
         };
@@ -451,7 +451,7 @@ export function tryResolveImportConflict(
         unresolvedImports++;
         return {
           mergedLines: null,
-          reason: `Conflit sur l'import '${base.source}' — theirs l'a supprimé, ours l'a modifié.`,
+          reason: `Conflict on import '${base.source}': theirs deleted it, ours modified it.`,
           resolvedImports,
           unresolvedImports,
         };
@@ -482,7 +482,7 @@ export function tryResolveImportConflict(
         unresolvedImports++;
         return {
           mergedLines: null,
-          reason: `Conflit sur les named imports '${ours.source}'.`,
+          reason: `Conflict on the named imports from '${ours.source}'.`,
           resolvedImports,
           unresolvedImports,
         };
@@ -491,7 +491,7 @@ export function tryResolveImportConflict(
       unresolvedImports++;
       return {
         mergedLines: null,
-        reason: `Conflit sur l'import '${ours.source}' — modifications incompatibles.`,
+        reason: `Conflict on import '${ours.source}': incompatible changes.`,
         resolvedImports,
         unresolvedImports,
       };
@@ -503,7 +503,7 @@ export function tryResolveImportConflict(
 
   return {
     mergedLines: sortedResult,
-    reason: `Fusion d'imports réussie : ${resolvedImports} import(s) fusionné(s).`,
+    reason: `Import merge succeeded: ${resolvedImports} import(s) merged.`,
     resolvedImports,
     unresolvedImports,
   };

--- a/packages/core/src/resolvers/json.ts
+++ b/packages/core/src/resolvers/json.ts
@@ -384,7 +384,7 @@ export function tryResolveJsonConflict(
   } catch (e) {
     return {
       merged: null,
-      reason: `Impossible de parser ours comme JSON : ${e instanceof Error ? e.message : String(e)}`,
+      reason: `Could not parse ours as JSON: ${e instanceof Error ? e.message : String(e)}`,
       resolvedKeys: 0,
       unresolvedKeys: 1,
     };
@@ -395,7 +395,7 @@ export function tryResolveJsonConflict(
   } catch (e) {
     return {
       merged: null,
-      reason: `Impossible de parser theirs comme JSON : ${e instanceof Error ? e.message : String(e)}`,
+      reason: `Could not parse theirs as JSON: ${e instanceof Error ? e.message : String(e)}`,
       resolvedKeys: 0,
       unresolvedKeys: 1,
     };
@@ -408,7 +408,7 @@ export function tryResolveJsonConflict(
       // Pour l'instant, pas de merge sémantique des tableaux — fallback textuel
       return {
         merged: null,
-        reason: "Fusion sémantique de tableaux JSON non supportée (fallback textuel).",
+        reason: "Semantic merging of JSON arrays is not supported, so this falls back to the textual engine.",
         resolvedKeys: 0,
         unresolvedKeys: 1,
       };
@@ -418,14 +418,14 @@ export function tryResolveJsonConflict(
       const indent = detectIndentation(oursText);
       return {
         merged: JSON.stringify(oursJson, null, indent),
-        reason: "Même valeur JSON des deux côtés — résolution triviale.",
+        reason: "Same JSON value on both sides, so the resolution is trivial.",
         resolvedKeys: 1,
         unresolvedKeys: 0,
       };
     }
     return {
       merged: null,
-      reason: "Valeurs JSON scalaires différentes — fallback textuel.",
+      reason: "Differing scalar JSON values, falling back to the textual engine.",
       resolvedKeys: 0,
       unresolvedKeys: 1,
     };
@@ -448,7 +448,7 @@ export function tryResolveJsonConflict(
   if (merged === null) {
     return {
       merged: null,
-      reason: `Fusion JSON impossible : ${unresolvedKeys} clé(s) en conflit non résolvable.`,
+      reason: `JSON merge not possible: ${unresolvedKeys} key(s) conflict irreducibly.`,
       resolvedKeys,
       unresolvedKeys,
     };
@@ -460,7 +460,7 @@ export function tryResolveJsonConflict(
 
   return {
     merged: mergedText,
-    reason: `Fusion JSON sémantique réussie : ${resolvedKeys} clé(s) fusionnée(s), ${unresolvedKeys} conflit(s).`,
+    reason: `Semantic JSON merge succeeded: ${resolvedKeys} key(s) merged, ${unresolvedKeys} conflict(s).`,
     resolvedKeys,
     unresolvedKeys,
   };

--- a/packages/core/src/resolvers/llm-fallback.ts
+++ b/packages/core/src/resolvers/llm-fallback.ts
@@ -205,7 +205,7 @@ export async function tryLlmFallbackResolve(
     };
     return {
       lines: null,
-      reason: "LLM fallback ignoré : aucun endpoint injecté (config.endpoint manquant).",
+      reason: "LLM fallback skipped: no endpoint was injected (config.endpoint missing).",
       llmTrace: trace,
     };
   }
@@ -254,7 +254,7 @@ export async function tryLlmFallbackResolve(
     };
     return {
       lines: null,
-      reason: "LLM a refusé de résoudre ce conflit (CANNOT_RESOLVE ou réponse vide).",
+      reason: "The LLM declined to resolve this conflict (CANNOT_RESOLVE, or an empty response).",
       llmTrace: trace,
     };
   }
@@ -278,15 +278,15 @@ export async function tryLlmFallbackResolve(
 
   if (!accepted) {
     const reason = !validation.isValid
-      ? `LLM résolution refusée : validation échouée (marqueurs résiduels: ${validation.hasResidualMarkers}, syntaxe: ${validation.syntaxError ?? "ok"}).`
-      : `LLM résolution refusée : score de validation ${validationScore} < minimum requis ${minPostMergeScore}.`;
+      ? `LLM resolution rejected: validation failed (residual markers: ${validation.hasResidualMarkers}, syntax: ${validation.syntaxError ?? "ok"}).`
+      : `LLM resolution rejected: validation score ${validationScore} is below the required minimum ${minPostMergeScore}.`;
 
     return { lines: null, reason, llmTrace: trace };
   }
 
   return {
     lines: proposedLines,
-    reason: `LLM résolution acceptée (score: ${validationScore}/100, latence: ${latencyMs}ms, modèle: ${model}).`,
+    reason: `LLM resolution accepted (score: ${validationScore}/100, latency: ${latencyMs}ms, model: ${model}).`,
     llmTrace: trace,
   };
 }

--- a/packages/core/src/resolvers/lockfile-npm.ts
+++ b/packages/core/src/resolvers/lockfile-npm.ts
@@ -104,7 +104,7 @@ export function tryResolveLockfileNpmConflict(
   if (!baseParsed || !oursParsed || !theirsParsed) {
     return {
       merged: null,
-      reason: "Impossible de parser une des versions du package-lock.json.",
+      reason: "One of the package-lock.json versions could not be parsed.",
       resolvedPackages: 0,
       versionConflicts: 0,
       conflictedPackages: [],
@@ -232,8 +232,8 @@ export function tryResolveLockfileNpmConflict(
   const merged = JSON.stringify(result, null, indent.length) + "\n";
 
   const reason = versionConflicts > 0
-    ? `Fusion sémantique lockfile : ${resolvedPackages} paquet(s) fusionné(s), ${versionConflicts} conflit(s) de version résolu(s) (prefer-theirs).`
-    : `Fusion sémantique lockfile réussie : ${resolvedPackages} paquet(s) fusionné(s) sans conflit.`;
+    ? `Semantic lockfile merge: ${resolvedPackages} package(s) merged, ${versionConflicts} version conflict(s) resolved (prefer-theirs).`
+    : `Semantic lockfile merge succeeded: ${resolvedPackages} package(s) merged with no conflict.`;
 
   return {
     merged,

--- a/packages/core/src/resolvers/lockfile-pnpm.ts
+++ b/packages/core/src/resolvers/lockfile-pnpm.ts
@@ -309,8 +309,8 @@ export function tryResolvePnpmLockConflict(
   }
 
   const reason = totalConflicts > 0
-    ? `Fusion sémantique pnpm-lock.yaml : ${totalResolved} entrée(s), ${totalConflicts} conflit(s) résolu(s) (prefer-theirs).`
-    : `Fusion sémantique pnpm-lock.yaml réussie : ${totalResolved} entrée(s) fusionnée(s) sans conflit.`;
+    ? `Semantic pnpm-lock.yaml merge: ${totalResolved} entries merged, ${totalConflicts} conflict(s) resolved (prefer-theirs).`
+    : `Semantic pnpm-lock.yaml merge succeeded: ${totalResolved} entries merged with no conflict.`;
 
   return {
     merged: outputLines.join("\n"),

--- a/packages/core/src/resolvers/lockfile-yarn.ts
+++ b/packages/core/src/resolvers/lockfile-yarn.ts
@@ -120,7 +120,7 @@ export function tryResolveYarnLockConflict(
   if (!baseParsed || !oursParsed || !theirsParsed) {
     return {
       merged: null,
-      reason: "Impossible de parser une des versions du yarn.lock.",
+      reason: "One of the yarn.lock versions could not be parsed.",
       resolvedBlocks: 0,
       versionConflicts: 0,
     };
@@ -216,8 +216,8 @@ export function tryResolveYarnLockConflict(
   }
 
   const reason = versionConflicts > 0
-    ? `Fusion sémantique yarn.lock : ${resolvedBlocks} bloc(s), ${versionConflicts} conflit(s) résolu(s) (prefer-theirs).`
-    : `Fusion sémantique yarn.lock réussie : ${resolvedBlocks} bloc(s) fusionné(s) sans conflit.`;
+    ? `Semantic yarn.lock merge: ${resolvedBlocks} block(s), ${versionConflicts} conflict(s) resolved (prefer-theirs).`
+    : `Semantic yarn.lock merge succeeded: ${resolvedBlocks} block(s) merged with no conflict.`;
 
   return {
     merged: output,

--- a/packages/core/src/resolvers/markdown.ts
+++ b/packages/core/src/resolvers/markdown.ts
@@ -175,7 +175,7 @@ export function tryResolveMarkdownConflict(
       mergedLines: null,
       conflictedSections: ["frontmatter"],
       resolvedSections: 0,
-      reason: "Conflit dans le frontmatter YAML — fusion manuelle requise.",
+      reason: "Conflict in the YAML frontmatter: manual merging required.",
     };
   }
 
@@ -222,7 +222,7 @@ export function tryResolveMarkdownConflict(
       }
       if (theirsSection && !sectionsEqual(oursSection ?? emptySectionFor(key), theirsSection)) {
         // Ajouter la version theirs avec un commentaire d'avertissement
-        mergedLines.push(`<!-- ⚠️ GitWand: section "${key}" modifiée des deux côtés -->`);
+        mergedLines.push(`<!-- ⚠️ GitWand: section "${key}" modified on both sides -->`);
         if (theirsSection.heading) mergedLines.push(theirsSection.heading);
         mergedLines.push(...theirsSection.lines);
       }
@@ -235,7 +235,7 @@ export function tryResolveMarkdownConflict(
       mergedLines: null, // Force resolution manuelle si des sections ont conflicté
       conflictedSections,
       resolvedSections,
-      reason: `Fusion Markdown partielle : ${resolvedSections} section(s) résolue(s), ${conflictedSections.length} en conflit (${conflictedSections.join(", ")}).`,
+      reason: `Partial Markdown merge: ${resolvedSections} section(s) resolved, ${conflictedSections.length} still in conflict (${conflictedSections.join(", ")}).`,
     };
   }
 
@@ -243,7 +243,7 @@ export function tryResolveMarkdownConflict(
     mergedLines,
     conflictedSections: [],
     resolvedSections,
-    reason: `Fusion Markdown réussie : ${resolvedSections} section(s) fusionnée(s) automatiquement.`,
+    reason: `Markdown merge succeeded: ${resolvedSections} section(s) merged automatically.`,
   };
 }
 

--- a/packages/core/src/resolvers/vue.ts
+++ b/packages/core/src/resolvers/vue.ts
@@ -224,7 +224,7 @@ export function tryResolveVueConflict(
             mergedLines: null,
             conflictedBlocks,
             resolvedBlocks,
-            reason: `Conflit sur le bloc <${ours.name}> — ajouté différemment des deux côtés.`,
+            reason: `Conflict on the <${ours.name}> block: added differently on each side.`,
           };
         }
       } else if (ours) {
@@ -256,7 +256,7 @@ export function tryResolveVueConflict(
           mergedLines: null,
           conflictedBlocks,
           resolvedBlocks,
-          reason: `Conflit sur le bloc <${base.name}> — ours l'a supprimé, theirs l'a modifié.`,
+          reason: `Conflict on the <${base.name}> block: ours deleted it, theirs modified it.`,
         };
       }
       continue;
@@ -272,7 +272,7 @@ export function tryResolveVueConflict(
           mergedLines: null,
           conflictedBlocks,
           resolvedBlocks,
-          reason: `Conflit sur le bloc <${base.name}> — theirs l'a supprimé, ours l'a modifié.`,
+          reason: `Conflict on the <${base.name}> block: theirs deleted it, ours modified it.`,
         };
       }
       continue;
@@ -298,7 +298,7 @@ export function tryResolveVueConflict(
         mergedLines: null,
         conflictedBlocks,
         resolvedBlocks,
-        reason: `Conflit sur le bloc <${ours.name}> — modifié des deux côtés de façon incompatible.`,
+        reason: `Conflict on the <${ours.name}> block: modified incompatibly on both sides.`,
       };
     }
   }
@@ -307,6 +307,6 @@ export function tryResolveVueConflict(
     mergedLines: resultLines,
     conflictedBlocks: [],
     resolvedBlocks,
-    reason: `Fusion Vue SFC réussie : ${resolvedBlocks} bloc(s) fusionné(s).`,
+    reason: `Vue SFC merge succeeded: ${resolvedBlocks} block(s) merged.`,
   };
 }

--- a/packages/core/src/resolvers/yaml.ts
+++ b/packages/core/src/resolvers/yaml.ts
@@ -432,7 +432,7 @@ export function tryResolveYamlConflict(
   ) {
     return {
       mergedLines: null,
-      reason: "YAML contient des anchors, aliases ou block scalars — fusion structurelle non supportée (fallback textuel).",
+      reason: "The YAML contains anchors, aliases or block scalars, which structural merging does not support, so it falls back to the textual engine.",
       resolvedKeys: 0,
       unresolvedKeys: 1,
     };
@@ -446,14 +446,14 @@ export function tryResolveYamlConflict(
     if (merged !== null) {
       return {
         mergedLines: merged,
-        reason: `YAML séquence scalaire — union des éléments (${merged.length} entrées).`,
+        reason: `Scalar YAML sequence: union of the items (${merged.length} entries).`,
         resolvedKeys: 1,
         unresolvedKeys: 0,
       };
     }
     return {
       mergedLines: null,
-      reason: "YAML séquence scalaire — fusion impossible (éléments en conflit).",
+      reason: "Scalar YAML sequence: merging is not possible, the items conflict.",
       resolvedKeys: 0,
       unresolvedKeys: 1,
     };
@@ -468,7 +468,7 @@ export function tryResolveYamlConflict(
   if (lines === null) {
     return {
       mergedLines: null,
-      reason: `Fusion YAML impossible : ${unresolvedKeys} clé(s) en conflit non résolvable.`,
+      reason: `YAML merge not possible: ${unresolvedKeys} key(s) conflict irreducibly.`,
       resolvedKeys,
       unresolvedKeys,
     };
@@ -476,7 +476,7 @@ export function tryResolveYamlConflict(
 
   return {
     mergedLines: lines,
-    reason: `Fusion YAML structurelle réussie : ${resolvedKeys} clé(s) fusionnée(s).`,
+    reason: `Structural YAML merge succeeded: ${resolvedKeys} key(s) merged.`,
     resolvedKeys,
     unresolvedKeys,
   };
@@ -531,7 +531,7 @@ function tryProfileBasedYamlMerge(
   const serialized = YAML.stringify(merged, { indent: 2, lineWidth: 0 }).trimEnd();
   return {
     mergedLines: serialized.split("\n"),
-    reason: `Fusion YAML via profil '${profile.name}'.`,
+    reason: `YAML merged using the '${profile.name}' profile.`,
     resolvedKeys: 1,
     unresolvedKeys: 0,
   };

--- a/packages/core/src/stats/tiers.ts
+++ b/packages/core/src/stats/tiers.ts
@@ -1,5 +1,5 @@
 /**
- * "Recoverable-before-model" metric (v2.7).
+ * "Recoverable-before-model" metric (v3.4).
  *
  * Design: docs/superpowers/specs/2026-07-07-recoverable-before-model-metric-design.md §4.B
  *

--- a/packages/core/src/structural/index.ts
+++ b/packages/core/src/structural/index.ts
@@ -186,11 +186,11 @@ export function wrapStructuralResult(
         boosters: ["structural-merge"],
         penalties: [],
       },
-      explanation: "Résolu via merge structurel (tree-sitter AST)",
+      explanation: "Resolved by a structural merge (tree-sitter AST)",
       trace: {
         steps: [],
         selected: "complex" as const,
-        summary: "Résolu via analyse structurelle AST — merge par entités TypeScript",
+        summary: "Resolved by structural AST analysis: merged per TypeScript entity",
         hasBase: s.conflict.baseLines.length > 0,
       },
     }));
@@ -199,7 +199,7 @@ export function wrapStructuralResult(
     hunk,
     resolvedLines: null,
     autoResolved: true,
-    resolutionReason: "structural-merge: résolu via analyse AST tree-sitter",
+    resolutionReason: "structural-merge: resolved by tree-sitter AST analysis",
   }));
 
   const byType = hunks.length > 0 ? ({ complex: hunks.length } as MergeStats["byType"]) : ({} as MergeStats["byType"]);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -28,7 +28,7 @@ export type ConflictType =
   | "value_only_change"         // Même structure, seule une valeur change (hash, version, timestamp…)
   | "reorder_only"              // v1.4 — mêmes lignes, ordre différent (permutation pure)
   | "insertion_at_boundary"     // v1.4 — insertions pures des deux côtés, base intacte
-  | "token_level_merge"        // v2.7 — fusion fine ligne/token, toujours proposée (jamais auto-appliquée)
+  | "token_level_merge"        // v3.4 — fusion fine ligne/token, toujours proposée (jamais auto-appliquée)
   | "llm_proposed"              // v2.5 — résolution proposée par LLM fallback (opt-in, priority 998)
   | "refactoring_aware_merge"  // v2.6 — RefMerge : détection/inversion/rejeu de refactorings (expérimental, opt-in)
   | "complex";                  // Conflit réel nécessitant intervention humaine
@@ -299,13 +299,13 @@ export interface DecisionTrace {
    */
   llmTrace?: LlmTrace;
   /**
-   * v2.7 — Proposition de fusion token-level (uniquement si
+   * v3.4 — Proposition de fusion token-level (uniquement si
    * `selected === "token_level_merge"`). `undefined` pour tous les autres types.
    */
   tokenMergeTrace?: TokenMergeTrace;
 }
 
-// ─── v2.7 — Token-level merge (proposition, jamais auto-appliquée) ──────
+// ─── v3.4 — Token-level merge (proposition, jamais auto-appliquée) ──────
 
 /** Détail de résolution pour une ligne du hunk. */
 export interface TokenMergeLineDetail {

--- a/packages/mcp/src/__tests__/preview.test.ts
+++ b/packages/mcp/src/__tests__/preview.test.ts
@@ -44,14 +44,20 @@ function makeRepo(): Repo {
   }
 }
 
+// Real git repositories, per AGENTS.md's rule against mocking the git layer.
+// That makes these subprocess-bound rather than CPU-bound: ~1s per test in
+// isolation, 5.8s and 8.4s observed once the whole monorepo runs at once, which
+// is how `pnpm test` and CI run them.
+//
+// 60s is deliberately generous, and matches the other git-backed suites. A
+// timeout here exists to catch a hang, not to enforce a performance budget,
+// and it costs nothing on a passing run. Tuning it down to "just above
+// observed" is what produced the flake in issue #172.
+const GIT_IO_TIMEOUT_MS = 60_000
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
-// These cases spin up real git repos and run the predictor against them, so
-// they are I/O-bound and measurably slower than vitest's 5s default whenever
-// the whole monorepo suite runs in parallel (5.8s and 8.4s observed, ~1s in
-// isolation). That made `pnpm -r run test` non-deterministic on a loaded
-// machine, and CI runs the same way.
-describe('simulate3way via toolPreviewRebase', { timeout: 30_000 }, () => {
+describe('simulate3way via toolPreviewRebase', { timeout: GIT_IO_TIMEOUT_MS }, () => {
   it('detects a real conflict on overlapping lines and reports it', async () => {
     // Regression guard: git merge-file exits with code = number of conflicts
     // (non-zero). The predictor must capture the conflict-marked stdout from
@@ -154,7 +160,7 @@ describe('simulate3way via toolPreviewRebase', { timeout: 30_000 }, () => {
   })
 })
 
-describe('toolPreviewRebase — error handling', () => {
+describe('toolPreviewRebase — error handling', { timeout: GIT_IO_TIMEOUT_MS }, () => {
   it('returns isError=true for an unknown onto ref', async () => {
     const { cwd, cleanup } = makeRepo()
     try {
@@ -191,7 +197,7 @@ describe('toolPreviewRebase — error handling', () => {
   })
 })
 
-describe('toolPreviewCherryPick — error handling', () => {
+describe('toolPreviewCherryPick — error handling', { timeout: GIT_IO_TIMEOUT_MS }, () => {
   it('returns isError=true for a root commit (no parent)', async () => {
     const { cwd, cleanup } = makeRepo()
     try {
@@ -296,7 +302,7 @@ describe('toolPreviewCherryPick — error handling', () => {
   })
 })
 
-describe('toolPreviewCherryPick — conflict detection', () => {
+describe('toolPreviewCherryPick — conflict detection', { timeout: GIT_IO_TIMEOUT_MS }, () => {
   it('detects a real conflict when the picked commit touches the same line', async () => {
     const { cwd, cleanup } = makeRepo()
     try {
@@ -374,7 +380,7 @@ describe('toolPreviewCherryPick — conflict detection', () => {
   })
 })
 
-describe('toolPreview — merge operation (working tree)', () => {
+describe('toolPreview — merge operation (working tree)', { timeout: GIT_IO_TIMEOUT_MS }, () => {
   it('reports no conflicts when the working tree is clean', async () => {
     const { cwd, cleanup } = makeRepo()
     try {

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -493,7 +493,7 @@ async function toolStatus(cwd: string) {
 
   const totalConflicts = conflicts.reduce((s: number, c: Record<string, unknown>) => s + ((c.totalConflicts as number) ?? 0), 0);
   const totalResolvable = conflicts.reduce((s: number, c: Record<string, unknown>) => s + ((c.autoResolvable as number) ?? 0), 0);
-  // v2.7 — "recoverable-before-model" : of the residual past the trivial passes,
+  // v3.4 — "recoverable-before-model" : of the residual past the trivial passes,
   // how much is still recoverable deterministically before the model is invoked.
   const tierSummary = summarizeTiers(aggregateByType as Record<ConflictType, number>);
 
@@ -551,7 +551,7 @@ async function toolResolve(cwd: string, args: Record<string, unknown>) {
 
   const totalConflicts = results.reduce((s: number, r: Record<string, unknown>) => s + ((r.totalConflicts as number) ?? 0), 0);
   const totalResolved = results.reduce((s: number, r: Record<string, unknown>) => s + ((r.autoResolved as number) ?? 0), 0);
-  // v2.7 — "recoverable-before-model" tier summary, see summarizeTiers() in @gitwand/core.
+  // v3.4 — "recoverable-before-model" tier summary, see summarizeTiers() in @gitwand/core.
   const tierSummary = summarizeTiers(aggregateByType as Record<ConflictType, number>);
 
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,10 +224,17 @@ importers:
         version: 5.9.3
 
   website:
+    dependencies:
+      '@gitwand/core':
+        specifier: workspace:*
+        version: link:../packages/core
     devDependencies:
       vitepress:
         specifier: 2.0.0-alpha.17
         version: 2.0.0-alpha.17(@types/node@25.5.0)(postcss@8.5.15)(typescript@5.9.3)(yaml@2.8.3)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.5.0)(jsdom@25.0.1)(vite@7.3.5(@types/node@25.5.0)(yaml@2.8.3))
       vue:
         specifier: ^3.5.0
         version: 3.5.32(typescript@5.9.3)

--- a/website/.vitepress/config.ts
+++ b/website/.vitepress/config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitepress'
 import { extractFaq } from './seo'
+import { fileURLToPath } from 'node:url'
 
 
 export default defineConfig({
@@ -13,6 +14,29 @@ export default defineConfig({
   // extensionless form everywhere, sitemap included. GitHub Pages already serves
   // /foo as /foo.html with a 200 and no redirect, which is what this requires.
   cleanUrls: true,
+
+  vite: {
+    resolve: {
+      alias: {
+        // Point at the TypeScript source rather than packages/core/dist.
+        // deploy-website.yml runs `pnpm install` and builds the site directly,
+        // with no `pnpm --filter @gitwand/core build` step, so dist/ does not
+        // exist in CI. Same reasoning as apps/desktop/vite.config.ts.
+        '@gitwand/core': fileURLToPath(new URL('../../packages/core/src/index.ts', import.meta.url)),
+      },
+    },
+    build: {
+      rollupOptions: {
+        // Mark Node built-ins external so Rollup can parse packages/core's
+        // node adapter (structural/parsers/adapters/node.ts) without trying to
+        // resolve it. The adapter is behind a dynamic import reached only when
+        // env === "node", which never happens in a browser, so it is dead code
+        // here. Without this, the build fails on `createRequire` from
+        // node:module. Same fix as apps/desktop/vite.config.ts.
+        external: (id: string) => id.startsWith('node:'),
+      },
+    },
+  },
 
   sitemap: {
     hostname: 'https://gitwand.app',
@@ -37,14 +61,21 @@ export default defineConfig({
     ['link', { rel: 'api-catalog', href: '/.well-known/api-catalog', type: 'application/linkset+json' }],
     ['link', { rel: 'service-doc', href: '/guide/mcp', type: 'text/html', title: 'GitWand MCP Server Guide' }],
     ['link', { rel: 'service-doc', href: '/reference/core-api', type: 'text/html', title: 'GitWand Core API Reference' }],
-    // WebMCP — expose site tools to AI agents via the browser (navigator.modelContext)
+    // WebMCP — expose site tools to AI agents via the browser.
+    // The spec puts the entry point on document.modelContext; Chrome 150
+    // deprecated navigator.modelContext but kept it as an ALIAS to the same
+    // object, with removal announced. So: prefer document, fall back to
+    // navigator, and register ONCE. Registering on both would duplicate every
+    // tool on the versions that still expose both names.
     ['script', {}, `
 (function () {
-  if (typeof navigator === 'undefined' || !navigator.modelContext) return;
+  var mc = (typeof document !== 'undefined' && document.modelContext) ||
+           (typeof navigator !== 'undefined' && navigator.modelContext) || null;
+  if (!mc) return;
   var ac = new AbortController();
-  var signal = ac.signal;
+  var opts = { signal: ac.signal };
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: 'search_gitwand_docs',
     description: 'Search the GitWand documentation for guides, API reference, CLI commands, and blog articles.',
     inputSchema: {
@@ -58,10 +89,9 @@ export default defineConfig({
       var url = 'https://gitwand.app/?q=' + encodeURIComponent(args.query);
       return Promise.resolve({ url: url, hint: 'Navigate to this URL to view search results.' });
     },
-    signal: signal
-  });
+  }, opts);
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: 'get_gitwand_mcp_install',
     description: 'Get the installation instructions and configuration snippet for GitWand MCP server.',
     inputSchema: { type: 'object', properties: {} },
@@ -73,10 +103,9 @@ export default defineConfig({
         guide: 'https://gitwand.app/guide/mcp'
       });
     },
-    signal: signal
-  });
+  }, opts);
 
-  navigator.modelContext.registerTool({
+  mc.registerTool({
     name: 'navigate_to_gitwand_section',
     description: 'Get the URL for a GitWand documentation section.',
     inputSchema: {
@@ -108,8 +137,7 @@ export default defineConfig({
       var path = routes[args.section] || '/';
       return Promise.resolve({ url: 'https://gitwand.app' + path });
     },
-    signal: signal
-  });
+  }, opts);
 })();
 `],
   ],

--- a/website/.vitepress/theme/AgentPage.vue
+++ b/website/.vitepress/theme/AgentPage.vue
@@ -1,0 +1,201 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { TOOLS } from './tools'
+import { registerTools, type Surface } from './webmcp'
+
+/**
+ * Registration happens on mount, never during the SSR pass: `document` does
+ * not exist there, and tools belong to a live document anyway. The
+ * AbortController is what unregisters them when the visitor navigates away,
+ * which matters on a SPA-routed site where the document outlives the page.
+ */
+const surface = ref<Surface>(null)
+const registered = ref<string[]>([])
+const failed = ref<{ name: string; reason: string }[]>([])
+const settled = ref(false)
+const calls = ref<Record<string, number>>({})
+const lastCall = ref<string | null>(null)
+
+let controller: AbortController | null = null
+
+function onCall(name: string) {
+  calls.value = { ...calls.value, [name]: (calls.value[name] ?? 0) + 1 }
+  lastCall.value = name
+}
+
+onMounted(async () => {
+  controller = new AbortController()
+  const outcome = await registerTools(TOOLS, { signal: controller.signal, onCall })
+  surface.value = outcome.surface
+  registered.value = outcome.registered
+  failed.value = outcome.failed
+  settled.value = true
+})
+
+onUnmounted(() => controller?.abort())
+</script>
+
+<template>
+  <div class="gw-page">
+    <section class="ph-hero">
+      <div class="ph-inner">
+        <span class="ph-badge">WebMCP</span>
+        <h1 class="ph-h1">Git tools your agent can <span class="grad">just call</span>.</h1>
+        <p class="ph-sub">
+          This page exposes GitWand's conflict engine to any agent browsing it, through the W3C WebMCP
+          standard. No install, no API key, no server: the tools run in the tab you are looking at.
+        </p>
+        <div class="ph-ctas">
+          <a href="/guide/mcp" class="ph-btn ph-btn--primary">Prefer a real MCP server?</a>
+          <a href="/conflict-engine" class="ph-btn">How the engine works</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Live registration state. Deliberately shows failure and absence as
+         plainly as success: a demo that always claims to work teaches nobody. -->
+    <section class="ph-section">
+      <div class="ph-inner">
+        <h2 class="ph-h2">Status in this browser</h2>
+        <p class="ph-secsub">
+          Read live from the page you have open, not from a screenshot taken on a good day.
+        </p>
+
+        <div class="st" :class="settled ? (surface ? 'st--on' : 'st--off') : 'st--wait'">
+          <template v-if="!settled">
+            <p class="st-line">Checking for a WebMCP entry point…</p>
+          </template>
+
+          <template v-else-if="surface">
+            <p class="st-line">
+              <strong>WebMCP available</strong> on <code>{{ surface }}.modelContext</code>.
+              {{ registered.length }} tool{{ registered.length === 1 ? '' : 's' }} registered.
+            </p>
+            <p v-if="surface === 'navigator'" class="st-note">
+              This browser only exposes the deprecated location. Chrome 150 kept
+              <code>navigator.modelContext</code> as an alias and has announced its removal, so this
+              page registered there rather than not at all.
+            </p>
+            <ul class="st-calls">
+              <li v-for="name in registered" :key="name">
+                <code>{{ name }}</code>
+                <span class="st-count" :class="{ 'st-count--hot': lastCall === name }">
+                  called {{ calls[name] ?? 0 }}×
+                </span>
+              </li>
+            </ul>
+            <p class="st-note">
+              That counter lives in this tab and is never sent anywhere. There is no backend behind
+              this page to send it to.
+            </p>
+          </template>
+
+          <template v-else>
+            <p class="st-line"><strong>No WebMCP in this browser.</strong> Nothing was registered.</p>
+            <p class="st-note">
+              As of today that means most browsers. The API ships behind an origin trial in Chrome and
+              a flag in Edge, and natively in the ChatGPT desktop app's built-in browser. Everything
+              below is readable without it, which is the point of writing it out.
+            </p>
+          </template>
+
+          <ul v-if="failed.length" class="st-failed">
+            <li v-for="f in failed" :key="f.name"><code>{{ f.name }}</code> failed: {{ f.reason }}</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- The same tool contract in HTML, for the majority of visitors whose
+         browser has no WebMCP and for crawlers that will never run the script. -->
+    <section class="ph-section ph-section--alt">
+      <div class="ph-inner">
+        <h2 class="ph-h2">The two tools, written out</h2>
+        <p class="ph-secsub">
+          Both are read-only. Neither runs git, neither writes to a repository, and neither uploads
+          what you pass it.
+        </p>
+
+        <article class="tool">
+          <h3 class="tool-name"><code>parse_git_error</code></h3>
+          <p class="tool-desc">
+            Paste the raw output of a git command that failed. Returns the cause in plain language
+            and the specific commands that resolve it, for the common failures: merge conflicts,
+            rejected pushes, unrelated histories, detached HEAD, an interrupted merge or rebase,
+            authentication.
+          </p>
+          <p class="tool-io"><span class="tool-k">Input</span> <code>{ output: string }</code></p>
+        </article>
+
+        <article class="tool">
+          <h3 class="tool-name"><code>resolve_conflict</code></h3>
+          <p class="tool-desc">
+            Pass a file that still contains conflict markers. Returns the merged result plus a
+            per-hunk classification: which conflicts carried no decision and were resolved, which
+            need a human, and why in each case. Deterministic patterns only, no model in the loop.
+            Pass the real file path when you have one: the extension selects the format-aware
+            resolvers, and the path is what identifies a generated file.
+          </p>
+          <p class="tool-io">
+            <span class="tool-k">Input</span> <code>{ content: string, filePath?: string }</code>
+          </p>
+        </article>
+
+        <p class="foot">
+          Neither tool is a substitute for
+          <a href="/guide/mcp"><code>@gitwand/mcp</code></a>, which runs against your real repository
+          and can write. WebMCP only carries callable tools, with no resources, prompts or sampling.
+          This page is the zero-install door, not the full one.
+        </p>
+      </div>
+    </section>
+  </div>
+</template>
+
+<style scoped>
+.gw-page{
+  --purple:#8B5CF6;--purple-d:#7C3AED;--green:#10B981;
+  --bg:#0c0c1a;--bg2:#111120;--card:#16162a;
+  --border:rgba(124,58,237,0.18);--border-soft:rgba(255,255,255,0.06);
+  --text:#e2e8f0;--muted:#94a3b8;
+  background:var(--bg);color:var(--text);
+  font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+}
+.ph-inner{max-width:1080px;margin:0 auto;padding:0 24px;}
+.ph-hero{padding:80px 0 56px;text-align:center;background:radial-gradient(ellipse 80% 60% at 50% -10%,rgba(124,58,237,0.18) 0%,transparent 70%),var(--bg);border-bottom:1px solid var(--border-soft);}
+.ph-badge{display:inline-block;font-size:12px;font-weight:600;padding:5px 12px;border-radius:999px;color:var(--purple);background:rgba(124,58,237,0.1);border:1px solid var(--border);margin-bottom:18px;}
+.ph-h1{font-size:44px;line-height:1.15;font-weight:800;letter-spacing:-0.02em;margin:0 auto 18px;max-width:800px;}
+.ph-h1 .grad{background:linear-gradient(135deg,var(--purple),var(--green));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;}
+.ph-sub{font-size:18px;line-height:1.65;color:var(--muted);max-width:680px;margin:0 auto 28px;}
+.ph-ctas{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;}
+.ph-btn{padding:11px 22px;border-radius:10px;font-size:15px;font-weight:600;text-decoration:none;color:var(--text);border:1px solid var(--border-soft);transition:border-color .15s,color .15s;}
+.ph-btn:hover{border-color:var(--purple);color:var(--purple);}
+.ph-btn--primary{background:var(--purple-d);color:#fff;border-color:var(--purple-d);}
+.ph-btn--primary:hover{background:var(--purple);color:#fff;}
+.ph-section{padding:72px 0;}
+.ph-section--alt{background:var(--bg2);border-top:1px solid var(--border-soft);border-bottom:1px solid var(--border-soft);}
+.ph-h2{font-size:30px;font-weight:800;letter-spacing:-0.01em;text-align:center;margin:0 0 10px;}
+.ph-secsub{font-size:16px;color:var(--muted);text-align:center;max-width:640px;margin:0 auto 40px;line-height:1.6;}
+
+.st{max-width:640px;margin:0 auto;background:var(--card);border:1px solid var(--border);border-left-width:3px;border-radius:12px;padding:20px 22px;}
+.st--on{border-left-color:var(--green);}
+.st--off{border-left-color:var(--muted);}
+.st--wait{border-left-color:var(--purple);}
+.st-line{margin:0;font-size:15px;line-height:1.6;}
+.st-note{margin:10px 0 0;font-size:13px;color:var(--muted);line-height:1.55;}
+.st-calls{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:8px;}
+.st-calls li{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:14px;}
+.st-count{font-size:12px;color:var(--muted);font-variant-numeric:tabular-nums;transition:color .2s;}
+.st-count--hot{color:var(--green);}
+.st-failed{margin:14px 0 0;padding-left:18px;font-size:13px;color:#f87171;}
+
+.tool{max-width:720px;margin:0 auto 20px;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:20px 22px;}
+.tool-name{margin:0 0 10px;font-size:16px;}
+.tool-name code{font-family:'JetBrains Mono',monospace;color:var(--purple);}
+.tool-desc{margin:0 0 12px;font-size:14px;line-height:1.65;color:var(--muted);}
+.tool-io{margin:0;font-size:13px;color:var(--muted);}
+.tool-k{display:inline-block;min-width:52px;font-weight:600;color:var(--text);}
+.foot{max-width:720px;margin:28px auto 0;font-size:14px;line-height:1.65;color:var(--muted);text-align:center;}
+.foot a{color:var(--purple);}
+code{font-family:'JetBrains Mono',monospace;font-size:0.92em;}
+</style>

--- a/website/.vitepress/theme/AgentPage.vue
+++ b/website/.vitepress/theme/AgentPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
-import { TOOLS } from './tools'
+import { TOOLS, parseGitErrorTool, resolveConflictTool } from './tools'
+import { SAMPLE_GIT_ERROR, SAMPLE_CONFLICT } from './tools/samples'
 import { registerTools, type Surface } from './webmcp'
 
 /**
@@ -33,6 +34,49 @@ onMounted(async () => {
 })
 
 onUnmounted(() => controller?.abort())
+
+/**
+ * Try-it panel. Calls the same `execute` an agent calls, not a mock of it,
+ * which is the only version of this worth shipping: if the panel disagreed
+ * with the tool, the page would be lying.
+ */
+
+type ToolId = 'resolve_conflict' | 'parse_git_error'
+
+const active = ref<ToolId>('resolve_conflict')
+const errorInput = ref(SAMPLE_GIT_ERROR)
+const conflictInput = ref(SAMPLE_CONFLICT)
+const conflictPath = ref('src/server.ts')
+const output = ref<string | null>(null)
+const running = ref(false)
+
+async function run() {
+  running.value = true
+  output.value = null
+  const signal = new AbortController().signal
+  try {
+    // Deliberately the un-instrumented tool: registerTools wraps a copy for
+    // its counter, so clicking here does not inflate the agent call count.
+    const result =
+      active.value === 'parse_git_error'
+        ? await parseGitErrorTool.execute({ output: errorInput.value }, { signal })
+        : await resolveConflictTool.execute(
+            { content: conflictInput.value, filePath: conflictPath.value },
+            { signal },
+          )
+    output.value = result.content.map((c) => c.text).join('\n')
+  } catch (err) {
+    output.value = `The tool threw: ${err instanceof Error ? err.message : String(err)}`
+  } finally {
+    running.value = false
+  }
+}
+
+function pick(id: ToolId) {
+  active.value = id
+  output.value = null
+}
+
 </script>
 
 <template>
@@ -102,6 +146,57 @@ onUnmounted(() => controller?.abort())
           <ul v-if="failed.length" class="st-failed">
             <li v-for="f in failed" :key="f.name"><code>{{ f.name }}</code> failed: {{ f.reason }}</li>
           </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Runs the real tools, so a visitor with no WebMCP can still see what an
+         agent would get back. -->
+    <section class="ph-section ph-section--alt">
+      <div class="ph-inner">
+        <h2 class="ph-h2">Try them without an agent</h2>
+        <p class="ph-secsub">
+          This runs the same code an agent calls. Nothing is sent anywhere: the engine executes in
+          this tab.
+        </p>
+
+        <div class="try">
+          <div class="try-tabs" role="tablist">
+            <button
+              v-for="id in (['resolve_conflict', 'parse_git_error'] as const)"
+              :key="id"
+              class="try-tab"
+              :class="{ 'try-tab--on': active === id }"
+              role="tab"
+              :aria-selected="active === id"
+              @click="pick(id)"
+            >
+              {{ id }}
+            </button>
+          </div>
+
+          <div v-if="active === 'resolve_conflict'" class="try-body">
+            <label class="try-label" for="try-path">File path</label>
+            <input id="try-path" v-model="conflictPath" class="try-input" spellcheck="false" />
+            <p class="try-hint">
+              The extension selects the format-aware resolvers, and the path is what identifies a
+              generated file. Try <code>pnpm-lock.yaml</code> to see that change the answer.
+            </p>
+
+            <label class="try-label" for="try-conflict">Conflicted file</label>
+            <textarea id="try-conflict" v-model="conflictInput" class="try-area" rows="14" spellcheck="false"></textarea>
+          </div>
+
+          <div v-else class="try-body">
+            <label class="try-label" for="try-error">Output of the failing git command</label>
+            <textarea id="try-error" v-model="errorInput" class="try-area" rows="8" spellcheck="false"></textarea>
+          </div>
+
+          <button class="try-run" :disabled="running" @click="run">
+            {{ running ? 'Running…' : `Call ${active}` }}
+          </button>
+
+          <pre v-if="output" class="try-out">{{ output }}</pre>
         </div>
       </div>
     </section>
@@ -189,6 +284,23 @@ onUnmounted(() => controller?.abort())
 .st-count--hot{color:var(--green);}
 .st-failed{margin:14px 0 0;padding-left:18px;font-size:13px;color:#f87171;}
 
+.try{max-width:760px;margin:0 auto;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:20px 22px;}
+.try-tabs{display:flex;gap:8px;margin-bottom:18px;flex-wrap:wrap;}
+.try-tab{font-family:'JetBrains Mono',monospace;font-size:13px;padding:7px 14px;border-radius:8px;background:transparent;color:var(--muted);border:1px solid var(--border-soft);cursor:pointer;transition:color .15s,border-color .15s;}
+.try-tab:hover{color:var(--text);}
+.try-tab--on{color:var(--purple);border-color:var(--border);background:rgba(124,58,237,0.1);}
+.try-body{display:flex;flex-direction:column;}
+.try-label{font-size:13px;font-weight:600;margin-bottom:6px;}
+.try-hint{font-size:12px;color:var(--muted);margin:6px 0 0;line-height:1.5;}
+.try-input,.try-area{width:100%;box-sizing:border-box;background:var(--bg);color:var(--text);border:1px solid var(--border-soft);border-radius:8px;padding:10px 12px;font-family:'JetBrains Mono',monospace;font-size:13px;line-height:1.6;}
+.try-input:focus,.try-area:focus{outline:none;border-color:var(--purple);}
+.try-area{resize:vertical;margin-bottom:4px;}
+.try-label + .try-area,.try-hint + .try-label{margin-top:0;}
+.try-body > .try-label:not(:first-child){margin-top:16px;}
+.try-run{margin-top:16px;align-self:flex-start;padding:10px 20px;border-radius:10px;font-size:14px;font-weight:600;background:var(--purple-d);color:#fff;border:1px solid var(--purple-d);cursor:pointer;font-family:'JetBrains Mono',monospace;}
+.try-run:hover:not(:disabled){background:var(--purple);}
+.try-run:disabled{opacity:0.6;cursor:default;}
+.try-out{margin:18px 0 0;padding:14px 16px;background:var(--bg);border:1px solid var(--border-soft);border-radius:8px;font-family:'JetBrains Mono',monospace;font-size:12.5px;line-height:1.6;white-space:pre-wrap;word-break:break-word;max-height:460px;overflow:auto;color:var(--text);}
 .tool{max-width:720px;margin:0 auto 20px;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:20px 22px;}
 .tool-name{margin:0 0 10px;font-size:16px;}
 .tool-name code{font-family:'JetBrains Mono',monospace;color:var(--purple);}

--- a/website/.vitepress/theme/ConflictEnginePage.vue
+++ b/website/.vitepress/theme/ConflictEnginePage.vue
@@ -1,26 +1,5 @@
 <script setup lang="ts">
-// 8 registry patterns auto-apply (auto: true). token_level_merge proposes
-// a merge you confirm; refactoring_aware_merge and llm_proposed are opt-in;
-// complex is the fallback that always hands the hunk back with its trace.
-// generated_file (registry: false) is NOT a classifier pattern: it is a
-// post-classification pass that rescues complex hunks whose path matches a
-// generated-file glob. Mirrors packages/core/src/classifier.ts and
-// packages/core/src/resolver/generated-detection.ts.
-const PATTERNS = [
-  { name: 'same_change',           conf: 'certain', auto: true, registry: true,  desc: 'Both branches made the exact same edit.' },
-  { name: 'one_side_change',       conf: 'certain', auto: true, registry: true,  desc: 'Only one branch touched this block.' },
-  { name: 'delete_no_change',      conf: 'certain', auto: true, registry: true,  desc: 'One side deleted the block, the other left it untouched.' },
-  { name: 'non_overlapping',       conf: 'high',    auto: true, registry: true,  desc: 'Additions at different positions in the block.' },
-  { name: 'whitespace_only',       conf: 'high',    auto: true, registry: true,  desc: 'Same logic, different indentation or spacing.' },
-  { name: 'reorder_only',          conf: 'high',    auto: true, registry: true,  desc: 'Same lines, different order.' },
-  { name: 'insertion_at_boundary', conf: 'high',    auto: true, registry: true,  desc: 'New lines added at the edge of a hunk.' },
-  { name: 'value_only_change',     conf: 'high',    auto: true, registry: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
-  { name: 'token_level_merge',     conf: 'medium',  auto: false, registry: true, desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
-  { name: 'refactoring_aware_merge', conf: 'high',  auto: false, registry: true, desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
-  { name: 'llm_proposed',          conf: 'medium',  auto: false, registry: true, desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
-  { name: 'complex',               conf: 'low',     auto: false, registry: true, desc: 'Overlapping edits — surfaced with full classification trace.' },
-  { name: 'generated_file',        conf: 'high',    auto: true,  registry: false, desc: 'Path matches a generated-file glob (lockfile, minified bundle, dist/). Reclassified out of complex and resolved to theirs: the file will be regenerated.' },
-] as const
+import { PATTERNS, AUTO_PATTERN_COUNT } from './patterns'
 </script>
 
 <template>
@@ -29,7 +8,7 @@ const PATTERNS = [
       <div class="ph-inner">
         <span class="ph-badge">Conflict engine</span>
         <h1 class="ph-h1">Deterministic conflict resolution. <span class="grad">No guessing.</span></h1>
-        <p class="ph-sub">Every hunk runs through a classifier of pattern recognizers — 8 of them resolve deterministically on their own, each with its own confidence profile. Conflicts that carry no decision are resolved without you. The rest is surfaced with a full decision trace — never a black box.</p>
+        <p class="ph-sub">Every hunk runs through a classifier of pattern recognizers — {{ AUTO_PATTERN_COUNT }} of them resolve deterministically on their own, each with its own confidence profile. Conflicts that carry no decision are resolved without you. The rest is surfaced with a full decision trace — never a black box.</p>
         <div class="ph-ctas">
           <a href="/guide/conflict-resolution" class="ph-btn ph-btn--primary">Read the deep dive</a>
           <a href="/" class="ph-btn">← Back to home</a>
@@ -66,8 +45,8 @@ const PATTERNS = [
 
     <section class="ph-section ph-section--alt">
       <div class="ph-inner">
-        <h2 class="ph-h2">8 auto-applied patterns, plus the generated-file pass.</h2>
-        <p class="ph-secsub">Eight deterministic patterns in the registry resolve on their own; the rest either propose a merge you confirm, are opt-in, or hand the hunk back with its trace. <code>generated_file</code> sits apart: it is not a registry pattern but a post-classification pass that rescues lockfiles and build output already classified as complex. The classifier never guesses; when it can't be certain, it stops.</p>
+        <h2 class="ph-h2">{{ AUTO_PATTERN_COUNT }} auto-applied patterns, plus the generated-file pass.</h2>
+        <p class="ph-secsub">{{ AUTO_PATTERN_COUNT }} deterministic patterns in the registry resolve on their own; the rest either propose a merge you confirm, are opt-in, or hand the hunk back with its trace. <code>generated_file</code> sits apart: it is not a registry pattern but a post-classification pass that rescues lockfiles and build output already classified as complex. The classifier never guesses; when it can't be certain, it stops.</p>
         <div class="pat-grid">
           <div v-for="p in PATTERNS" :key="p.name" class="pat" :class="{ 'pat--dim': !p.auto }">
             <div class="pat-head">

--- a/website/.vitepress/theme/ConflictEnginePage.vue
+++ b/website/.vitepress/theme/ConflictEnginePage.vue
@@ -1,20 +1,25 @@
 <script setup lang="ts">
-// 8 deterministic patterns auto-apply (auto: true). token_level_merge proposes
+// 8 registry patterns auto-apply (auto: true). token_level_merge proposes
 // a merge you confirm; refactoring_aware_merge and llm_proposed are opt-in;
 // complex is the fallback that always hands the hunk back with its trace.
+// generated_file (registry: false) is NOT a classifier pattern: it is a
+// post-classification pass that rescues complex hunks whose path matches a
+// generated-file glob. Mirrors packages/core/src/classifier.ts and
+// packages/core/src/resolver/generated-detection.ts.
 const PATTERNS = [
-  { name: 'same_change',           conf: 'certain', auto: true,  desc: 'Both branches made the exact same edit.' },
-  { name: 'one_side_change',       conf: 'certain', auto: true,  desc: 'Only one branch touched this block.' },
-  { name: 'delete_no_change',      conf: 'certain', auto: true,  desc: 'One side deleted the block, the other left it untouched.' },
-  { name: 'non_overlapping',       conf: 'high',    auto: true,  desc: 'Additions at different positions in the block.' },
-  { name: 'whitespace_only',       conf: 'high',    auto: true,  desc: 'Same logic, different indentation or spacing.' },
-  { name: 'reorder_only',          conf: 'high',    auto: true,  desc: 'Same lines, different order.' },
-  { name: 'insertion_at_boundary', conf: 'high',    auto: true,  desc: 'New lines added at the edge of a hunk.' },
-  { name: 'value_only_change',     conf: 'high',    auto: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
-  { name: 'token_level_merge',     conf: 'medium',  auto: false, desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
-  { name: 'refactoring_aware_merge', conf: 'high',  auto: false, desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
-  { name: 'llm_proposed',          conf: 'medium',  auto: false, desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
-  { name: 'complex',               conf: 'low',     auto: false, desc: 'Overlapping edits — surfaced with full classification trace.' },
+  { name: 'same_change',           conf: 'certain', auto: true, registry: true,  desc: 'Both branches made the exact same edit.' },
+  { name: 'one_side_change',       conf: 'certain', auto: true, registry: true,  desc: 'Only one branch touched this block.' },
+  { name: 'delete_no_change',      conf: 'certain', auto: true, registry: true,  desc: 'One side deleted the block, the other left it untouched.' },
+  { name: 'non_overlapping',       conf: 'high',    auto: true, registry: true,  desc: 'Additions at different positions in the block.' },
+  { name: 'whitespace_only',       conf: 'high',    auto: true, registry: true,  desc: 'Same logic, different indentation or spacing.' },
+  { name: 'reorder_only',          conf: 'high',    auto: true, registry: true,  desc: 'Same lines, different order.' },
+  { name: 'insertion_at_boundary', conf: 'high',    auto: true, registry: true,  desc: 'New lines added at the edge of a hunk.' },
+  { name: 'value_only_change',     conf: 'high',    auto: true, registry: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
+  { name: 'token_level_merge',     conf: 'medium',  auto: false, registry: true, desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
+  { name: 'refactoring_aware_merge', conf: 'high',  auto: false, registry: true, desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
+  { name: 'llm_proposed',          conf: 'medium',  auto: false, registry: true, desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
+  { name: 'complex',               conf: 'low',     auto: false, registry: true, desc: 'Overlapping edits — surfaced with full classification trace.' },
+  { name: 'generated_file',        conf: 'high',    auto: true,  registry: false, desc: 'Path matches a generated-file glob (lockfile, minified bundle, dist/). Reclassified out of complex and resolved to theirs: the file will be regenerated.' },
 ] as const
 </script>
 
@@ -61,8 +66,8 @@ const PATTERNS = [
 
     <section class="ph-section ph-section--alt">
       <div class="ph-inner">
-        <h2 class="ph-h2">8 auto-applied patterns. Deterministic. Auditable.</h2>
-        <p class="ph-secsub">Eight deterministic patterns resolve on their own; the rest below either propose a merge you confirm, are opt-in, or hand the hunk back with its trace. The classifier never guesses — when it can't be certain, it stops.</p>
+        <h2 class="ph-h2">8 auto-applied patterns, plus the generated-file pass.</h2>
+        <p class="ph-secsub">Eight deterministic patterns in the registry resolve on their own; the rest either propose a merge you confirm, are opt-in, or hand the hunk back with its trace. <code>generated_file</code> sits apart: it is not a registry pattern but a post-classification pass that rescues lockfiles and build output already classified as complex. The classifier never guesses; when it can't be certain, it stops.</p>
         <div class="pat-grid">
           <div v-for="p in PATTERNS" :key="p.name" class="pat" :class="{ 'pat--dim': !p.auto }">
             <div class="pat-head">
@@ -71,6 +76,7 @@ const PATTERNS = [
             </div>
             <p class="pat-desc">{{ p.desc }}</p>
             <div class="pat-auto" :class="p.auto ? 'pat-auto--yes' : 'pat-auto--no'">{{ p.auto ? '⚡ Auto-resolved' : '○ Review needed' }}</div>
+            <p v-if="!p.registry" class="pat-note">Post-classification pass, not a classifier pattern.</p>
           </div>
         </div>
       </div>
@@ -142,6 +148,7 @@ const PATTERNS = [
 .pat-conf--low{color:#94a3b8;background:rgba(148,163,184,0.12);}
 .pat-desc{font-size:13px;color:var(--muted);line-height:1.55;margin:0 0 12px;}
 .pat-auto{font-size:12px;font-weight:600;}.pat-auto--yes{color:var(--green);}.pat-auto--no{color:var(--muted);}
+.pat-note{font-size:11px;color:var(--muted);font-style:italic;margin:6px 0 0;line-height:1.4;}
 .bench{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:16px;}
 .bcard{background:var(--card);border:1px solid var(--border);border-radius:12px;padding:24px;text-align:center;}
 .bcard--p{border-color:rgba(124,58,237,0.4);}.bcard--g{border-color:rgba(16,185,129,0.4);}

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -41,22 +41,27 @@ function runTerminalDemo() {
 
 
 // ── Resolution patterns (technical — not localised) ───────────────────────────
-// 8 deterministic patterns auto-apply (auto: true). token_level_merge proposes
+// 8 registry patterns auto-apply (auto: true). token_level_merge proposes
 // a merge you confirm; refactoring_aware_merge and llm_proposed are opt-in;
 // complex is the fallback that always hands the hunk back with its trace.
+// generated_file (registry: false) is NOT a classifier pattern: it is a
+// post-classification pass that rescues complex hunks whose path matches a
+// generated-file glob. Mirrors packages/core/src/classifier.ts and
+// packages/core/src/resolver/generated-detection.ts.
 const PATTERNS = [
-  { name: 'same_change',           conf: 'certain', auto: true,  desc: 'Both branches made the exact same edit.' },
-  { name: 'one_side_change',       conf: 'certain', auto: true,  desc: 'Only one branch touched this block.' },
-  { name: 'delete_no_change',      conf: 'certain', auto: true,  desc: 'One side deleted the block, the other left it untouched.' },
-  { name: 'non_overlapping',       conf: 'high',    auto: true,  desc: 'Additions at different positions in the block.' },
-  { name: 'whitespace_only',       conf: 'high',    auto: true,  desc: 'Same logic, different indentation or spacing.' },
-  { name: 'reorder_only',          conf: 'high',    auto: true,  desc: 'Same lines, different order.' },
-  { name: 'insertion_at_boundary', conf: 'high',    auto: true,  desc: 'New lines added at the edge of a hunk.' },
-  { name: 'value_only_change',     conf: 'high',    auto: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
-  { name: 'token_level_merge',     conf: 'medium',  auto: false, desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
-  { name: 'refactoring_aware_merge', conf: 'high',  auto: false, desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
-  { name: 'llm_proposed',          conf: 'medium',  auto: false, desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
-  { name: 'complex',               conf: 'low',     auto: false, desc: 'Overlapping edits — surfaced with full classification trace.' },
+  { name: 'same_change',           conf: 'certain', auto: true, registry: true,  desc: 'Both branches made the exact same edit.' },
+  { name: 'one_side_change',       conf: 'certain', auto: true, registry: true,  desc: 'Only one branch touched this block.' },
+  { name: 'delete_no_change',      conf: 'certain', auto: true, registry: true,  desc: 'One side deleted the block, the other left it untouched.' },
+  { name: 'non_overlapping',       conf: 'high',    auto: true, registry: true,  desc: 'Additions at different positions in the block.' },
+  { name: 'whitespace_only',       conf: 'high',    auto: true, registry: true,  desc: 'Same logic, different indentation or spacing.' },
+  { name: 'reorder_only',          conf: 'high',    auto: true, registry: true,  desc: 'Same lines, different order.' },
+  { name: 'insertion_at_boundary', conf: 'high',    auto: true, registry: true,  desc: 'New lines added at the edge of a hunk.' },
+  { name: 'value_only_change',     conf: 'high',    auto: true, registry: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
+  { name: 'token_level_merge',     conf: 'medium',  auto: false, registry: true, desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
+  { name: 'refactoring_aware_merge', conf: 'high',  auto: false, registry: true, desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
+  { name: 'llm_proposed',          conf: 'medium',  auto: false, registry: true, desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
+  { name: 'complex',               conf: 'low',     auto: false, registry: true, desc: 'Overlapping edits — surfaced with full classification trace.' },
+  { name: 'generated_file',        conf: 'high',    auto: true,  registry: false, desc: 'Path matches a generated-file glob (lockfile, minified bundle, dist/). Reclassified out of complex and resolved to theirs: the file will be regenerated.' },
 ] as const
 
 // Short labels keep the picker compact; `title` surfaces the full native name on hover.

--- a/website/.vitepress/theme/HomeLanding.vue
+++ b/website/.vitepress/theme/HomeLanding.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
+import { AUTO_PATTERN_COUNT } from './patterns'
 
 type Locale = 'en' | 'fr' | 'es' | 'pt-BR' | 'zh-CN'
 
@@ -40,29 +41,6 @@ function runTerminalDemo() {
 }
 
 
-// ── Resolution patterns (technical — not localised) ───────────────────────────
-// 8 registry patterns auto-apply (auto: true). token_level_merge proposes
-// a merge you confirm; refactoring_aware_merge and llm_proposed are opt-in;
-// complex is the fallback that always hands the hunk back with its trace.
-// generated_file (registry: false) is NOT a classifier pattern: it is a
-// post-classification pass that rescues complex hunks whose path matches a
-// generated-file glob. Mirrors packages/core/src/classifier.ts and
-// packages/core/src/resolver/generated-detection.ts.
-const PATTERNS = [
-  { name: 'same_change',           conf: 'certain', auto: true, registry: true,  desc: 'Both branches made the exact same edit.' },
-  { name: 'one_side_change',       conf: 'certain', auto: true, registry: true,  desc: 'Only one branch touched this block.' },
-  { name: 'delete_no_change',      conf: 'certain', auto: true, registry: true,  desc: 'One side deleted the block, the other left it untouched.' },
-  { name: 'non_overlapping',       conf: 'high',    auto: true, registry: true,  desc: 'Additions at different positions in the block.' },
-  { name: 'whitespace_only',       conf: 'high',    auto: true, registry: true,  desc: 'Same logic, different indentation or spacing.' },
-  { name: 'reorder_only',          conf: 'high',    auto: true, registry: true,  desc: 'Same lines, different order.' },
-  { name: 'insertion_at_boundary', conf: 'high',    auto: true, registry: true,  desc: 'New lines added at the edge of a hunk.' },
-  { name: 'value_only_change',     conf: 'high',    auto: true, registry: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
-  { name: 'token_level_merge',     conf: 'medium',  auto: false, registry: true, desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
-  { name: 'refactoring_aware_merge', conf: 'high',  auto: false, registry: true, desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
-  { name: 'llm_proposed',          conf: 'medium',  auto: false, registry: true, desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
-  { name: 'complex',               conf: 'low',     auto: false, registry: true, desc: 'Overlapping edits — surfaced with full classification trace.' },
-  { name: 'generated_file',        conf: 'high',    auto: true,  registry: false, desc: 'Path matches a generated-file glob (lockfile, minified bundle, dist/). Reclassified out of complex and resolved to theirs: the file will be regenerated.' },
-] as const
 
 // Short labels keep the picker compact; `title` surfaces the full native name on hover.
 const LOCALES: { code: Locale; label: string; title: string }[] = [
@@ -857,7 +835,7 @@ function cellClass(v: CompareValue | undefined): string {
     ══════════════════════════════════════ -->
     <section class="stats-bar">
       <div class="stat">
-        <span class="stat-n">8</span>
+        <span class="stat-n">{{ AUTO_PATTERN_COUNT }}</span>
         <span class="stat-l">{{ t.statPatterns }}</span>
       </div>
       <div class="stat-sep"></div>

--- a/website/.vitepress/theme/__tests__/webmcp.test.ts
+++ b/website/.vitepress/theme/__tests__/webmcp.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { detectSurface, registerTools, type WebMcpTool } from '../webmcp'
 import { matchGitErrors } from '../tools/git-errors'
 import { parseGitErrorTool, resolveConflictTool } from '../tools'
+import { SAMPLE_GIT_ERROR, SAMPLE_CONFLICT } from '../tools/samples'
 
 function fakeModelContext() {
   const calls: { tool: WebMcpTool; options?: { signal?: AbortSignal } }[] = []
@@ -228,5 +229,40 @@ describe('resolve_conflict tool', () => {
   it('rejects empty input', async () => {
     const r = await resolveConflictTool.execute({ content: '' }, { signal })
     expect(r.content[0].text).toContain('No content provided')
+  })
+})
+
+describe('try-it panel samples', () => {
+  const signal = new AbortController().signal
+
+  it('the conflict sample shows both halves of the pitch in one run', async () => {
+    // The whole point of this sample is that it resolves one hunk and refuses
+    // the other. If a pattern change ever makes it resolve both, or neither,
+    // the demo stops demonstrating anything and this test should say so.
+    const r = await resolveConflictTool.execute(
+      { content: SAMPLE_CONFLICT, filePath: 'src/server.ts' },
+      { signal },
+    )
+    const text = r.content[0].text
+
+    expect(text).toContain('2 conflicts found')
+    expect(text).toContain('1 resolved deterministically, 1 left for you')
+    // Pin the classifications, not just the counts. A sample where both hunks
+    // land on `complex` still satisfies the counts while showing the reader
+    // nothing about how the engine decides.
+    expect(text).toContain('same_change')
+    expect(text).toContain('complex')
+    expect(text).toContain('NEEDS REVIEW')
+  })
+
+  it('the git error sample matches more than one failure', async () => {
+    // Chosen to show that a real paste usually carries several problems and
+    // that the tool reports all of them rather than the first.
+    const ids = matchGitErrors(SAMPLE_GIT_ERROR).map((m) => m.entry.id)
+    expect(ids).toContain('push_rejected')
+    expect(ids).toContain('merge_head_exists')
+
+    const r = await parseGitErrorTool.execute({ output: SAMPLE_GIT_ERROR }, { signal })
+    expect(r.content[0].text).toContain('2 known git errors matched')
   })
 })

--- a/website/.vitepress/theme/__tests__/webmcp.test.ts
+++ b/website/.vitepress/theme/__tests__/webmcp.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { detectSurface, registerTools, type WebMcpTool } from '../webmcp'
+import { matchGitErrors } from '../tools/git-errors'
+import { parseGitErrorTool, resolveConflictTool } from '../tools'
+
+function fakeModelContext() {
+  const calls: { tool: WebMcpTool; options?: { signal?: AbortSignal } }[] = []
+  return {
+    calls,
+    registerTool(tool: WebMcpTool, options?: { signal?: AbortSignal }) {
+      calls.push({ tool, options })
+      return Promise.resolve()
+    },
+  }
+}
+
+const g = globalThis as any
+
+describe('surface detection', () => {
+  beforeEach(() => {
+    // Node 21+ defines globalThis.navigator as a getter-only property, so it
+    // has to be stubbed rather than assigned.
+    vi.stubGlobal('document', {})
+    vi.stubGlobal('navigator', {})
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('returns null when the browser has no WebMCP at all', () => {
+    expect(detectSurface()).toBe(null)
+  })
+
+  it('prefers document, which is where the spec puts it', () => {
+    g.document.modelContext = fakeModelContext()
+    g.navigator.modelContext = fakeModelContext()
+    expect(detectSurface()).toBe('document')
+  })
+
+  it('falls back to the deprecated navigator location when it is the only one', () => {
+    g.navigator.modelContext = fakeModelContext()
+    expect(detectSurface()).toBe('navigator')
+  })
+})
+
+describe('registration', () => {
+  const tool: WebMcpTool = {
+    name: 'noop',
+    description: 'does nothing',
+    inputSchema: { type: 'object', properties: {} },
+    execute: async () => ({ content: [{ type: 'text' as const, text: 'ok' }] }),
+  }
+
+  beforeEach(() => {
+    // Node 21+ defines globalThis.navigator as a getter-only property, so it
+    // has to be stubbed rather than assigned.
+    vi.stubGlobal('document', {})
+    vi.stubGlobal('navigator', {})
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('registers each tool exactly once when both locations are aliases', async () => {
+    // Chrome 150 keeps navigator.modelContext as an alias to the same object.
+    // Registering on both surfaces would register every tool twice.
+    const shared = fakeModelContext()
+    g.document.modelContext = shared
+    g.navigator.modelContext = shared
+
+    const ac = new AbortController()
+    const outcome = await registerTools([tool], { signal: ac.signal })
+
+    expect(outcome.surface).toBe('document')
+    expect(outcome.registered).toEqual(['noop'])
+    expect(shared.calls).toHaveLength(1)
+  })
+
+  it('passes the signal in the options argument, not on the tool dictionary', async () => {
+    // ModelContextTool declares no `signal` member, so a signal set on the tool
+    // itself is dropped and the tool can never be unregistered.
+    const mc = fakeModelContext()
+    g.document.modelContext = mc
+    const ac = new AbortController()
+
+    await registerTools([tool], { signal: ac.signal })
+
+    expect(mc.calls[0].options?.signal).toBe(ac.signal)
+    expect((mc.calls[0].tool as any).signal).toBeUndefined()
+  })
+
+  it('reports a failing registration instead of throwing', async () => {
+    g.document.modelContext = {
+      registerTool: () => Promise.reject(new Error('name already taken')),
+    }
+    const outcome = await registerTools([tool], { signal: new AbortController().signal })
+
+    expect(outcome.registered).toEqual([])
+    expect(outcome.failed).toEqual([{ name: 'noop', reason: 'name already taken' }])
+  })
+
+  it('counts every call through onCall', async () => {
+    const mc = fakeModelContext()
+    g.document.modelContext = mc
+    const onCall = vi.fn()
+
+    await registerTools([tool], { signal: new AbortController().signal, onCall })
+    const registered = mc.calls[0].tool
+    await registered.execute({}, { signal: new AbortController().signal })
+    await registered.execute({}, { signal: new AbortController().signal })
+
+    expect(onCall).toHaveBeenCalledTimes(2)
+    expect(onCall).toHaveBeenCalledWith('noop')
+  })
+
+  it('does nothing, and says so, when the browser has no WebMCP', async () => {
+    const outcome = await registerTools([tool], { signal: new AbortController().signal })
+    expect(outcome).toEqual({ surface: null, registered: [], failed: [] })
+  })
+})
+
+describe('matchGitErrors', () => {
+  it('recognises a merge conflict', () => {
+    const out = matchGitErrors(
+      'Auto-merging src/app.ts\nCONFLICT (content): Merge conflict in src/app.ts\nAutomatic merge failed; fix conflicts and then commit the result.',
+    )
+    expect(out.map((m) => m.entry.id)).toContain('merge_conflict')
+  })
+
+  it('reports every error in a paste, not just the first', () => {
+    const out = matchGitErrors(
+      [
+        'error: failed to push some refs to git@github.com:acme/app.git',
+        'hint: Updates were rejected because the remote contains work that you do not have.',
+        'fatal: You have not concluded your merge (MERGE_HEAD exists).',
+      ].join('\n'),
+    )
+    const ids = out.map((m) => m.entry.id)
+    expect(ids).toContain('push_rejected')
+    expect(ids).toContain('merge_head_exists')
+  })
+
+  it('never reports the same entry twice', () => {
+    const out = matchGitErrors('CONFLICT (content): a\nCONFLICT (content): b\nCONFLICT (content): c')
+    expect(out.filter((m) => m.entry.id === 'merge_conflict')).toHaveLength(1)
+  })
+
+  it('returns nothing for output it does not know', () => {
+    expect(matchGitErrors('Everything up-to-date')).toEqual([])
+  })
+
+  it('names GitWand on conflicts and stays quiet elsewhere', () => {
+    const conflict = matchGitErrors('CONFLICT (content): Merge conflict in a.ts')
+    expect(conflict[0].entry.gitwand).toBeTruthy()
+
+    const auth = matchGitErrors('remote: Authentication failed for https://github.com/acme/app')
+    expect(auth[0].entry.gitwand).toBeUndefined()
+  })
+})
+
+describe('parse_git_error tool', () => {
+  const signal = new AbortController().signal
+
+  it('explains a recognised failure', async () => {
+    const r = await parseGitErrorTool.execute(
+      { output: 'fatal: refusing to merge unrelated histories' },
+      { signal },
+    )
+    expect(r.content[0].text).toContain('share no common commit')
+    expect(r.content[0].text).toContain('--allow-unrelated-histories')
+  })
+
+  it('asks for input rather than guessing when given none', async () => {
+    const r = await parseGitErrorTool.execute({ output: '   ' }, { signal })
+    expect(r.content[0].text).toContain('No output provided')
+  })
+
+  it('says plainly when nothing matched', async () => {
+    const r = await parseGitErrorTool.execute({ output: 'Everything up-to-date' }, { signal })
+    expect(r.content[0].text).toContain('No known git error matched')
+  })
+})
+
+describe('resolve_conflict tool', () => {
+  const signal = new AbortController().signal
+
+  it('resolves a hunk that carries no decision', async () => {
+    const conflicted = [
+      'const a = 1',
+      '<<<<<<< ours',
+      'const b = 3',
+      '||||||| base',
+      'const b = 2',
+      '=======',
+      'const b = 3',
+      '>>>>>>> theirs',
+      'const c = 4',
+    ].join('\n')
+
+    const r = await resolveConflictTool.execute({ content: conflicted, filePath: 'src/a.ts' }, { signal })
+    const text = r.content[0].text
+
+    expect(text).toContain('same_change')
+    expect(text).toContain('1 resolved deterministically, 0 left for you')
+    expect(text).toContain('const b = 3')
+    expect(text).not.toContain('<<<<<<<')
+  })
+
+  it('hands back a genuinely overlapping edit instead of guessing', async () => {
+    const conflicted = [
+      '<<<<<<< ours',
+      'const x = 1',
+      '||||||| base',
+      'const x = 0',
+      '=======',
+      'const x = 2',
+      '>>>>>>> theirs',
+    ].join('\n')
+
+    const r = await resolveConflictTool.execute({ content: conflicted, filePath: 'src/a.ts' }, { signal })
+    const text = r.content[0].text
+
+    expect(text).toContain('complex')
+    expect(text).toContain('NEEDS REVIEW')
+  })
+
+  it('rejects content with no conflict markers', async () => {
+    const r = await resolveConflictTool.execute({ content: 'const a = 1' }, { signal })
+    expect(r.content[0].text).toContain('No conflict markers found')
+  })
+
+  it('rejects empty input', async () => {
+    const r = await resolveConflictTool.execute({ content: '' }, { signal })
+    expect(r.content[0].text).toContain('No content provided')
+  })
+})

--- a/website/.vitepress/theme/__tests__/webmcp.test.ts
+++ b/website/.vitepress/theme/__tests__/webmcp.test.ts
@@ -4,6 +4,14 @@ import { matchGitErrors } from '../tools/git-errors'
 import { parseGitErrorTool, resolveConflictTool } from '../tools'
 import { SAMPLE_GIT_ERROR, SAMPLE_CONFLICT } from '../tools/samples'
 
+// resolve_conflict loads @gitwand/core through a dynamic import, and the vitest
+// alias points at the TypeScript source rather than a built dist, so the first
+// call pays for Vite transforming the whole engine. That is comfortably over
+// vitest's 5s default on a cold cache (5028ms observed), and warm on every run
+// after, which is exactly the shape of a test that passes locally and fails in
+// CI. See issue #172 for the same problem in the git-backed suites.
+const ENGINE_LOAD_TIMEOUT_MS = 30_000
+
 function fakeModelContext() {
   const calls: { tool: WebMcpTool; options?: { signal?: AbortSignal } }[] = []
   return {
@@ -178,7 +186,7 @@ describe('parse_git_error tool', () => {
   })
 })
 
-describe('resolve_conflict tool', () => {
+describe('resolve_conflict tool', { timeout: ENGINE_LOAD_TIMEOUT_MS }, () => {
   const signal = new AbortController().signal
 
   it('resolves a hunk that carries no decision', async () => {
@@ -232,7 +240,7 @@ describe('resolve_conflict tool', () => {
   })
 })
 
-describe('try-it panel samples', () => {
+describe('try-it panel samples', { timeout: ENGINE_LOAD_TIMEOUT_MS }, () => {
   const signal = new AbortController().signal
 
   it('the conflict sample shows both halves of the pitch in one run', async () => {

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -4,6 +4,7 @@ import HomeLanding from './HomeLanding.vue'
 import FeaturesPage from './FeaturesPage.vue'
 import ConflictEnginePage from './ConflictEnginePage.vue'
 import AiAgentsPage from './AiAgentsPage.vue'
+import AgentPage from './AgentPage.vue'
 import CompareMatrix from './CompareMatrix.vue'
 import './custom.css'
 
@@ -14,6 +15,7 @@ export default {
     app.component('FeaturesPage', FeaturesPage)
     app.component('ConflictEnginePage', ConflictEnginePage)
     app.component('AiAgentsPage', AiAgentsPage)
+    app.component('AgentPage', AgentPage)
     app.component('CompareMatrix', CompareMatrix)
   },
 } satisfies Theme

--- a/website/.vitepress/theme/patterns.ts
+++ b/website/.vitepress/theme/patterns.ts
@@ -1,0 +1,48 @@
+/**
+ * Resolution patterns, mirrored from packages/core/src/classifier.ts.
+ *
+ * Technical names, deliberately not localised: they are the identifiers the
+ * engine emits in its decision trace, and they read the same in every locale.
+ *
+ * - `registry: true`  a pattern in the classifier registry, evaluated in
+ *   priority order until one matches.
+ * - `registry: false` not a classifier pattern at all. `generated_file` is a
+ *   post-classification pass that rescues `complex` hunks whose path matches a
+ *   generated-file glob (packages/core/src/resolver/generated-detection.ts).
+ * - `auto: true` resolved without human confirmation.
+ *
+ * Keep in sync with the classifier. `AUTO_PATTERN_COUNT` is derived, so the
+ * homepage stats bar follows automatically; the localised "8 deterministic
+ * patterns" strings in HomeLanding.vue are still hand-written and have to be
+ * updated alongside it.
+ */
+export type ResolutionPattern = {
+  /** Identifier emitted in the decision trace. */
+  name: string
+  /** Indicative label only: every hunk carries a computed composite score. */
+  conf: 'certain' | 'high' | 'medium' | 'low'
+  /** Resolved without asking the user. */
+  auto: boolean
+  /** Lives in the classifier registry, as opposed to a post-classification pass. */
+  registry: boolean
+  desc: string
+}
+
+export const PATTERNS: readonly ResolutionPattern[] = [
+  { name: 'same_change',             conf: 'certain', auto: true,  registry: true,  desc: 'Both branches made the exact same edit.' },
+  { name: 'one_side_change',         conf: 'certain', auto: true,  registry: true,  desc: 'Only one branch touched this block.' },
+  { name: 'delete_no_change',        conf: 'certain', auto: true,  registry: true,  desc: 'One side deleted the block, the other left it untouched.' },
+  { name: 'non_overlapping',         conf: 'high',    auto: true,  registry: true,  desc: 'Additions at different positions in the block.' },
+  { name: 'whitespace_only',         conf: 'high',    auto: true,  registry: true,  desc: 'Same logic, different indentation or spacing.' },
+  { name: 'reorder_only',            conf: 'high',    auto: true,  registry: true,  desc: 'Same lines, different order.' },
+  { name: 'insertion_at_boundary',   conf: 'high',    auto: true,  registry: true,  desc: 'New lines added at the edge of a hunk.' },
+  { name: 'value_only_change',       conf: 'high',    auto: true,  registry: true,  desc: 'A scalar value (version, timestamp, hash) updated on both sides — keeps the higher semver / later timestamp.' },
+  { name: 'token_level_merge',       conf: 'medium',  auto: false, registry: true,  desc: 'Both sides changed disjoint tokens on the same line — proposes a merge you confirm, never auto-applied.' },
+  { name: 'refactoring_aware_merge', conf: 'high',    auto: false, registry: true,  desc: 'Rename/move detected and replayed across the conflict (opt-in).' },
+  { name: 'llm_proposed',            conf: 'medium',  auto: false, registry: true,  desc: 'AI-proposed resolution, validated post-merge (opt-in).' },
+  { name: 'complex',                 conf: 'low',     auto: false, registry: true,  desc: 'Overlapping edits — surfaced with full classification trace.' },
+  { name: 'generated_file',          conf: 'high',    auto: true,  registry: false, desc: 'Path matches a generated-file glob (lockfile, minified bundle, dist/). Reclassified out of complex and resolved to theirs: the file will be regenerated.' },
+]
+
+/** Registry patterns that auto-apply: the number the site claims. */
+export const AUTO_PATTERN_COUNT = PATTERNS.filter((p) => p.auto && p.registry).length

--- a/website/.vitepress/theme/tools/git-errors.ts
+++ b/website/.vitepress/theme/tools/git-errors.ts
@@ -1,0 +1,204 @@
+/**
+ * A catalogue of git failures an agent is likely to paste in, each with the
+ * cause in plain words and the commands that actually resolve it.
+ *
+ * Two rules kept this list useful rather than promotional:
+ *  - GitWand is named only where it genuinely applies (conflict resolution).
+ *    A tool that answers every question with "install our product" gets
+ *    called once and never again.
+ *  - Every command here is one a maintainer would actually run. No
+ *    `--force` on shared branches, no destructive suggestion without the
+ *    non-destructive option listed first.
+ */
+
+export interface GitErrorFix {
+  command: string
+  /** When this is the right one to reach for. */
+  when: string
+}
+
+export interface GitErrorEntry {
+  id: string
+  /** Matched against the pasted output, case-insensitively. */
+  match: RegExp
+  title: string
+  cause: string
+  fixes: GitErrorFix[]
+  /** Only set where GitWand is genuinely the better answer. */
+  gitwand?: string
+}
+
+export const GIT_ERRORS: GitErrorEntry[] = [
+  {
+    id: 'merge_conflict',
+    match: /CONFLICT \(|Automatic merge failed|fix conflicts and then commit/i,
+    title: 'Merge conflict: both sides changed the same region',
+    cause:
+      'Git merged what it could and stopped on the hunks where both branches edited overlapping lines. The listed files now contain conflict markers (<<<<<<<, =======, >>>>>>>) and the merge is paused, not failed.',
+    fixes: [
+      { command: 'git diff --name-only --diff-filter=U', when: 'List exactly which files are still conflicted.' },
+      { command: 'git merge --abort', when: 'Back out entirely and return to the pre-merge state.' },
+      { command: 'git checkout --ours <file> && git add <file>', when: 'Keep your side of one file wholesale, when you know theirs is redundant.' },
+    ],
+    gitwand:
+      'Many of these hunks carry no decision at all: identical edits on both sides, pure reordering, whitespace, insertions at different positions. `npx @gitwand/cli resolve` classifies each hunk against a deterministic pattern registry, resolves those, and hands back only the ones that need a human, each with a decision trace. Run `npx @gitwand/cli preview` first to see what it would do without writing anything.',
+  },
+  {
+    id: 'unrelated_histories',
+    match: /refusing to merge unrelated histories/i,
+    title: 'The two branches share no common commit',
+    cause:
+      'Git found no merge base. Usually one side was re-initialised, or a fresh `git init` was pushed over a remote that already had history, or two genuinely separate projects got wired to the same remote.',
+    fixes: [
+      { command: 'git log --oneline -5 FETCH_HEAD', when: 'Look at what you are about to merge before forcing it. If this is not the project you expected, the remote is wrong, not the flag.' },
+      { command: 'git merge --allow-unrelated-histories <branch>', when: 'You confirmed both histories belong together, e.g. joining a repo that was split.' },
+    ],
+  },
+  {
+    id: 'local_changes_overwritten',
+    match: /local changes to the following files would be overwritten/i,
+    title: 'Uncommitted work sits in files the operation needs to touch',
+    cause:
+      'Git refuses to clobber changes that exist nowhere but your working tree. Nothing has been lost and nothing has been changed yet.',
+    fixes: [
+      { command: 'git stash push -u -m "wip"', when: 'Set the work aside, run the operation, then `git stash pop`.' },
+      { command: 'git commit -am "wip"', when: 'The work is coherent enough to keep as a commit you can amend later.' },
+      { command: 'git checkout -- <file>', when: 'The local change is genuinely disposable. This discards it permanently.' },
+    ],
+  },
+  {
+    id: 'push_rejected',
+    match: /failed to push some refs|Updates were rejected because|non-fast-forward/i,
+    title: 'The remote branch has commits you do not have',
+    cause:
+      'Someone else pushed since you last fetched, so your push would drop their commits. Git rejects it rather than losing work.',
+    fixes: [
+      { command: 'git pull --rebase origin <branch>', when: 'The normal case: replay your commits on top of theirs, then push.' },
+      { command: 'git fetch origin && git log --oneline HEAD..origin/<branch>', when: 'Inspect what landed upstream before deciding how to reconcile.' },
+      { command: 'git push --force-with-lease', when: 'You deliberately rewrote your own branch and no one else works on it. `--force-with-lease` refuses if the remote moved again; plain `--force` does not.' },
+    ],
+  },
+  {
+    id: 'no_upstream',
+    match: /has no upstream branch|set the remote as upstream/i,
+    title: 'The branch exists locally but was never pushed',
+    cause: 'Git will not guess which remote branch this one should track.',
+    fixes: [{ command: 'git push -u origin HEAD', when: 'Push and set the tracking relationship in one step.' }],
+  },
+  {
+    id: 'divergent_branches',
+    match: /divergent branches|need to specify how to reconcile/i,
+    title: 'Pull will not guess between merge and rebase',
+    cause:
+      'Local and remote both moved. Since Git 2.27 the default is to refuse rather than silently pick a strategy that rewrites history or adds a merge commit.',
+    fixes: [
+      { command: 'git pull --rebase', when: 'Keep a linear history. The usual choice on a feature branch.' },
+      { command: 'git pull --no-rebase', when: 'Record the divergence as a merge commit.' },
+      { command: 'git config pull.rebase true', when: 'Settle it once for this repo so the prompt stops coming back.' },
+    ],
+  },
+  {
+    id: 'merge_head_exists',
+    match: /MERGE_HEAD exists|not concluded your merge/i,
+    title: 'A merge is still in progress',
+    cause: 'A previous merge stopped on conflicts and was never finished or aborted. Git blocks new operations until it is settled.',
+    fixes: [
+      { command: 'git status', when: 'See what is still unresolved.' },
+      { command: 'git commit', when: 'Conflicts are resolved and staged: conclude the merge.' },
+      { command: 'git merge --abort', when: 'Discard the merge and return to the previous state.' },
+    ],
+  },
+  {
+    id: 'rebase_in_progress',
+    match: /rebase-merge directory|rebase-apply|rebase is in progress/i,
+    title: 'A rebase is still in progress',
+    cause: 'A rebase stopped, usually on a conflict, and was neither continued nor aborted.',
+    fixes: [
+      { command: 'git rebase --continue', when: 'The conflict is resolved and staged.' },
+      { command: 'git rebase --skip', when: 'This particular commit is no longer needed.' },
+      { command: 'git rebase --abort', when: 'Return to where the branch was before the rebase started.' },
+    ],
+  },
+  {
+    id: 'pathspec_no_match',
+    match: /pathspec .* did not match any file/i,
+    title: 'That branch or path does not exist locally',
+    cause:
+      'Either a typo, or the branch exists only on the remote and has not been fetched yet.',
+    fixes: [
+      { command: 'git fetch origin', when: 'The branch was created by someone else and you have a stale view.' },
+      { command: 'git branch -a', when: 'List every branch, local and remote-tracking, to find the real name.' },
+    ],
+  },
+  {
+    id: 'not_a_repository',
+    match: /not a git repository/i,
+    title: 'This directory is not inside a git repository',
+    cause: 'The command ran outside any working tree, or in a directory whose .git was never created.',
+    fixes: [
+      { command: 'git rev-parse --show-toplevel', when: 'Print the repo root, or fail, which confirms the diagnosis.' },
+      { command: 'git init', when: 'This really is a new project that should be under version control.' },
+    ],
+  },
+  {
+    id: 'detached_head',
+    match: /detached HEAD/i,
+    title: 'HEAD points at a commit rather than a branch',
+    cause:
+      'Normal after checking out a tag or a raw SHA. It matters because commits made here belong to no branch and are easy to lose once you move away.',
+    fixes: [
+      { command: 'git switch -c <new-branch>', when: 'You made commits here and want to keep them.' },
+      { command: 'git switch -', when: 'You made nothing worth keeping: go back to the previous branch.' },
+    ],
+  },
+  {
+    id: 'unstaged_changes_rebase',
+    match: /cannot pull with rebase|cannot rebase: You have unstaged changes/i,
+    title: 'Rebase needs a clean working tree',
+    cause: 'Rebase replays commits, which it cannot do while uncommitted edits sit on top of them.',
+    fixes: [
+      { command: 'git stash push -u -m "wip"', when: 'Set the work aside, rebase, then `git stash pop`.' },
+      { command: 'git commit -am "wip"', when: 'Keep it as a commit you fold in later.' },
+    ],
+  },
+  {
+    id: 'auth_failed',
+    match: /Authentication failed|support for password authentication was removed|Permission denied \(publickey\)/i,
+    title: 'The remote rejected your credentials',
+    cause:
+      'GitHub removed password authentication for git operations in August 2021. HTTPS now needs a personal access token, and SSH needs a key the account knows about.',
+    fixes: [
+      { command: 'gh auth login', when: 'GitHub, with the gh CLI available. Handles both HTTPS tokens and SSH keys.' },
+      { command: 'git remote -v', when: 'Confirm whether the remote is HTTPS or SSH before fixing the wrong one.' },
+      { command: 'ssh -T git@github.com', when: 'Test whether your SSH key is accepted, independently of git.' },
+    ],
+  },
+]
+
+export interface GitErrorMatch {
+  entry: GitErrorEntry
+  /** The line that triggered the match, for echoing back. */
+  matchedOn: string
+}
+
+/**
+ * Find every catalogue entry the pasted output matches, most specific first.
+ * Returns all of them rather than one: real git output often carries a
+ * conflict notice and a follow-up failure in the same paste, and an agent
+ * that only sees the first will fix the wrong thing.
+ */
+export function matchGitErrors(raw: string): GitErrorMatch[] {
+  const lines = raw.split('\n')
+  const seen = new Set<string>()
+  const out: GitErrorMatch[] = []
+
+  for (const entry of GIT_ERRORS) {
+    if (seen.has(entry.id)) continue
+    const line = lines.find((l) => entry.match.test(l))
+    if (line === undefined && !entry.match.test(raw)) continue
+    seen.add(entry.id)
+    out.push({ entry, matchedOn: (line ?? '').trim() })
+  }
+
+  return out
+}

--- a/website/.vitepress/theme/tools/index.ts
+++ b/website/.vitepress/theme/tools/index.ts
@@ -70,7 +70,7 @@ export const parseGitErrorTool: WebMcpTool = {
         ? 'One known git error matched.'
         : `${matches.length} known git errors matched this output, listed in the order they should be dealt with.`
 
-    return text(truncate([header, '', ...sections].join('\n\n')))
+    return text(truncate([header, ...sections].join('\n\n')))
   },
 }
 

--- a/website/.vitepress/theme/tools/index.ts
+++ b/website/.vitepress/theme/tools/index.ts
@@ -1,0 +1,158 @@
+/**
+ * The tools this page exposes to agents.
+ *
+ * Both are read-only and run entirely in the visitor's tab: nothing is
+ * uploaded, and there is no backend to upload it to. That is the point of
+ * putting them here rather than behind an API.
+ */
+import type { WebMcpTool } from '../webmcp'
+import { text } from '../webmcp'
+import { matchGitErrors } from './git-errors'
+
+/** Keep a single tool response from swallowing an agent's context window. */
+const MAX_CONTENT_CHARS = 20_000
+
+function truncate(body: string): string {
+  if (body.length <= MAX_CONTENT_CHARS) return body
+  return `${body.slice(0, MAX_CONTENT_CHARS)}\n\n[truncated at ${MAX_CONTENT_CHARS} characters]`
+}
+
+export const parseGitErrorTool: WebMcpTool = {
+  name: 'parse_git_error',
+  description:
+    'Explain a git command that failed. Paste the raw stderr or stdout of the failing command and get back the cause in plain language plus the specific commands that resolve it. Handles merge conflicts, rejected pushes, unrelated histories, detached HEAD, interrupted merges and rebases, authentication failures and other common git errors. Read-only: it never runs git and never touches the repository.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      output: {
+        type: 'string',
+        description: 'The raw output of the failing git command, copied verbatim. Multiple errors in one paste are all reported.',
+      },
+    },
+    required: ['output'],
+  },
+  async execute({ output }: { output: string }) {
+    if (typeof output !== 'string' || output.trim() === '') {
+      return text('No output provided. Pass the raw text of the failing git command as `output`.')
+    }
+
+    const matches = matchGitErrors(output)
+    if (matches.length === 0) {
+      return text(
+        [
+          'No known git error matched this output.',
+          '',
+          'This catalogue covers the common failures (conflicts, rejected pushes, unrelated histories, detached HEAD, interrupted merge or rebase, authentication). An unmatched paste is usually either a tool wrapping git, or a genuine edge case worth reading the full output for.',
+          '',
+          'Useful next command: `git status` prints the repository state that most git errors are really about.',
+        ].join('\n'),
+      )
+    }
+
+    const sections = matches.map(({ entry, matchedOn }) => {
+      const fixes = entry.fixes.map((f) => `  ${f.command}\n      ${f.when}`).join('\n')
+      return [
+        `## ${entry.title}`,
+        matchedOn ? `Matched on: ${matchedOn}` : '',
+        '',
+        entry.cause,
+        '',
+        'Commands:',
+        fixes,
+        entry.gitwand ? `\nGitWand: ${entry.gitwand}` : '',
+      ]
+        .filter(Boolean)
+        .join('\n')
+    })
+
+    const header =
+      matches.length === 1
+        ? 'One known git error matched.'
+        : `${matches.length} known git errors matched this output, listed in the order they should be dealt with.`
+
+    return text(truncate([header, '', ...sections].join('\n\n')))
+  },
+}
+
+export const resolveConflictTool: WebMcpTool = {
+  name: 'resolve_conflict',
+  description:
+    "Resolve a file that contains git conflict markers. Pass the full conflicted file content and get back the merged result, plus a per-hunk classification saying which conflicts were resolved deterministically and which still need a human decision. Hunks that carry no real decision (identical edits on both sides, pure reordering, whitespace, insertions at different positions, generated files) are resolved; genuinely overlapping edits are handed back untouched with the reason. No model is involved and nothing is guessed. Runs in the browser tab: the file content is never uploaded.",
+  inputSchema: {
+    type: 'object',
+    properties: {
+      content: {
+        type: 'string',
+        description: 'The complete conflicted file, including the <<<<<<<, ======= and >>>>>>> markers. Pass the whole file, not just the conflicted region.',
+      },
+      filePath: {
+        type: 'string',
+        description:
+          'Path of the file, e.g. "src/config.json" or "pnpm-lock.yaml". This changes the result: the extension selects format-aware resolvers (JSON, YAML, TypeScript imports, Vue SFC, CSS, lockfiles) and the path is what identifies a generated file. Pass the real path when you have it.',
+      },
+    },
+    required: ['content'],
+  },
+  async execute({ content, filePath }: { content: string; filePath?: string }) {
+    if (typeof content !== 'string' || content.trim() === '') {
+      return text('No content provided. Pass the full conflicted file as `content`.')
+    }
+    if (!content.includes('<<<<<<<')) {
+      return text(
+        'No conflict markers found in this content. `resolve_conflict` expects a file left conflicted by git, containing <<<<<<<, ======= and >>>>>>> markers. If git reported a conflict but the file has no markers, the conflict is probably a tree-level one (add/add, delete/modify), which `git status` will name.',
+      )
+    }
+
+    const path = typeof filePath === 'string' && filePath.trim() !== '' ? filePath : 'unknown.txt'
+
+    let result
+    try {
+      // Loaded on demand, not at module scope. AgentPage is registered in the
+      // shared theme entry, so a static import pulls the whole engine into the
+      // chunk that every page of the site downloads. This way only a real call
+      // to resolve_conflict pays for it.
+      const { resolve } = await import('@gitwand/core')
+      result = resolve(content, path)
+    } catch (err) {
+      return text(`The resolver failed on this input: ${err instanceof Error ? err.message : String(err)}`)
+    }
+
+    const { stats, resolutions, mergedContent, validation } = result
+
+    const hunkLines = resolutions.map((r, i) => {
+      const status = r.autoResolved ? 'resolved' : 'NEEDS REVIEW'
+      const conf = r.hunk.confidence
+      return `  [${i + 1}] ${r.hunk.type} (${conf.label}, score ${conf.score}) — ${status}\n      ${r.resolutionReason}`
+    })
+
+    const summary = [
+      `${stats.totalConflicts} conflict${stats.totalConflicts === 1 ? '' : 's'} found in ${path}.`,
+      `${stats.autoResolved} resolved deterministically, ${stats.remaining} left for you.`,
+      '',
+      'Per hunk:',
+      ...hunkLines,
+    ]
+
+    if (!validation.isValid) {
+      const reasons: string[] = []
+      if (validation.hasResidualMarkers) {
+        reasons.push(`conflict markers still present at line ${validation.residualMarkerLines.join(', ')}`)
+      }
+      if (validation.syntaxError) reasons.push(validation.syntaxError)
+      summary.push('', `Post-merge validation rejected this result: ${reasons.join('; ')}. Treat the merged output below as untrusted.`)
+    }
+
+    if (mergedContent === null) {
+      summary.push(
+        '',
+        `${stats.remaining} hunk${stats.remaining === 1 ? '' : 's'} could not be resolved without a decision, so no merged file is returned. The conflict markers for those hunks are still in place. Resolve them by hand, or ask the user which side to take.`,
+      )
+      return text(truncate(summary.join('\n')))
+    }
+
+    summary.push('', 'Merged file:', '', mergedContent)
+    return text(truncate(summary.join('\n')))
+  },
+}
+
+export const TOOLS: WebMcpTool[] = [parseGitErrorTool, resolveConflictTool]

--- a/website/.vitepress/theme/tools/samples.ts
+++ b/website/.vitepress/theme/tools/samples.ts
@@ -1,0 +1,44 @@
+/**
+ * The inputs the /agent try-it panel starts with.
+ *
+ * They live here rather than in the component so they can be asserted: a
+ * sample that quietly stops demonstrating the thing it was chosen to
+ * demonstrate is worse than no sample. See __tests__/webmcp.test.ts.
+ *
+ * Assembled from arrays so no line of this file literally begins with a
+ * conflict marker. A source file carrying real markers trips merge-conflict
+ * detectors, GitWand's own post-merge validation among them.
+ */
+export const SAMPLE_GIT_ERROR = [
+  'To github.com:acme/app.git',
+  ' ! [rejected]        main -> main (non-fast-forward)',
+  "error: failed to push some refs to 'github.com:acme/app.git'",
+  'hint: Updates were rejected because the tip of your current branch is behind',
+  'hint: its remote counterpart.',
+  'fatal: You have not concluded your merge (MERGE_HEAD exists).',
+].join('\n')
+
+export const SAMPLE_CONFLICT = [
+  "import { createServer } from 'node:http'",
+  '',
+  'export function start(port, handler) {',
+  '<<<<<<<'.concat(' ours'),
+  '  const server = createServer(handler)',
+  '  server.setTimeout(30_000)',
+  '|||||||'.concat(' base'),
+  '  const server = createServer(handler)',
+  '=======',
+  '  const server = createServer(handler)',
+  '  server.setTimeout(30_000)',
+  '>>>>>>>'.concat(' theirs'),
+  '',
+  '<<<<<<<'.concat(' ours'),
+  "  server.listen(port, '0.0.0.0')",
+  '|||||||'.concat(' base'),
+  '  server.listen(port)',
+  '=======',
+  '  server.listen(port, { backlog: 511 })',
+  '>>>>>>>'.concat(' theirs'),
+  '  return server',
+  '}',
+].join('\n')

--- a/website/.vitepress/theme/webmcp.ts
+++ b/website/.vitepress/theme/webmcp.ts
@@ -1,0 +1,104 @@
+/**
+ * WebMCP registration, shared by every page that exposes tools to agents.
+ *
+ * The spec (W3C Draft Community Group Report, 26 August 2026) puts the entry
+ * point on `document.modelContext`. Tools belong to a document, which is the
+ * stated reason the getter moved off Navigator on 27 May 2026.
+ *
+ * Chrome 150 deprecated `navigator.modelContext` but kept it as an ALIAS to
+ * the same object. Registering on both locations would therefore register
+ * every tool twice on the versions that matter today. Detect, pick one,
+ * register once.
+ *
+ * Spec:   https://webmachinelearning.github.io/webmcp/
+ * Chrome: https://developer.chrome.com/docs/ai/webmcp/imperative-api
+ */
+
+/**
+ * MCP-style tool result. The spec serialises whatever `execute` resolves to
+ * into JSON and imposes no shape, but content blocks are what MCP clients
+ * already parse, so they cost nothing and travel further than a bare object.
+ */
+export interface ToolResult {
+  content: { type: 'text'; text: string }[]
+}
+
+export interface WebMcpTool {
+  /** 1-128 chars, alphanumeric plus underscore, hyphen and period. */
+  name: string
+  /** Written for an agent deciding whether to call it, not for a human. */
+  description: string
+  /** JSON Schema for the input object. */
+  inputSchema: Record<string, unknown>
+  execute: (input: any, options: { signal: AbortSignal }) => Promise<ToolResult>
+}
+
+interface ModelContextLike {
+  registerTool(tool: WebMcpTool, options?: { signal?: AbortSignal }): Promise<void> | void
+}
+
+export type Surface = 'document' | 'navigator' | null
+
+/** Which surface this browser exposes, if any. Null during the SSR pass. */
+export function detectSurface(): Surface {
+  if (typeof document === 'undefined') return null
+  if ((document as any).modelContext) return 'document'
+  if (typeof navigator !== 'undefined' && (navigator as any).modelContext) return 'navigator'
+  return null
+}
+
+function getModelContext(surface: Surface): ModelContextLike | null {
+  if (surface === 'document') return (document as any).modelContext
+  if (surface === 'navigator') return (navigator as any).modelContext
+  return null
+}
+
+/** Wrap a string into the content-block shape. */
+export function text(body: string): ToolResult {
+  return { content: [{ type: 'text', text: body }] }
+}
+
+export interface RegisterOutcome {
+  /** Null when the browser has no WebMCP support at all. */
+  surface: Surface
+  registered: string[]
+  failed: { name: string; reason: string }[]
+}
+
+/**
+ * Register every tool on whichever surface exists, counting calls through
+ * `onCall`. Returns what actually landed rather than throwing: a page that
+ * cannot register its tools should still render for the humans reading it.
+ */
+export async function registerTools(
+  tools: WebMcpTool[],
+  options: { signal: AbortSignal; onCall?: (name: string) => void },
+): Promise<RegisterOutcome> {
+  const surface = detectSurface()
+  const mc = getModelContext(surface)
+  if (!mc) return { surface: null, registered: [], failed: [] }
+
+  const registered: string[] = []
+  const failed: { name: string; reason: string }[] = []
+
+  for (const tool of tools) {
+    const instrumented: WebMcpTool = {
+      ...tool,
+      execute: (input, execOptions) => {
+        options.onCall?.(tool.name)
+        return tool.execute(input, execOptions)
+      },
+    }
+    try {
+      // `signal` goes in the options argument, NOT in the tool dictionary.
+      // ModelContextTool declares no `signal` member, so one set on the tool
+      // itself is dropped on the floor and the tool can never be unregistered.
+      await mc.registerTool(instrumented, { signal: options.signal })
+      registered.push(tool.name)
+    } catch (err) {
+      failed.push({ name: tool.name, reason: err instanceof Error ? err.message : String(err) })
+    }
+  }
+
+  return { surface, registered, failed }
+}

--- a/website/agent.md
+++ b/website/agent.md
@@ -1,0 +1,58 @@
+---
+layout: page
+title: "GitWand for agents — WebMCP git tools, no install"
+description: "A WebMCP page that hands any browsing agent two read-only git tools. One explains a failing git command, the other resolves a conflicted file with GitWand's deterministic engine. Runs in the tab, no server, no API key."
+head:
+  - - meta
+    - property: og:title
+      content: GitWand for agents — callable git tools over WebMCP
+  - - meta
+    - property: og:description
+      content: Two read-only git tools any agent can call straight from the page. Deterministic conflict resolution, no model in the loop, no install.
+  - - script
+    - type: application/ld+json
+    - |
+      {
+        "@context": "https://schema.org",
+        "@type": "WebAPI",
+        "name": "GitWand agent tools",
+        "description": "Read-only git tools exposed to browsing agents over the W3C WebMCP standard. Nothing is uploaded: the tools execute in the visitor's browser tab.",
+        "documentation": "https://gitwand.app/agent",
+        "termsOfService": "https://github.com/devlint/GitWand/blob/main/LICENSE",
+        "provider": {
+          "@type": "Organization",
+          "name": "GitWand",
+          "url": "https://gitwand.app"
+        },
+        "potentialAction": [
+          {
+            "@type": "Action",
+            "name": "parse_git_error",
+            "description": "Explain a git command that failed. Takes the raw output of the failing command and returns the cause in plain language plus the commands that resolve it. Covers merge conflicts, rejected pushes, unrelated histories, detached HEAD, interrupted merge or rebase, and authentication failures. Read-only: never runs git.",
+            "target": {
+              "@type": "EntryPoint",
+              "urlTemplate": "https://gitwand.app/agent",
+              "actionPlatform": "https://webmachinelearning.github.io/webmcp/"
+            }
+          },
+          {
+            "@type": "Action",
+            "name": "resolve_conflict",
+            "description": "Resolve a file containing git conflict markers. Takes the full conflicted content and an optional file path, returns the merged result plus a per-hunk classification separating the conflicts that carried no decision from the ones needing a human. Deterministic patterns only, no model involved.",
+            "target": {
+              "@type": "EntryPoint",
+              "urlTemplate": "https://gitwand.app/agent",
+              "actionPlatform": "https://webmachinelearning.github.io/webmcp/"
+            }
+          }
+        ],
+        "isRelatedTo": {
+          "@type": "SoftwareApplication",
+          "name": "@gitwand/mcp",
+          "applicationCategory": "DeveloperApplication",
+          "url": "https://gitwand.app/guide/mcp"
+        }
+      }
+---
+
+<AgentPage />

--- a/website/package.json
+++ b/website/package.json
@@ -6,10 +6,15 @@
   "scripts": {
     "dev": "vitepress dev",
     "build": "vitepress build",
-    "preview": "vitepress preview"
+    "preview": "vitepress preview",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@gitwand/core": "workspace:*"
   },
   "devDependencies": {
     "vitepress": "2.0.0-alpha.17",
+    "vitest": "^4.1.0",
     "vue": "^3.5.0"
   }
 }

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import { fileURLToPath } from 'node:url'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Same aliasing as .vitepress/config.ts: the site never builds
+      // packages/core/dist, so tests must reach the TypeScript source too.
+      '@gitwand/core': fileURLToPath(new URL('../packages/core/src/index.ts', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'node',
+    include: ['.vitepress/**/__tests__/**/*.test.ts'],
+  },
+})


### PR DESCRIPTION
Phase 1 of the WebMCP action plan: a `/agent` page that hands browsing agents two read-only git tools. Along the way this fixes a latent bug in the WebMCP layer the site already had, translates the engine's user-facing strings to English, and makes `pnpm test` deterministic.

Seven commits, each standalone. Worth reviewing in order.

## The headline: `/agent`

`gitwand.app/agent` registers two tools over the W3C WebMCP standard:

- **`parse_git_error`** takes the raw output of a failing git command and returns the cause plus the commands that fix it. 13 common failures: conflicts, rejected pushes, unrelated histories, detached HEAD, interrupted merge or rebase, authentication. GitWand is named only on the conflict entry, on the theory that a tool answering everything with "install our product" gets called once.
- **`resolve_conflict`** runs the real engine over a conflicted file and reports per hunk what was resolved and what needs a human.

Both are read-only and execute in the visitor's tab. There is no backend. The page states its registration status live, including when the browser has no WebMCP at all, and writes both contracts out in HTML and JSON-LD for the majority of visitors and crawlers that never run the script. A try-it panel runs the same `execute` an agent calls, so a visitor without WebMCP can still see an answer.

## The bug it was built on

The site was already registering three documentation tools from an inline script in `config.ts`, with two defects the new page would have inherited:

- It bailed out unless `navigator.modelContext` existed, so all three tools disappear the day Chrome removes the alias it deprecated in 150. The spec has put the entry point on `document.modelContext` since 27 May 2026.
- `signal` was passed inside the tool dictionary. `ModelContextTool` declares no such member, so it was dropped and nothing could ever be unregistered.

Registration now prefers `document`, falls back to `navigator`, and registers **once** either way. The action plan called for registering on both; where both names exist they alias the same object, so that would have duplicated every tool.

## Breaking-ish: the engine now speaks English

`@gitwand/core` produced its explanations, resolution reasons, trace steps, boosters and penalties in French. No consumer translates them: the desktop merge editor renders `hunk.explanation` raw, the CLI prints the reason as-is, and `@gitwand/mcp` ships both fields straight to agents. Every user and every agent has been reading French regardless of locale, and four of the five shipped locales were simply wrong.

194 strings across 38 files. Comments and test names stay French, which is deliberate in this repository; this is only about what leaves the engine.

**Why the `!`:** these strings are observable through `@gitwand/mcp` and `gitwand --json`. Nothing in this monorepo pattern-matches on them (checked), but an external consumer could.

A regression guard (`english-output.test.ts`) runs the engine over the whole corpus and asserts nothing French comes back, checking real output rather than scanning source so it cannot be fooled by how a string is assembled. It found four strings three source scans had missed, one carrying no accented character at all.

## Test determinism (#172)

`pnpm test` failed roughly one run in three, on a different test each time. Two findings corrected the diagnosis in the issue:

- Three packages were affected, not two. `apps/desktop` has a git-backed suite that already had a 20s timeout and still failed at 31s.
- The timeouts were the symptom. Five workspaces each fanning out to one worker per core oversubscribes an 11-core machine several times over. Measured: parallel **119s**, sequential **49s**. Running workspaces one at a time is 2.4x *faster*, so `--workspace-concurrency=1` is both, not a trade.

All git-backed suites now share a 60s timeout, set to catch a hang rather than enforce a performance budget. Eleven consecutive full runs green.

## Documentation accuracy

- The README's pattern table listed 10 rows matching nothing in the code. It now mirrors `classifier.ts`: 12 registry patterns with an auto-applies column that makes the site's "8" checkable, plus a note placing `generated_file` in the post-classification pass it actually belongs to.
- `token_level_merge` and the tier metric were commented `v2.7` across four packages. They shipped in 3.4.0; v2.7.0 was a desktop train and carried neither.
- The pattern table was duplicated in two Vue files, one of which never rendered it. Extracted to a shared module, with the count now derived rather than hardcoded in four places.

## Verification

- 2228 tests green across all five workspaces.
- `/agent` driven in a real browser against the built site: both tools return, the lazy `import('@gitwand/core')` resolves on first call, the no-WebMCP status block renders as intended, and the output is fully English.
- `@gitwand/core` is imported inside `execute()` rather than at module scope, keeping the engine out of the chunk every page downloads (shared theme chunk 358K to 161K).

## What this does not do

**No agent has ever called these tools.** Registration is covered by tests using doubles, and the tools by the panel, but never end to end in a WebMCP-capable browser. The action plan asks for a pass in the ChatGPT desktop built-in browser; that needs doing once this is deployed, and it is the only test that proves the page works.

**The call counter measures nothing.** It is local to the tab, and the site has no analytics at all, so the plan's measurement checkpoint has nothing to read. Worth deciding before this goes live.

Phase 2 of the plan (directories, awesome-lists, article) is untouched and depends on this being deployed.


Closes #172.
