### PR TITLE
feat(website): Merge Room on /agent, plus the redesign that makes it legible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The Merge Room on `/agent`.** The page is now a shared workspace rather than a tool listing. Tool handlers no longer just return text to the agent: they file a case into live page state that the person sitting there watches fill up. The engine settles every hunk that carries no decision; every hunk where the two branches genuinely disagree queues for a human, who picks a side and gets the assembled file back, ready to paste. No tool on the page can make that call, which is the boundary the whole thing is built around. A live journal records who did what, agent and human alike.
+- **`list_cases`**, a third WebMCP tool, lets an agent read the room back: what is filed, what the engine settled, what is still waiting on a person, what they have already decided. It is what turns a stateless calculator into a workspace an agent can pick back up.
+
 ### Fixed
 
 - **`parse_git_error` did not recognise a rebase that stopped on a conflict.** The catalogue only knew the phrases git prints when you try to *start* a rebase while one is already unfinished (`rebase-merge directory`), not the ones it prints when a rebase *halts*, which is the far more common paste. Reported by an agent audit of the live page. It now keys on the rebase-specific commands, and a halted cherry-pick gets its own entry rather than being mislabelled a rebase: both print `could not apply`, so matching on that phrase would have handed out `git rebase --continue` to someone mid-cherry-pick.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`parse_git_error` did not recognise a rebase that stopped on a conflict.** The catalogue only knew the phrases git prints when you try to *start* a rebase while one is already unfinished (`rebase-merge directory`), not the ones it prints when a rebase *halts*, which is the far more common paste. Reported by an agent audit of the live page. It now keys on the rebase-specific commands, and a halted cherry-pick gets its own entry rather than being mislabelled a rebase: both print `could not apply`, so matching on that phrase would have handed out `git rebase --continue` to someone mid-cherry-pick.
+
 ### Added
 
 - **`/agent`, a WebMCP page.** gitwand.app/agent exposes two read-only git tools to any agent browsing it, over the W3C WebMCP standard: `parse_git_error` explains a failing git command and gives the commands that fix it, `resolve_conflict` runs the deterministic engine over a conflicted file and reports per hunk what was resolved and what still needs a human. Both execute in the visitor's tab, so nothing is uploaded and there is no backend. `@gitwand/core` is imported on demand rather than at module scope, which keeps it out of the shared theme chunk every page downloads.

--- a/website/.vitepress/theme/AgentPage.vue
+++ b/website/.vitepress/theme/AgentPage.vue
@@ -15,19 +15,15 @@ const surface = ref<Surface>(null)
 const registered = ref<string[]>([])
 const failed = ref<{ name: string; reason: string }[]>([])
 const settled = ref(false)
-const calls = ref<Record<string, number>>({})
-const lastCall = ref<string | null>(null)
 
 let controller: AbortController | null = null
 
-function onCall(name: string) {
-  calls.value = { ...calls.value, [name]: (calls.value[name] ?? 0) + 1 }
-  lastCall.value = name
-}
-
+// No separate call counter any more: the room's activity log records every
+// invocation with its actor and timestamp, which is the same evidence in a
+// form that says what happened rather than only how often.
 onMounted(async () => {
   controller = new AbortController()
-  const outcome = await registerTools(TOOLS, { signal: controller.signal, onCall })
+  const outcome = await registerTools(TOOLS, { signal: controller.signal })
   surface.value = outcome.surface
   registered.value = outcome.registered
   failed.value = outcome.failed
@@ -82,247 +78,215 @@ function pick(id: ToolId) {
 
 <template>
   <div class="gw-page">
-    <section class="ph-hero">
-      <div class="ph-inner">
-        <span class="ph-badge">WebMCP</span>
-        <h1 class="ph-h1">Your agent clears the queue. <span class="grad">You make the calls.</span></h1>
-                <p class="ph-sub">
-          A shared Git workspace for you and whatever agent is browsing this page, over the W3C
-          WebMCP standard. The engine settles every hunk that carries no decision. The ones where
-          your two branches genuinely disagree wait for you, and no tool here can take that call.
-        </p>
-        <div class="ph-ctas">
-          <a href="/guide/mcp" class="ph-btn ph-btn--primary">Prefer a real MCP server?</a>
-          <a href="/conflict-engine" class="ph-btn">How the engine works</a>
+    <!-- ══ WORKSHOP ══════════════════════════════════════════════════════
+         A tool, not a pitch. Status is a strip, not a section: it is a
+         connection indicator, and giving it a heading of its own is what
+         made the previous version read as two things fighting. -->
+    <div class="shop">
+      <div class="wrap">
+        <div class="strip" :class="settled ? (surface ? 'strip--on' : 'strip--off') : 'strip--wait'">
+          <span class="dot" aria-hidden="true"></span>
+          <span v-if="!settled">Looking for a WebMCP entry point…</span>
+          <span v-else-if="surface">
+            WebMCP live on <code>{{ surface }}.modelContext</code>, {{ registered.length }} tool{{ registered.length === 1 ? '' : 's' }} registered
+            <span v-if="surface === 'navigator'" class="strip--legacy">· deprecated location, registered there rather than not at all</span>
+          </span>
+          <span v-else>No WebMCP in this browser. The room still works by hand, and everything below is readable without it.</span>
+          <span v-for="f in failed" :key="f.name" class="strip-fail">{{ f.name }} failed: {{ f.reason }}</span>
         </div>
-      </div>
-    </section>
 
-    <MergeRoom />
+        <header class="shop-head">
+          <h1 class="shop-h1">Merge Room</h1>
+          <p class="shop-line">
+            Your agent clears what was never a decision. Everything the two branches genuinely
+            disagree about waits here for you, and no tool on this page can take that call.
+          </p>
+        </header>
 
-    <!-- Live registration state. Deliberately shows failure and absence as
-         plainly as success: a demo that always claims to work teaches nobody. -->
-    <section class="ph-section">
-      <div class="ph-inner">
-        <h2 class="ph-h2">Status in this browser</h2>
-        <p class="ph-secsub">
-          Read live from the page you have open, not from a screenshot taken on a good day.
-        </p>
+        <MergeRoom />
 
-        <div class="st" :class="settled ? (surface ? 'st--on' : 'st--off') : 'st--wait'">
-          <template v-if="!settled">
-            <p class="st-line">Checking for a WebMCP entry point…</p>
-          </template>
+        <!-- The input sits with the tool it feeds, not in its own marketing bay. -->
+        <section class="feed">
+          <h2 class="feed-h">File a case</h2>
+          <p class="feed-sub">
+            The same code an agent calls, wired to the same room. Nothing leaves this tab.
+          </p>
 
-          <template v-else-if="surface">
-            <p class="st-line">
-              <strong>WebMCP available</strong> on <code>{{ surface }}.modelContext</code>.
-              {{ registered.length }} tool{{ registered.length === 1 ? '' : 's' }} registered.
-            </p>
-            <p v-if="surface === 'navigator'" class="st-note">
-              This browser only exposes the deprecated location. Chrome 150 kept
-              <code>navigator.modelContext</code> as an alias and has announced its removal, so this
-              page registered there rather than not at all.
-            </p>
-            <ul class="st-calls">
-              <li v-for="name in registered" :key="name">
-                <code>{{ name }}</code>
-                <span class="st-count" :class="{ 'st-count--hot': lastCall === name }">
-                  called {{ calls[name] ?? 0 }}×
-                </span>
-              </li>
-            </ul>
-            <p class="st-note">
-              That counter lives in this tab and is never sent anywhere. There is no backend behind
-              this page to send it to.
-            </p>
-          </template>
-
-          <template v-else>
-            <p class="st-line"><strong>No WebMCP in this browser.</strong> Nothing was registered.</p>
-            <p class="st-note">
-              As of today that means most browsers. The API ships behind an origin trial in Chrome and
-              a flag in Edge, and natively in the ChatGPT desktop app's built-in browser. Everything
-              below is readable without it, which is the point of writing it out.
-            </p>
-          </template>
-
-          <ul v-if="failed.length" class="st-failed">
-            <li v-for="f in failed" :key="f.name"><code>{{ f.name }}</code> failed: {{ f.reason }}</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <!-- Runs the real tools, so a visitor with no WebMCP can still see what an
-         agent would get back. -->
-    <section class="ph-section ph-section--alt">
-      <div class="ph-inner">
-        <h2 class="ph-h2">File a case yourself</h2>
-        <p class="ph-secsub">
-          The same code an agent calls, wired to the same room. Whatever you run here shows up above
-          exactly as an agent's call would. Nothing is sent anywhere.
-        </p>
-
-        <div class="try">
-          <div class="try-tabs" role="tablist">
+          <div class="feed-tabs" role="tablist">
             <button
               v-for="id in (['resolve_conflict', 'parse_git_error'] as const)"
               :key="id"
-              class="try-tab"
-              :class="{ 'try-tab--on': active === id }"
+              class="feed-tab"
+              :class="{ 'feed-tab--on': active === id }"
               role="tab"
               :aria-selected="active === id"
               @click="pick(id)"
-            >
-              {{ id }}
-            </button>
+            >{{ id }}</button>
           </div>
 
-          <div v-if="active === 'resolve_conflict'" class="try-body">
-            <label class="try-label" for="try-path">File path</label>
-            <input id="try-path" v-model="conflictPath" class="try-input" spellcheck="false" />
-            <p class="try-hint">
-              The extension selects the format-aware resolvers, and the path is what identifies a
-              generated file. Try <code>pnpm-lock.yaml</code> to see that change the answer.
+          <div v-if="active === 'resolve_conflict'" class="feed-body">
+            <label class="feed-label" for="try-path">File path</label>
+            <input id="try-path" v-model="conflictPath" class="feed-input" spellcheck="false" />
+            <p class="feed-hint">
+              The extension picks the format-aware resolvers and the path is what marks a generated
+              file. Try <code>pnpm-lock.yaml</code> to watch the answer change.
             </p>
-
-            <label class="try-label" for="try-conflict">Conflicted file</label>
-            <textarea id="try-conflict" v-model="conflictInput" class="try-area" rows="14" spellcheck="false"></textarea>
+            <label class="feed-label" for="try-conflict">Conflicted file</label>
+            <textarea id="try-conflict" v-model="conflictInput" class="feed-area" rows="13" spellcheck="false"></textarea>
           </div>
 
-          <div v-else class="try-body">
-            <label class="try-label" for="try-error">Output of the failing git command</label>
-            <textarea id="try-error" v-model="errorInput" class="try-area" rows="8" spellcheck="false"></textarea>
+          <div v-else class="feed-body">
+            <label class="feed-label" for="try-error">Output of the failing git command</label>
+            <textarea id="try-error" v-model="errorInput" class="feed-area" rows="8" spellcheck="false"></textarea>
           </div>
 
-          <button class="try-run" :disabled="running" @click="run">
+          <button class="feed-run" :disabled="running" @click="run">
             {{ running ? 'Running…' : `Call ${active}` }}
           </button>
-
-          <pre v-if="output" class="try-out">{{ output }}</pre>
-        </div>
+          <p v-if="output" class="feed-note">Filed. The case is in the room above.</p>
+        </section>
       </div>
-    </section>
+    </div>
 
-    <!-- The same tool contract in HTML, for the majority of visitors whose
-         browser has no WebMCP and for crawlers that will never run the script. -->
-    <section class="ph-section ph-section--alt">
-      <div class="ph-inner">
-        <h2 class="ph-h2">The three tools, written out</h2>
-        <p class="ph-secsub">
-          All read-only with respect to your machine. None runs git, none writes to a repository,
-          none uploads what you pass it. What they do write to is the room above. Deliberately
-          missing: any tool that picks a side on a conflicted hunk.
+    <!-- ══ THE BREAK ═════════════════════════════════════════════════════
+         Deliberate and visible. Above it the page is a tool; below it the
+         page argues. Interleaving the two is what made it muddled. -->
+    <div class="seam" aria-hidden="true"></div>
+
+    <!-- ══ SHOWCASE ══════════════════════════════════════════════════════ -->
+    <div class="tell">
+      <div class="wrap">
+        <p class="tell-lede">
+          Every other tool in this space asks you to trust that a model got it right.
+          <strong>This one refuses to guess.</strong>
+        </p>
+        <p class="tell-body">
+          Twelve patterns in a classifier registry, eight of which apply on their own. Every
+          resolution carries the pattern that produced it, a composite confidence score and a full
+          decision trace. Where the two branches genuinely disagree, the engine stops and says so.
+          That refusal is the product, so it is enforced in the data rather than promised in the
+          copy: nothing exposed on this page can pick a side for you.
         </p>
 
-        <article class="tool">
-          <h3 class="tool-name"><code>parse_git_error</code></h3>
-          <p class="tool-desc">
-            Paste the raw output of a git command that failed. Returns the cause in plain language
-            and the specific commands that resolve it, for the common failures: merge conflicts,
-            rejected pushes, unrelated histories, detached HEAD, an interrupted merge or rebase,
-            authentication.
-          </p>
-          <p class="tool-io"><span class="tool-k">Input</span> <code>{ output: string }</code></p>
-        </article>
+        <h2 class="tell-h">The three tools</h2>
+        <dl class="spec">
+          <div class="spec-row">
+            <dt><code>resolve_conflict</code></dt>
+            <dd>
+              <p>A file with conflict markers goes in. Hunks that carry no decision come back
+              resolved; the rest are filed for you, with the reason each one was refused.</p>
+              <p class="spec-io"><code>{ content: string, filePath?: string }</code></p>
+            </dd>
+          </div>
+          <div class="spec-row">
+            <dt><code>parse_git_error</code></dt>
+            <dd>
+              <p>The raw output of a git command that failed, in. The cause in plain words and the
+              commands that resolve it, out. Fourteen of the failures you actually hit.</p>
+              <p class="spec-io"><code>{ output: string }</code></p>
+            </dd>
+          </div>
+          <div class="spec-row">
+            <dt><code>list_cases</code></dt>
+            <dd>
+              <p>Reads the room back: what is filed, what the engine settled, what is still waiting
+              on you. It is what lets an agent pick up where it left off.</p>
+              <p class="spec-io"><code>{}</code></p>
+            </dd>
+          </div>
+        </dl>
 
-        <article class="tool">
-          <h3 class="tool-name"><code>resolve_conflict</code></h3>
-          <p class="tool-desc">
-            Pass a file that still contains conflict markers. Returns the merged result plus a
-            per-hunk classification: which conflicts carried no decision and were resolved, which
-            need a human, and why in each case. Deterministic patterns only, no model in the loop.
-            Pass the real file path when you have one: the extension selects the format-aware
-            resolvers, and the path is what identifies a generated file.
-          </p>
-          <p class="tool-io">
-            <span class="tool-k">Input</span> <code>{ content: string, filePath?: string }</code>
-          </p>
-        </article>
-
-        <article class="tool">
-          <h3 class="tool-name"><code>list_cases</code></h3>
-          <p class="tool-desc">
-            Reads the room back: what has been filed, which hunks the engine settled, which are still
-            waiting on a person, and which you have already decided. It is what lets an agent pick up
-            where it left off, and check whether you have made the calls it was waiting on.
-          </p>
-          <p class="tool-io"><span class="tool-k">Input</span> <code>{}</code></p>
-        </article>
-
-        <p class="foot">
-          Neither tool is a substitute for
-          <a href="/guide/mcp"><code>@gitwand/mcp</code></a>, which runs against your real repository
-          and can write. WebMCP only carries callable tools, with no resources, prompts or sampling.
-          This page is the zero-install door, not the full one.
+        <p class="tell-foot">
+          None of these runs git or touches a repository, and none uploads what you pass it. For the
+          real thing against your working tree, there is
+          <a href="/guide/mcp"><code>@gitwand/mcp</code></a>. WebMCP carries callable tools only, no
+          resources, prompts or sampling, so this page is the zero-install door rather than the
+          whole house. <a href="/conflict-engine">How the engine decides →</a>
         </p>
       </div>
-    </section>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .gw-page{
-  --purple:#8B5CF6;--purple-d:#7C3AED;--green:#10B981;
-  --bg:#0c0c1a;--bg2:#111120;--card:#16162a;
-  --border:rgba(124,58,237,0.18);--border-soft:rgba(255,255,255,0.06);
-  --text:#e2e8f0;--muted:#94a3b8;
-  background:var(--bg);color:var(--text);
+  --ink:#e8edf5;
+  --ink-dim:#9aa7bd;
+  --ground:#0c0c1a;
+  --ground-tell:#08080f;
+  --surface:#13131f;
+  --rule:rgba(255,255,255,0.09);
+  --rule-soft:rgba(255,255,255,0.05);
+  --brand:#a78bfa;
+  --settled:#34d399;
+  --waiting:#fbbf24;
+  --ease:cubic-bezier(0.22,1,0.36,1);
+  background:var(--ground);
+  color:var(--ink);
   font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  -webkit-font-smoothing:antialiased;
 }
-.ph-inner{max-width:1080px;margin:0 auto;padding:0 24px;}
-.ph-hero{padding:80px 0 56px;text-align:center;background:radial-gradient(ellipse 80% 60% at 50% -10%,rgba(124,58,237,0.18) 0%,transparent 70%),var(--bg);border-bottom:1px solid var(--border-soft);}
-.ph-badge{display:inline-block;font-size:12px;font-weight:600;padding:5px 12px;border-radius:999px;color:var(--purple);background:rgba(124,58,237,0.1);border:1px solid var(--border);margin-bottom:18px;}
-.ph-h1{font-size:44px;line-height:1.15;font-weight:800;letter-spacing:-0.02em;margin:0 auto 18px;max-width:800px;}
-.ph-h1 .grad{background:linear-gradient(135deg,var(--purple),var(--green));-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;}
-.ph-sub{font-size:18px;line-height:1.65;color:var(--muted);max-width:680px;margin:0 auto 28px;}
-.ph-ctas{display:flex;gap:12px;justify-content:center;flex-wrap:wrap;}
-.ph-btn{padding:11px 22px;border-radius:10px;font-size:15px;font-weight:600;text-decoration:none;color:var(--text);border:1px solid var(--border-soft);transition:border-color .15s,color .15s;}
-.ph-btn:hover{border-color:var(--purple);color:var(--purple);}
-.ph-btn--primary{background:var(--purple-d);color:#fff;border-color:var(--purple-d);}
-.ph-btn--primary:hover{background:var(--purple);color:#fff;}
-.ph-section{padding:72px 0;}
-.ph-section--alt{background:var(--bg2);border-top:1px solid var(--border-soft);border-bottom:1px solid var(--border-soft);}
-.ph-h2{font-size:30px;font-weight:800;letter-spacing:-0.01em;text-align:center;margin:0 0 10px;}
-.ph-secsub{font-size:16px;color:var(--muted);text-align:center;max-width:640px;margin:0 auto 40px;line-height:1.6;}
+.wrap{max-width:940px;margin:0 auto;padding:0 26px;}
 
-.st{max-width:640px;margin:0 auto;background:var(--card);border:1px solid var(--border);border-left-width:3px;border-radius:12px;padding:20px 22px;}
-.st--on{border-left-color:var(--green);}
-.st--off{border-left-color:var(--muted);}
-.st--wait{border-left-color:var(--purple);}
-.st-line{margin:0;font-size:15px;line-height:1.6;}
-.st-note{margin:10px 0 0;font-size:13px;color:var(--muted);line-height:1.55;}
-.st-calls{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:8px;}
-.st-calls li{display:flex;align-items:center;justify-content:space-between;gap:12px;font-size:14px;}
-.st-count{font-size:12px;color:var(--muted);font-variant-numeric:tabular-nums;transition:color .2s;}
-.st-count--hot{color:var(--green);}
-.st-failed{margin:14px 0 0;padding-left:18px;font-size:13px;color:#f87171;}
+/* ── workshop ─────────────────────────────────────────────────────────── */
+.shop{padding:26px 0 74px;}
+.strip{display:flex;align-items:center;gap:10px;flex-wrap:wrap;font-size:13px;color:var(--ink-dim);padding:11px 15px;background:var(--surface);border:1px solid var(--rule-soft);border-radius:9px;}
+.strip code{font-family:'JetBrains Mono',monospace;font-size:0.92em;color:var(--ink);}
+.dot{width:7px;height:7px;border-radius:99px;background:var(--ink-dim);flex:none;}
+.strip--on .dot{background:var(--settled);box-shadow:0 0 0 3px rgba(52,211,153,0.16);}
+.strip--wait .dot{background:var(--brand);}
+.strip--legacy{color:var(--waiting);}
+.strip-fail{color:#f87171;}
 
-.try{max-width:760px;margin:0 auto;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:20px 22px;}
-.try-tabs{display:flex;gap:8px;margin-bottom:18px;flex-wrap:wrap;}
-.try-tab{font-family:'JetBrains Mono',monospace;font-size:13px;padding:7px 14px;border-radius:8px;background:transparent;color:var(--muted);border:1px solid var(--border-soft);cursor:pointer;transition:color .15s,border-color .15s;}
-.try-tab:hover{color:var(--text);}
-.try-tab--on{color:var(--purple);border-color:var(--border);background:rgba(124,58,237,0.1);}
-.try-body{display:flex;flex-direction:column;}
-.try-label{font-size:13px;font-weight:600;margin-bottom:6px;}
-.try-hint{font-size:12px;color:var(--muted);margin:6px 0 0;line-height:1.5;}
-.try-input,.try-area{width:100%;box-sizing:border-box;background:var(--bg);color:var(--text);border:1px solid var(--border-soft);border-radius:8px;padding:10px 12px;font-family:'JetBrains Mono',monospace;font-size:13px;line-height:1.6;}
-.try-input:focus,.try-area:focus{outline:none;border-color:var(--purple);}
-.try-area{resize:vertical;margin-bottom:4px;}
-.try-label + .try-area,.try-hint + .try-label{margin-top:0;}
-.try-body > .try-label:not(:first-child){margin-top:16px;}
-.try-run{margin-top:16px;align-self:flex-start;padding:10px 20px;border-radius:10px;font-size:14px;font-weight:600;background:var(--purple-d);color:#fff;border:1px solid var(--purple-d);cursor:pointer;font-family:'JetBrains Mono',monospace;}
-.try-run:hover:not(:disabled){background:var(--purple);}
-.try-run:disabled{opacity:0.6;cursor:default;}
-.try-out{margin:18px 0 0;padding:14px 16px;background:var(--bg);border:1px solid var(--border-soft);border-radius:8px;font-family:'JetBrains Mono',monospace;font-size:12.5px;line-height:1.6;white-space:pre-wrap;word-break:break-word;max-height:460px;overflow:auto;color:var(--text);}
-.tool{max-width:720px;margin:0 auto 20px;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:20px 22px;}
-.tool-name{margin:0 0 10px;font-size:16px;}
-.tool-name code{font-family:'JetBrains Mono',monospace;color:var(--purple);}
-.tool-desc{margin:0 0 12px;font-size:14px;line-height:1.65;color:var(--muted);}
-.tool-io{margin:0;font-size:13px;color:var(--muted);}
-.tool-k{display:inline-block;min-width:52px;font-weight:600;color:var(--text);}
-.foot{max-width:720px;margin:28px auto 0;font-size:14px;line-height:1.65;color:var(--muted);text-align:center;}
-.foot a{color:var(--purple);}
-code{font-family:'JetBrains Mono',monospace;font-size:0.92em;}
+.shop-head{margin:46px 0 30px;}
+.shop-h1{font-size:40px;line-height:1.08;font-weight:800;letter-spacing:-0.03em;margin:0 0 14px;text-wrap:balance;}
+.shop-line{margin:0;font-size:17px;line-height:1.65;color:var(--ink-dim);max-width:62ch;text-wrap:pretty;}
+
+.feed{margin-top:52px;padding-top:30px;border-top:1px solid var(--rule);}
+.feed-h{font-size:15px;font-weight:700;margin:0 0 5px;letter-spacing:-0.01em;}
+.feed-sub{margin:0 0 20px;font-size:13.5px;color:var(--ink-dim);}
+.feed-tabs{display:flex;gap:7px;margin-bottom:18px;flex-wrap:wrap;}
+.feed-tab{font-family:'JetBrains Mono',monospace;font-size:12.5px;padding:7px 13px;border-radius:7px;background:transparent;color:var(--ink-dim);border:1px solid var(--rule-soft);cursor:pointer;transition:color .16s,border-color .16s,background .16s;}
+.feed-tab:hover,.feed-tab:focus-visible{color:var(--ink);}
+.feed-tab--on{color:var(--ink);border-color:var(--rule);background:var(--surface);}
+.feed-body{display:flex;flex-direction:column;}
+.feed-label{font-size:12.5px;font-weight:600;margin-bottom:6px;}
+.feed-body > .feed-label:not(:first-child){margin-top:17px;}
+.feed-hint{font-size:12.5px;color:var(--ink-dim);margin:7px 0 0;line-height:1.55;}
+.feed-hint code{font-family:'JetBrains Mono',monospace;color:var(--ink);}
+.feed-input,.feed-area{width:100%;box-sizing:border-box;background:var(--surface);color:var(--ink);border:1px solid var(--rule-soft);border-radius:8px;padding:10px 13px;font-family:'JetBrains Mono',monospace;font-size:12.5px;line-height:1.65;}
+.feed-input:focus,.feed-area:focus{outline:none;border-color:var(--brand);}
+.feed-area{resize:vertical;}
+.feed-run{margin-top:17px;align-self:flex-start;padding:10px 19px;border-radius:8px;font:inherit;font-size:13.5px;font-weight:600;background:var(--ink);color:#0c0c14;border:1px solid var(--ink);cursor:pointer;transition:opacity .16s;}
+.feed-run:hover:not(:disabled){opacity:0.86;}
+.feed-run:disabled{opacity:0.5;cursor:default;}
+.feed-note{margin:12px 0 0;font-size:13px;color:var(--settled);}
+
+/* ── the break ────────────────────────────────────────────────────────── */
+.seam{height:0;border-top:1px solid var(--rule);box-shadow:0 -22px 44px -30px rgba(167,139,250,0.55);}
+
+/* ── showcase ─────────────────────────────────────────────────────────── */
+.tell{background:var(--ground-tell);padding:96px 0 100px;}
+.tell-lede{margin:0 0 26px;font-size:29px;line-height:1.3;font-weight:600;letter-spacing:-0.02em;color:var(--ink-dim);max-width:24ch;text-wrap:balance;}
+.tell-lede strong{color:var(--ink);font-weight:800;display:block;}
+.tell-body{margin:0 0 62px;font-size:16px;line-height:1.75;color:var(--ink-dim);max-width:70ch;text-wrap:pretty;}
+.tell-h{font-size:13px;font-weight:700;margin:0 0 4px;color:var(--ink);}
+
+.spec{margin:0 0 44px;}
+.spec-row{display:grid;grid-template-columns:minmax(160px,0.9fr) 2fr;gap:26px;padding:22px 0;border-top:1px solid var(--rule-soft);}
+@media (max-width:680px){.spec-row{grid-template-columns:1fr;gap:9px;}}
+.spec-row dt code{font-family:'JetBrains Mono',monospace;font-size:14px;color:var(--brand);}
+.spec-row dd{margin:0;}
+.spec-row dd p{margin:0;font-size:14.5px;line-height:1.65;color:var(--ink-dim);max-width:62ch;}
+.spec-io{margin-top:9px !important;font-family:'JetBrains Mono',monospace;}
+.spec-io code{font-size:12.5px;color:var(--ink-dim);}
+
+.tell-foot{margin:0;font-size:14px;line-height:1.75;color:var(--ink-dim);max-width:70ch;}
+.tell-foot a{color:var(--brand);text-underline-offset:3px;}
+.tell-foot code{font-family:'JetBrains Mono',monospace;font-size:0.92em;}
+
+@media (max-width:640px){
+  .shop-h1{font-size:32px;}
+  .tell-lede{font-size:24px;}
+}
 </style>

--- a/website/.vitepress/theme/AgentPage.vue
+++ b/website/.vitepress/theme/AgentPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from 'vue'
 import { TOOLS, parseGitErrorTool, resolveConflictTool } from './tools'
+import MergeRoom from './MergeRoom.vue'
 import { SAMPLE_GIT_ERROR, SAMPLE_CONFLICT } from './tools/samples'
 import { registerTools, type Surface } from './webmcp'
 
@@ -84,10 +85,11 @@ function pick(id: ToolId) {
     <section class="ph-hero">
       <div class="ph-inner">
         <span class="ph-badge">WebMCP</span>
-        <h1 class="ph-h1">Git tools your agent can <span class="grad">just call</span>.</h1>
-        <p class="ph-sub">
-          This page exposes GitWand's conflict engine to any agent browsing it, through the W3C WebMCP
-          standard. No install, no API key, no server: the tools run in the tab you are looking at.
+        <h1 class="ph-h1">Your agent clears the queue. <span class="grad">You make the calls.</span></h1>
+                <p class="ph-sub">
+          A shared Git workspace for you and whatever agent is browsing this page, over the W3C
+          WebMCP standard. The engine settles every hunk that carries no decision. The ones where
+          your two branches genuinely disagree wait for you, and no tool here can take that call.
         </p>
         <div class="ph-ctas">
           <a href="/guide/mcp" class="ph-btn ph-btn--primary">Prefer a real MCP server?</a>
@@ -95,6 +97,8 @@ function pick(id: ToolId) {
         </div>
       </div>
     </section>
+
+    <MergeRoom />
 
     <!-- Live registration state. Deliberately shows failure and absence as
          plainly as success: a demo that always claims to work teaches nobody. -->
@@ -154,10 +158,10 @@ function pick(id: ToolId) {
          agent would get back. -->
     <section class="ph-section ph-section--alt">
       <div class="ph-inner">
-        <h2 class="ph-h2">Try them without an agent</h2>
+        <h2 class="ph-h2">File a case yourself</h2>
         <p class="ph-secsub">
-          This runs the same code an agent calls. Nothing is sent anywhere: the engine executes in
-          this tab.
+          The same code an agent calls, wired to the same room. Whatever you run here shows up above
+          exactly as an agent's call would. Nothing is sent anywhere.
         </p>
 
         <div class="try">
@@ -205,10 +209,11 @@ function pick(id: ToolId) {
          browser has no WebMCP and for crawlers that will never run the script. -->
     <section class="ph-section ph-section--alt">
       <div class="ph-inner">
-        <h2 class="ph-h2">The two tools, written out</h2>
+        <h2 class="ph-h2">The three tools, written out</h2>
         <p class="ph-secsub">
-          Both are read-only. Neither runs git, neither writes to a repository, and neither uploads
-          what you pass it.
+          All read-only with respect to your machine. None runs git, none writes to a repository,
+          none uploads what you pass it. What they do write to is the room above. Deliberately
+          missing: any tool that picks a side on a conflicted hunk.
         </p>
 
         <article class="tool">
@@ -234,6 +239,16 @@ function pick(id: ToolId) {
           <p class="tool-io">
             <span class="tool-k">Input</span> <code>{ content: string, filePath?: string }</code>
           </p>
+        </article>
+
+        <article class="tool">
+          <h3 class="tool-name"><code>list_cases</code></h3>
+          <p class="tool-desc">
+            Reads the room back: what has been filed, which hunks the engine settled, which are still
+            waiting on a person, and which you have already decided. It is what lets an agent pick up
+            where it left off, and check whether you have made the calls it was waiting on.
+          </p>
+          <p class="tool-io"><span class="tool-k">Input</span> <code>{}</code></p>
         </article>
 
         <p class="foot">

--- a/website/.vitepress/theme/MergeRoom.vue
+++ b/website/.vitepress/theme/MergeRoom.vue
@@ -3,11 +3,50 @@ import { computed, ref } from 'vue'
 import { roomCases, roomJournal, summary, decide, clearRoom, finalFile, type ConflictCase } from './room'
 
 const copied = ref<string | null>(null)
+const journalOpen = ref(false)
+
+/**
+ * A decided hunk collapses to the side that was taken. Keeping both columns
+ * and both buttons on screen after the call is made is the same mistake as
+ * leaving settled work at full weight: the room stops showing what is left.
+ * Reopening is one click, because changing your mind is not an error state.
+ */
+const reopened = ref<Set<string>>(new Set())
+const key = (caseId: string, i: number) => `${caseId}:${i}`
+const isForkOpen = (caseId: string, h: { autoResolved: boolean; decision: string | null }, i: number) =>
+  !h.autoResolved && (!h.decision || reopened.value.has(key(caseId, i)))
+function reopen(caseId: string, i: number) {
+  const next = new Set(reopened.value)
+  next.add(key(caseId, i))
+  reopened.value = next
+}
 
 const empty = computed(() => roomCases.value.length === 0)
 
-function finalFor(c: ConflictCase) {
-  return finalFile(c)
+/**
+ * The rail is a proportion, not a scoreboard. Three counts as three big
+ * numbers is the hero-metric template; the same three as widths of one bar
+ * says the thing that actually matters, which is how much is left.
+ */
+const rail = computed(() => {
+  const s = summary.value
+  const total = s.hunksSettledByEngine + s.hunksDecidedByYou + s.hunksWaitingOnYou
+  if (!total) return null
+  const pct = (n: number) => (n / total) * 100
+  return {
+    total,
+    settled: pct(s.hunksSettledByEngine),
+    decided: pct(s.hunksDecidedByYou),
+    waiting: pct(s.hunksWaitingOnYou),
+    done: s.hunksWaitingOnYou === 0,
+  }
+})
+
+function take(caseId: string, index: number, side: 'ours' | 'theirs') {
+  decide(caseId, index, side)
+  const next = new Set(reopened.value)
+  next.delete(key(caseId, index))
+  reopened.value = next
 }
 
 function waitingIn(c: ConflictCase) {
@@ -29,170 +68,243 @@ const clock = (t: number) =>
 </script>
 
 <template>
-  <section class="ph-section">
-    <div class="ph-inner">
-      <h2 class="ph-h2">The Merge Room</h2>
-      <p class="ph-secsub">
-        Everything an agent files lands here. The engine settles what carries no decision. Every hunk
-        where the two branches genuinely disagree waits for you, and no tool on this page can take
-        that call.
-      </p>
-
-      <div class="mr-bar">
-        <div class="mr-stat">
-          <span class="mr-n mr-n--green">{{ summary.hunksSettledByEngine }}</span>
-          <span class="mr-l">settled by the engine</span>
-        </div>
-        <div class="mr-stat">
-          <span class="mr-n mr-n--amber">{{ summary.hunksWaitingOnYou }}</span>
-          <span class="mr-l">waiting on you</span>
-        </div>
-        <div class="mr-stat">
-          <span class="mr-n">{{ summary.hunksDecidedByYou }}</span>
-          <span class="mr-l">decided by you</span>
-        </div>
-        <button v-if="!empty" class="mr-clear" @click="clearRoom">Clear room</button>
+  <div class="room">
+    <!-- One line, not a scoreboard. Reads as a sentence and doubles as the
+         only progress indicator on the page. -->
+    <div v-if="rail" class="rail">
+      <div class="rail-track" role="img" :aria-label="`${summary.hunksSettledByEngine} settled by the engine, ${summary.hunksDecidedByYou} decided by you, ${summary.hunksWaitingOnYou} waiting on you`">
+        <span class="rail-fill rail-fill--settled" :style="{ width: rail.settled + '%' }"></span>
+        <span class="rail-fill rail-fill--decided" :style="{ width: rail.decided + '%' }"></span>
+        <span class="rail-fill rail-fill--waiting" :style="{ width: rail.waiting + '%' }"></span>
       </div>
-
-      <p v-if="empty" class="mr-empty">
-        Nothing filed yet. Ask an agent to call <code>resolve_conflict</code> or
-        <code>parse_git_error</code>, or use the panel below to file a case yourself.
+      <p class="rail-read">
+        <span class="tick tick--settled">{{ summary.hunksSettledByEngine }} settled by the engine</span>
+        <span v-if="summary.hunksDecidedByYou" class="tick tick--decided">{{ summary.hunksDecidedByYou }} you decided</span>
+        <span v-if="summary.hunksWaitingOnYou" class="tick tick--waiting">{{ summary.hunksWaitingOnYou }} waiting on you</span>
+        <span v-else class="tick tick--clear">nothing left for you</span>
       </p>
+      <button class="ghost" @click="clearRoom">Clear</button>
+    </div>
 
-      <div v-for="c in roomCases" :key="c.id" class="mr-case">
-        <header class="mr-head">
-          <code class="mr-id">{{ c.id }}</code>
-          <span v-if="c.kind === 'conflict'" class="mr-path">{{ c.filePath }}</span>
-          <span v-else class="mr-path">git error</span>
-          <span class="mr-time">{{ clock(c.at) }}</span>
+    <p v-if="empty" class="void">
+      Empty. An agent calls <code>resolve_conflict</code> or <code>parse_git_error</code> and the
+      case lands here, split into what it settled and what it will not touch. No agent to hand?
+      File one below.
+    </p>
+
+    <!-- A ledger, not a stack of cards: one surface, rows separated by rules.
+         Settled rows recede to a single quiet line; the ones needing a person
+         are the only thing on the page carrying weight. -->
+    <TransitionGroup name="file" tag="div" class="ledger">
+      <article v-for="c in roomCases" :key="c.id" class="entry">
+        <header class="entry-head">
+          <code class="entry-id">{{ c.id }}</code>
+          <span class="entry-subject">{{ c.kind === 'conflict' ? c.filePath : 'git failure' }}</span>
+          <time class="entry-time">{{ clock(c.at) }}</time>
         </header>
 
         <template v-if="c.kind === 'error'">
-          <p v-if="c.titles.length" class="mr-titles">{{ c.titles.join(' · ') }}</p>
-          <pre class="mr-body">{{ c.body }}</pre>
+          <p v-if="c.titles.length" class="err-title">{{ c.titles.join(' · ') }}</p>
+          <pre class="block">{{ c.body }}</pre>
         </template>
 
         <template v-else>
-          <div v-for="h in c.hunks" :key="h.index" class="mr-hunk" :class="{ 'mr-hunk--open': !h.autoResolved && !h.decision }">
-            <div class="mr-hunk-head">
-              <span class="mr-idx">[{{ h.index }}]</span>
-              <code class="mr-type">{{ h.type }}</code>
-              <span class="mr-conf" :class="`mr-conf--${h.confidenceLabel}`">{{ h.confidenceLabel }} · {{ h.confidenceScore }}</span>
-              <span v-if="h.autoResolved" class="mr-tag mr-tag--auto">settled</span>
-              <span v-else-if="h.decision" class="mr-tag mr-tag--you">you took {{ h.decision }}</span>
-              <span v-else class="mr-tag mr-tag--open">your call</span>
+          <div
+            v-for="h in c.hunks"
+            :key="h.index"
+            class="hunk"
+            :class="{
+              'hunk--settled': h.autoResolved,
+              'hunk--decided': !h.autoResolved && !!h.decision,
+              'hunk--open': !h.autoResolved && !h.decision,
+            }"
+          >
+            <div class="hunk-line">
+              <span class="hunk-n">{{ h.index }}</span>
+              <code class="hunk-type">{{ h.type }}</code>
+              <span class="hunk-score">{{ h.confidenceLabel }} {{ h.confidenceScore }}</span>
+              <span class="hunk-state">
+                <template v-if="h.autoResolved">settled</template>
+                <template v-else-if="h.decision">you took {{ h.decision }}</template>
+                <template v-else>your call</template>
+              </span>
             </div>
-            <p class="mr-reason">{{ h.reason }}</p>
+            <p class="hunk-why">{{ h.reason }}</p>
 
-            <!-- Only the hunks the engine refused get a chooser. There is
-                 deliberately no control to override one it settled. -->
-            <div v-if="!h.autoResolved" class="mr-choose">
-              <div class="mr-side">
-                <div class="mr-side-head">ours</div>
-                <pre class="mr-code">{{ h.ours.join('\n') || '(empty)' }}</pre>
-                <button class="mr-pick" :class="{ 'mr-pick--on': h.decision === 'ours' }" @click="decide(c.id, h.index, 'ours')">Take ours</button>
+            <!-- Only for hunks the engine refused. There is deliberately no
+                 control to override one it settled. -->
+            <div v-if="isForkOpen(c.id, h, h.index)" class="fork">
+              <div class="fork-side">
+                <div class="fork-label">ours</div>
+                <pre class="block block--side">{{ h.ours.join('\n') || '(empty)' }}</pre>
+                <button class="choose" :class="{ 'choose--taken': h.decision === 'ours' }" @click="take(c.id, h.index, 'ours')">
+                  Take ours
+                </button>
               </div>
-              <div class="mr-side">
-                <div class="mr-side-head">theirs</div>
-                <pre class="mr-code">{{ h.theirs.join('\n') || '(empty)' }}</pre>
-                <button class="mr-pick" :class="{ 'mr-pick--on': h.decision === 'theirs' }" @click="decide(c.id, h.index, 'theirs')">Take theirs</button>
+              <div class="fork-side">
+                <div class="fork-label">theirs</div>
+                <pre class="block block--side">{{ h.theirs.join('\n') || '(empty)' }}</pre>
+                <button class="choose" :class="{ 'choose--taken': h.decision === 'theirs' }" @click="take(c.id, h.index, 'theirs')">
+                  Take theirs
+                </button>
               </div>
+            </div>
+
+            <!-- Decided: the call collapses to the side that was taken. -->
+            <div v-else-if="!h.autoResolved" class="kept">
+              <span class="fork-label">{{ h.decision }}</span>
+              <pre class="block block--kept">{{ (h.decision === 'ours' ? h.ours : h.theirs).join('\n') || '(empty)' }}</pre>
+              <button class="relink" @click="reopen(c.id, h.index)">Change</button>
             </div>
           </div>
 
-          <div v-if="finalFor(c)" class="mr-final">
-            <div class="mr-final-head">
-              <span>Merged file, ready to paste back</span>
-              <button class="mr-copy" @click="copy(c.id, finalFor(c) as string)">
-                {{ copied === c.id ? 'Copied' : 'Copy' }}
-              </button>
+          <Transition name="unfurl">
+            <div v-if="finalFile(c)" class="done">
+              <div class="done-head">
+                <span class="done-say">Merged. Nothing left to decide.</span>
+                <button class="ghost" @click="copy(c.id, finalFile(c) as string)">
+                  {{ copied === c.id ? 'Copied' : 'Copy file' }}
+                </button>
+              </div>
+              <pre class="block block--done">{{ finalFile(c) }}</pre>
             </div>
-            <pre class="mr-code mr-code--final">{{ finalFor(c) }}</pre>
-          </div>
-          <p v-else class="mr-pending">
-            {{ waitingIn(c) }} hunk{{ waitingIn(c) === 1 ? '' : 's' }} still waiting on you. The merged
-            file appears here once every one has a side.
+          </Transition>
+          <p v-if="!finalFile(c)" class="held">
+            Held: {{ waitingIn(c) }} hunk{{ waitingIn(c) === 1 ? '' : 's' }} still yours to call. The
+            merged file appears the moment the last one has a side.
           </p>
         </template>
-      </div>
+      </article>
+    </TransitionGroup>
 
-      <div v-if="roomJournal.length" class="mr-journal">
-        <h3 class="mr-jh">Live journal</h3>
-        <ul>
-          <li v-for="(e, i) in roomJournal" :key="i">
-            <span class="mr-jt">{{ clock(e.at) }}</span>
-            <span class="mr-actor" :class="`mr-actor--${e.actor}`">{{ e.actor }}</span>
-            <span>{{ e.text }}</span>
-          </li>
-        </ul>
-      </div>
+    <div v-if="roomJournal.length" class="log">
+      <button class="log-toggle" :aria-expanded="journalOpen" @click="journalOpen = !journalOpen">
+        {{ journalOpen ? 'Hide' : 'Show' }} activity ({{ roomJournal.length }})
+      </button>
+      <ul v-if="journalOpen">
+        <li v-for="(e, i) in roomJournal" :key="i">
+          <time>{{ clock(e.at) }}</time>
+          <span class="log-who" :class="`log-who--${e.actor}`">{{ e.actor }}</span>
+          <span>{{ e.text }}</span>
+        </li>
+      </ul>
     </div>
-  </section>
+  </div>
 </template>
 
 <style scoped>
-.ph-inner{max-width:1080px;margin:0 auto;padding:0 24px;}
-.ph-section{padding:72px 0;}
-.ph-h2{font-size:30px;font-weight:800;letter-spacing:-0.01em;text-align:center;margin:0 0 10px;}
-.ph-secsub{font-size:16px;color:var(--muted);text-align:center;max-width:660px;margin:0 auto 36px;line-height:1.6;}
+.room{
+  --ink:#e8edf5;
+  --ink-dim:#9aa7bd;
+  --ink-quiet:#78849a;
+  --ground:#0c0c1a;
+  --surface:#13131f;
+  --rule:rgba(255,255,255,0.09);
+  --rule-soft:rgba(255,255,255,0.05);
+  --settled:#34d399;
+  --waiting:#fbbf24;
+  --decided:#a78bfa;
+  --ease:cubic-bezier(0.22,1,0.36,1);
+  color:var(--ink);
+  font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+}
 
-.mr-bar{display:flex;align-items:center;gap:28px;flex-wrap:wrap;max-width:820px;margin:0 auto 24px;padding:16px 20px;background:var(--card);border:1px solid var(--border);border-radius:12px;}
-.mr-stat{display:flex;flex-direction:column;gap:2px;}
-.mr-n{font-size:26px;font-weight:800;font-variant-numeric:tabular-nums;line-height:1;}
-.mr-n--green{color:var(--green);}
-.mr-n--amber{color:#fbbf24;}
-.mr-l{font-size:12px;color:var(--muted);}
-.mr-clear{margin-left:auto;background:transparent;border:1px solid var(--border-soft);color:var(--muted);border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;}
-.mr-clear:hover{color:var(--text);border-color:var(--purple);}
+/* ── rail ─────────────────────────────────────────────────────────────── */
+.rail{display:flex;align-items:center;gap:18px;flex-wrap:wrap;padding-bottom:14px;border-bottom:1px solid var(--rule);}
+.rail-track{flex:0 0 100%;display:flex;height:5px;border-radius:99px;overflow:hidden;background:rgba(255,255,255,0.06);}
+.rail-fill{transition:width .45s var(--ease);}
+.rail-fill--settled{background:var(--settled);}
+.rail-fill--decided{background:var(--decided);}
+.rail-fill--waiting{background:var(--waiting);}
+.rail-read{margin:0;font-size:14px;color:var(--ink-dim);display:flex;gap:16px;flex-wrap:wrap;align-items:baseline;}
+.tick{display:inline-flex;align-items:baseline;gap:7px;font-variant-numeric:tabular-nums;}
+.tick::before{content:'';width:7px;height:7px;border-radius:99px;transform:translateY(-1px);}
+.tick--settled{color:var(--settled);}
+.tick--settled::before{background:var(--settled);}
+.tick--decided{color:var(--decided);}
+.tick--decided::before{background:var(--decided);}
+.tick--waiting{color:var(--waiting);font-weight:600;}
+.tick--waiting::before{background:var(--waiting);}
+.tick--clear{color:var(--settled);}
+.tick--clear::before{background:var(--settled);}
 
-.mr-empty{max-width:820px;margin:0 auto;text-align:center;color:var(--muted);font-size:14px;line-height:1.6;}
+.ghost{margin-left:auto;background:transparent;border:1px solid var(--rule);color:var(--ink-dim);border-radius:7px;padding:6px 13px;font:inherit;font-size:13px;cursor:pointer;transition:color .16s,border-color .16s;}
+.ghost:hover,.ghost:focus-visible{color:var(--ink);border-color:var(--ink-dim);}
 
-.mr-case{max-width:820px;margin:0 auto 18px;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:18px 20px;}
-.mr-head{display:flex;align-items:center;gap:10px;margin-bottom:12px;flex-wrap:wrap;}
-.mr-id{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--purple);}
-.mr-path{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--muted);}
-.mr-time{margin-left:auto;font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;}
-.mr-titles{margin:0 0 8px;font-size:14px;font-weight:600;}
-.mr-body{margin:0;padding:12px 14px;background:var(--bg);border:1px solid var(--border-soft);border-radius:8px;font-family:'JetBrains Mono',monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;max-height:280px;overflow:auto;}
+.void{margin:0;font-size:15px;line-height:1.7;color:var(--ink-dim);max-width:58ch;text-wrap:pretty;}
+.void code{font-family:'JetBrains Mono',monospace;font-size:0.9em;color:var(--ink);}
 
-.mr-hunk{padding:12px 0;border-top:1px solid var(--border-soft);}
-.mr-hunk:first-of-type{border-top:none;}
-.mr-hunk--open{background:rgba(251,191,36,0.04);margin:0 -20px;padding:12px 20px;}
-.mr-hunk-head{display:flex;align-items:center;gap:9px;flex-wrap:wrap;}
-.mr-idx{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--muted);}
-.mr-type{font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--purple);}
-.mr-conf{font-size:11px;font-weight:600;padding:2px 8px;border-radius:6px;background:rgba(148,163,184,0.12);color:var(--muted);}
-.mr-conf--certain{color:var(--green);background:rgba(16,185,129,0.12);}
-.mr-conf--high{color:var(--purple);background:rgba(124,58,237,0.14);}
-.mr-conf--medium{color:#fbbf24;background:rgba(251,191,36,0.12);}
-.mr-tag{margin-left:auto;font-size:11px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;}
-.mr-tag--auto{color:var(--green);}
-.mr-tag--you{color:var(--purple);}
-.mr-tag--open{color:#fbbf24;}
-.mr-reason{margin:6px 0 0;font-size:13px;color:var(--muted);line-height:1.55;}
+/* ── ledger ───────────────────────────────────────────────────────────── */
+.ledger{margin-top:4px;}
+.entry{padding:26px 0;border-bottom:1px solid var(--rule-soft);}
+.entry-head{display:flex;align-items:baseline;gap:12px;margin-bottom:16px;}
+.entry-id{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--decided);}
+.entry-subject{font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--ink);}
+.entry-time{margin-left:auto;font-size:12px;color:var(--ink-dim);font-variant-numeric:tabular-nums;}
+.err-title{margin:0 0 10px;font-size:16px;font-weight:600;}
 
-.mr-choose{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px;}
-@media (max-width:640px){.mr-choose{grid-template-columns:1fr;}}
-.mr-side{display:flex;flex-direction:column;}
-.mr-side-head{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--muted);margin-bottom:5px;}
-.mr-code{margin:0;padding:10px 12px;background:var(--bg);border:1px solid var(--border-soft);border-radius:8px;font-family:'JetBrains Mono',monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-word;max-height:200px;overflow:auto;flex:1;}
-.mr-code--final{max-height:320px;}
-.mr-pick{margin-top:8px;padding:8px 14px;border-radius:8px;font-size:13px;font-weight:600;background:transparent;color:var(--text);border:1px solid var(--border-soft);cursor:pointer;}
-.mr-pick:hover{border-color:var(--purple);color:var(--purple);}
-.mr-pick--on{background:var(--purple-d);border-color:var(--purple-d);color:#fff;}
+.block{margin:0;padding:13px 15px;background:var(--surface);border:1px solid var(--rule-soft);border-radius:9px;font-family:'JetBrains Mono',monospace;font-size:12.5px;line-height:1.65;white-space:pre-wrap;word-break:break-word;overflow:auto;max-height:300px;color:var(--ink);}
+.block--side{max-height:180px;flex:1;}
+.block--done{max-height:340px;}
 
-.mr-final{margin-top:14px;}
-.mr-final-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:7px;font-size:13px;font-weight:600;color:var(--green);}
-.mr-copy{background:transparent;border:1px solid var(--border-soft);color:var(--muted);border-radius:8px;padding:5px 12px;font-size:12px;cursor:pointer;}
-.mr-copy:hover{color:var(--text);border-color:var(--green);}
-.mr-pending{margin:12px 0 0;font-size:13px;color:#fbbf24;}
+/* Settled work recedes. Open work is the only thing with weight. */
+.hunk{padding:13px 0;border-top:1px solid var(--rule-soft);transition:opacity .3s var(--ease);}
+.hunk:first-of-type{border-top:none;}
+.hunk--settled .hunk-type{color:var(--ink-quiet);}
+.hunk--settled .hunk-why,.hunk--settled .hunk-score{color:var(--ink-quiet);}
+.hunk--settled:hover .hunk-type,.hunk--settled:hover .hunk-why{color:var(--ink-dim);}
+.hunk--open{background:rgba(251,191,36,0.05);border-radius:10px;padding:15px 16px;margin:6px -16px;border-top-color:transparent;}
+.hunk-line{display:flex;align-items:baseline;gap:11px;}
+.hunk-n{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--ink-dim);min-width:1.2em;font-variant-numeric:tabular-nums;}
+.hunk-type{font-family:'JetBrains Mono',monospace;font-size:13.5px;color:var(--ink);}
+.hunk-score{font-family:'JetBrains Mono',monospace;font-size:11.5px;color:var(--ink-dim);font-variant-numeric:tabular-nums;}
+.hunk-state{margin-left:auto;font-size:11.5px;font-weight:700;letter-spacing:0.02em;}
+.hunk--settled .hunk-state{color:var(--settled);}
+.hunk--decided .hunk-state{color:var(--decided);}
+.hunk--open .hunk-state{color:var(--waiting);}
+.hunk-why{margin:7px 0 0 calc(1.2em + 11px);font-size:13.5px;line-height:1.6;color:var(--ink-dim);max-width:70ch;}
 
-.mr-journal{max-width:820px;margin:26px auto 0;}
-.mr-jh{font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--muted);margin:0 0 10px;}
-.mr-journal ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px;}
-.mr-journal li{display:flex;gap:10px;align-items:baseline;font-size:13px;line-height:1.5;}
-.mr-jt{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;}
-.mr-actor{font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:700;min-width:44px;}
-.mr-actor--agent{color:var(--purple);}
-.mr-actor--you{color:var(--green);}
+.fork{display:grid;grid-template-columns:1fr 1fr;gap:14px;margin-top:14px;}
+@media (max-width:660px){.fork{grid-template-columns:1fr;}}
+.fork-side{display:flex;flex-direction:column;}
+.fork-label{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--ink-dim);margin-bottom:6px;}
+.choose{margin-top:9px;padding:9px 15px;border-radius:8px;font:inherit;font-size:13.5px;font-weight:600;background:transparent;color:var(--ink);border:1px solid var(--rule);cursor:pointer;transition:background .16s,border-color .16s,color .16s;}
+.choose:hover,.choose:focus-visible{border-color:var(--waiting);color:var(--waiting);}
+.choose--taken{background:var(--decided);border-color:var(--decided);color:#12121e;}
+.choose--taken:hover{background:var(--decided);color:#12121e;}
+
+.kept{display:flex;align-items:center;gap:12px;margin-top:11px;margin-left:calc(1.2em + 11px);}
+.kept .fork-label{margin:0;flex:none;min-width:44px;}
+.block--kept{flex:1;max-height:76px;padding:8px 12px;font-size:12px;}
+.relink{flex:none;background:transparent;border:none;padding:0;color:var(--ink-dim);font:inherit;font-size:12.5px;cursor:pointer;text-decoration:underline;text-underline-offset:3px;text-decoration-color:var(--rule);}
+.relink:hover,.relink:focus-visible{color:var(--ink);}
+
+.done{margin-top:16px;}
+.done-head{display:flex;align-items:center;gap:12px;margin-bottom:9px;}
+.done-say{font-size:13.5px;font-weight:600;color:var(--settled);}
+.held{margin:14px 0 0;font-size:13.5px;color:var(--waiting);max-width:64ch;}
+
+/* ── activity log, folded away by default ─────────────────────────────── */
+.log{margin-top:22px;}
+.log-toggle{background:transparent;border:none;padding:0;color:var(--ink-dim);font:inherit;font-size:13px;cursor:pointer;text-decoration:underline;text-underline-offset:3px;text-decoration-color:var(--rule);}
+.log-toggle:hover,.log-toggle:focus-visible{color:var(--ink);}
+.log ul{list-style:none;padding:0;margin:14px 0 0;display:flex;flex-direction:column;gap:7px;}
+.log li{display:flex;gap:11px;align-items:baseline;font-size:13px;line-height:1.5;color:var(--ink-dim);}
+.log time{font-family:'JetBrains Mono',monospace;font-size:11px;font-variant-numeric:tabular-nums;}
+.log-who{font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:700;min-width:42px;}
+.log-who--agent{color:var(--decided);}
+.log-who--you{color:var(--settled);}
+
+/* ── motion: only the two moments that mean something ─────────────────── */
+.file-enter-active{transition:opacity .34s var(--ease), transform .34s var(--ease);}
+.file-enter-from{opacity:0;transform:translateY(10px);}
+.unfurl-enter-active{transition:opacity .3s var(--ease), transform .3s var(--ease);}
+.unfurl-enter-from{opacity:0;transform:translateY(-6px);}
+
+@media (prefers-reduced-motion:reduce){
+  .file-enter-active,.unfurl-enter-active{transition:opacity .01ms;}
+  .file-enter-from,.unfurl-enter-from{transform:none;}
+  .rail-fill{transition:none;}
+  .hunk{transition:none;}
+}
 </style>

--- a/website/.vitepress/theme/MergeRoom.vue
+++ b/website/.vitepress/theme/MergeRoom.vue
@@ -1,0 +1,198 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { roomCases, roomJournal, summary, decide, clearRoom, finalFile, type ConflictCase } from './room'
+
+const copied = ref<string | null>(null)
+
+const empty = computed(() => roomCases.value.length === 0)
+
+function finalFor(c: ConflictCase) {
+  return finalFile(c)
+}
+
+function waitingIn(c: ConflictCase) {
+  return c.hunks.filter((h) => !h.autoResolved && !h.decision).length
+}
+
+async function copy(id: string, body: string) {
+  try {
+    await navigator.clipboard.writeText(body)
+    copied.value = id
+    setTimeout(() => (copied.value = null), 1600)
+  } catch {
+    copied.value = null
+  }
+}
+
+const clock = (t: number) =>
+  new Date(t).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+</script>
+
+<template>
+  <section class="ph-section">
+    <div class="ph-inner">
+      <h2 class="ph-h2">The Merge Room</h2>
+      <p class="ph-secsub">
+        Everything an agent files lands here. The engine settles what carries no decision. Every hunk
+        where the two branches genuinely disagree waits for you, and no tool on this page can take
+        that call.
+      </p>
+
+      <div class="mr-bar">
+        <div class="mr-stat">
+          <span class="mr-n mr-n--green">{{ summary.hunksSettledByEngine }}</span>
+          <span class="mr-l">settled by the engine</span>
+        </div>
+        <div class="mr-stat">
+          <span class="mr-n mr-n--amber">{{ summary.hunksWaitingOnYou }}</span>
+          <span class="mr-l">waiting on you</span>
+        </div>
+        <div class="mr-stat">
+          <span class="mr-n">{{ summary.hunksDecidedByYou }}</span>
+          <span class="mr-l">decided by you</span>
+        </div>
+        <button v-if="!empty" class="mr-clear" @click="clearRoom">Clear room</button>
+      </div>
+
+      <p v-if="empty" class="mr-empty">
+        Nothing filed yet. Ask an agent to call <code>resolve_conflict</code> or
+        <code>parse_git_error</code>, or use the panel below to file a case yourself.
+      </p>
+
+      <div v-for="c in roomCases" :key="c.id" class="mr-case">
+        <header class="mr-head">
+          <code class="mr-id">{{ c.id }}</code>
+          <span v-if="c.kind === 'conflict'" class="mr-path">{{ c.filePath }}</span>
+          <span v-else class="mr-path">git error</span>
+          <span class="mr-time">{{ clock(c.at) }}</span>
+        </header>
+
+        <template v-if="c.kind === 'error'">
+          <p v-if="c.titles.length" class="mr-titles">{{ c.titles.join(' · ') }}</p>
+          <pre class="mr-body">{{ c.body }}</pre>
+        </template>
+
+        <template v-else>
+          <div v-for="h in c.hunks" :key="h.index" class="mr-hunk" :class="{ 'mr-hunk--open': !h.autoResolved && !h.decision }">
+            <div class="mr-hunk-head">
+              <span class="mr-idx">[{{ h.index }}]</span>
+              <code class="mr-type">{{ h.type }}</code>
+              <span class="mr-conf" :class="`mr-conf--${h.confidenceLabel}`">{{ h.confidenceLabel }} · {{ h.confidenceScore }}</span>
+              <span v-if="h.autoResolved" class="mr-tag mr-tag--auto">settled</span>
+              <span v-else-if="h.decision" class="mr-tag mr-tag--you">you took {{ h.decision }}</span>
+              <span v-else class="mr-tag mr-tag--open">your call</span>
+            </div>
+            <p class="mr-reason">{{ h.reason }}</p>
+
+            <!-- Only the hunks the engine refused get a chooser. There is
+                 deliberately no control to override one it settled. -->
+            <div v-if="!h.autoResolved" class="mr-choose">
+              <div class="mr-side">
+                <div class="mr-side-head">ours</div>
+                <pre class="mr-code">{{ h.ours.join('\n') || '(empty)' }}</pre>
+                <button class="mr-pick" :class="{ 'mr-pick--on': h.decision === 'ours' }" @click="decide(c.id, h.index, 'ours')">Take ours</button>
+              </div>
+              <div class="mr-side">
+                <div class="mr-side-head">theirs</div>
+                <pre class="mr-code">{{ h.theirs.join('\n') || '(empty)' }}</pre>
+                <button class="mr-pick" :class="{ 'mr-pick--on': h.decision === 'theirs' }" @click="decide(c.id, h.index, 'theirs')">Take theirs</button>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="finalFor(c)" class="mr-final">
+            <div class="mr-final-head">
+              <span>Merged file, ready to paste back</span>
+              <button class="mr-copy" @click="copy(c.id, finalFor(c) as string)">
+                {{ copied === c.id ? 'Copied' : 'Copy' }}
+              </button>
+            </div>
+            <pre class="mr-code mr-code--final">{{ finalFor(c) }}</pre>
+          </div>
+          <p v-else class="mr-pending">
+            {{ waitingIn(c) }} hunk{{ waitingIn(c) === 1 ? '' : 's' }} still waiting on you. The merged
+            file appears here once every one has a side.
+          </p>
+        </template>
+      </div>
+
+      <div v-if="roomJournal.length" class="mr-journal">
+        <h3 class="mr-jh">Live journal</h3>
+        <ul>
+          <li v-for="(e, i) in roomJournal" :key="i">
+            <span class="mr-jt">{{ clock(e.at) }}</span>
+            <span class="mr-actor" :class="`mr-actor--${e.actor}`">{{ e.actor }}</span>
+            <span>{{ e.text }}</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </section>
+</template>
+
+<style scoped>
+.ph-inner{max-width:1080px;margin:0 auto;padding:0 24px;}
+.ph-section{padding:72px 0;}
+.ph-h2{font-size:30px;font-weight:800;letter-spacing:-0.01em;text-align:center;margin:0 0 10px;}
+.ph-secsub{font-size:16px;color:var(--muted);text-align:center;max-width:660px;margin:0 auto 36px;line-height:1.6;}
+
+.mr-bar{display:flex;align-items:center;gap:28px;flex-wrap:wrap;max-width:820px;margin:0 auto 24px;padding:16px 20px;background:var(--card);border:1px solid var(--border);border-radius:12px;}
+.mr-stat{display:flex;flex-direction:column;gap:2px;}
+.mr-n{font-size:26px;font-weight:800;font-variant-numeric:tabular-nums;line-height:1;}
+.mr-n--green{color:var(--green);}
+.mr-n--amber{color:#fbbf24;}
+.mr-l{font-size:12px;color:var(--muted);}
+.mr-clear{margin-left:auto;background:transparent;border:1px solid var(--border-soft);color:var(--muted);border-radius:8px;padding:7px 14px;font-size:13px;cursor:pointer;}
+.mr-clear:hover{color:var(--text);border-color:var(--purple);}
+
+.mr-empty{max-width:820px;margin:0 auto;text-align:center;color:var(--muted);font-size:14px;line-height:1.6;}
+
+.mr-case{max-width:820px;margin:0 auto 18px;background:var(--card);border:1px solid var(--border);border-radius:12px;padding:18px 20px;}
+.mr-head{display:flex;align-items:center;gap:10px;margin-bottom:12px;flex-wrap:wrap;}
+.mr-id{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--purple);}
+.mr-path{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--muted);}
+.mr-time{margin-left:auto;font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;}
+.mr-titles{margin:0 0 8px;font-size:14px;font-weight:600;}
+.mr-body{margin:0;padding:12px 14px;background:var(--bg);border:1px solid var(--border-soft);border-radius:8px;font-family:'JetBrains Mono',monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;max-height:280px;overflow:auto;}
+
+.mr-hunk{padding:12px 0;border-top:1px solid var(--border-soft);}
+.mr-hunk:first-of-type{border-top:none;}
+.mr-hunk--open{background:rgba(251,191,36,0.04);margin:0 -20px;padding:12px 20px;}
+.mr-hunk-head{display:flex;align-items:center;gap:9px;flex-wrap:wrap;}
+.mr-idx{font-family:'JetBrains Mono',monospace;font-size:12px;color:var(--muted);}
+.mr-type{font-family:'JetBrains Mono',monospace;font-size:13px;color:var(--purple);}
+.mr-conf{font-size:11px;font-weight:600;padding:2px 8px;border-radius:6px;background:rgba(148,163,184,0.12);color:var(--muted);}
+.mr-conf--certain{color:var(--green);background:rgba(16,185,129,0.12);}
+.mr-conf--high{color:var(--purple);background:rgba(124,58,237,0.14);}
+.mr-conf--medium{color:#fbbf24;background:rgba(251,191,36,0.12);}
+.mr-tag{margin-left:auto;font-size:11px;font-weight:700;letter-spacing:0.02em;text-transform:uppercase;}
+.mr-tag--auto{color:var(--green);}
+.mr-tag--you{color:var(--purple);}
+.mr-tag--open{color:#fbbf24;}
+.mr-reason{margin:6px 0 0;font-size:13px;color:var(--muted);line-height:1.55;}
+
+.mr-choose{display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-top:12px;}
+@media (max-width:640px){.mr-choose{grid-template-columns:1fr;}}
+.mr-side{display:flex;flex-direction:column;}
+.mr-side-head{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--muted);margin-bottom:5px;}
+.mr-code{margin:0;padding:10px 12px;background:var(--bg);border:1px solid var(--border-soft);border-radius:8px;font-family:'JetBrains Mono',monospace;font-size:12px;line-height:1.6;white-space:pre-wrap;word-break:break-word;max-height:200px;overflow:auto;flex:1;}
+.mr-code--final{max-height:320px;}
+.mr-pick{margin-top:8px;padding:8px 14px;border-radius:8px;font-size:13px;font-weight:600;background:transparent;color:var(--text);border:1px solid var(--border-soft);cursor:pointer;}
+.mr-pick:hover{border-color:var(--purple);color:var(--purple);}
+.mr-pick--on{background:var(--purple-d);border-color:var(--purple-d);color:#fff;}
+
+.mr-final{margin-top:14px;}
+.mr-final-head{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-bottom:7px;font-size:13px;font-weight:600;color:var(--green);}
+.mr-copy{background:transparent;border:1px solid var(--border-soft);color:var(--muted);border-radius:8px;padding:5px 12px;font-size:12px;cursor:pointer;}
+.mr-copy:hover{color:var(--text);border-color:var(--green);}
+.mr-pending{margin:12px 0 0;font-size:13px;color:#fbbf24;}
+
+.mr-journal{max-width:820px;margin:26px auto 0;}
+.mr-jh{font-size:13px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;color:var(--muted);margin:0 0 10px;}
+.mr-journal ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:6px;}
+.mr-journal li{display:flex;gap:10px;align-items:baseline;font-size:13px;line-height:1.5;}
+.mr-jt{font-family:'JetBrains Mono',monospace;font-size:11px;color:var(--muted);font-variant-numeric:tabular-nums;}
+.mr-actor{font-family:'JetBrains Mono',monospace;font-size:11px;font-weight:700;min-width:44px;}
+.mr-actor--agent{color:var(--purple);}
+.mr-actor--you{color:var(--green);}
+</style>

--- a/website/.vitepress/theme/__tests__/room.test.ts
+++ b/website/.vitepress/theme/__tests__/room.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { clearRoom, decide, finalFile, roomCases, roomJournal, summary, type ConflictCase } from '../room'
+import { resolveConflictTool, parseGitErrorTool, listCasesTool } from '../tools'
+
+const signal = new AbortController().signal
+const M = (a: string[]) => a.join('\n')
+
+/** One settled hunk, one the engine refuses, and text on both sides of each. */
+const MIXED = M([
+  'const header = 1',
+  '<<<<<<< ours',
+  'const shared = 42',
+  '||||||| base',
+  'const shared = 0',
+  '=======',
+  'const shared = 42',
+  '>>>>>>> theirs',
+  'const middle = 2',
+  '<<<<<<< ours',
+  'const argued = "a"',
+  '||||||| base',
+  'const argued = "base"',
+  '=======',
+  'const argued = "b"',
+  '>>>>>>> theirs',
+  'const footer = 3',
+])
+
+const asConflict = (i = 0) => roomCases.value[i] as ConflictCase
+
+describe('the Merge Room', { timeout: 30_000 }, () => {
+  beforeEach(() => clearRoom())
+
+  it('splits what the engine settled from what waits on a person', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+
+    expect(summary.value.conflicts).toBe(1)
+    expect(summary.value.hunksSettledByEngine).toBe(1)
+    expect(summary.value.hunksWaitingOnYou).toBe(1)
+    expect(summary.value.hunksDecidedByYou).toBe(0)
+
+    const c = asConflict()
+    expect(c.hunks[0].type).toBe('same_change')
+    expect(c.hunks[0].autoResolved).toBe(true)
+    expect(c.hunks[1].autoResolved).toBe(false)
+  })
+
+  it('withholds the merged file until every hunk has a side', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+    const c = asConflict()
+
+    expect(finalFile(c)).toBe(null)
+
+    decide(c.id, 2, 'ours')
+    expect(finalFile(asConflict())).not.toBe(null)
+  })
+
+  it('assembles the file from engine output, the human choice, and the untouched text', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+    decide(asConflict().id, 2, 'theirs')
+
+    const out = finalFile(asConflict())!
+    expect(out).toBe(
+      M(['const header = 1', 'const shared = 42', 'const middle = 2', 'const argued = "b"', 'const footer = 3']),
+    )
+    // The thing that would ruin a demo: markers surviving into the result.
+    expect(out).not.toContain('<<<<<<<')
+    expect(out).not.toContain('=======')
+  })
+
+  it('honours the other side too, so the choice is real', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+    decide(asConflict().id, 2, 'ours')
+    expect(finalFile(asConflict())).toContain('const argued = "a"')
+  })
+
+  it('refuses to let anyone override a hunk the engine settled', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+    const c = asConflict()
+
+    expect(decide(c.id, 1, 'theirs')).toBe(false)
+    expect(asConflict().hunks[0].decision).toBe(null)
+  })
+
+  it('records both actors in the journal', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+    decide(asConflict().id, 2, 'ours')
+
+    const actors = roomJournal.value.map((e) => e.actor)
+    expect(actors).toContain('agent')
+    expect(actors).toContain('you')
+  })
+
+  it('files git errors as cases too', async () => {
+    await parseGitErrorTool.execute({ output: 'fatal: refusing to merge unrelated histories' }, { signal })
+    expect(summary.value.errors).toBe(1)
+    expect(roomCases.value[0].kind).toBe('error')
+  })
+
+  it('reports an empty room rather than pretending', async () => {
+    const r = await listCasesTool.execute({}, { signal })
+    expect(r.content[0].text).toContain('The Merge Room is empty')
+  })
+
+  it('tells an agent exactly which hunk is blocking', async () => {
+    await resolveConflictTool.execute({ content: MIXED, filePath: 'src/app.ts' }, { signal })
+    const before = (await listCasesTool.execute({}, { signal })).content[0].text
+    expect(before).toContain('waiting on hunk 2')
+    expect(before).toContain('1 settled by the engine')
+
+    decide(asConflict().id, 2, 'ours')
+    const after = (await listCasesTool.execute({}, { signal })).content[0].text
+    expect(after).toContain('merged file available on the page')
+    expect(after).toContain('1 decided by the human')
+  })
+})

--- a/website/.vitepress/theme/__tests__/webmcp.test.ts
+++ b/website/.vitepress/theme/__tests__/webmcp.test.ts
@@ -150,6 +150,65 @@ describe('matchGitErrors', () => {
     expect(out.filter((m) => m.entry.id === 'merge_conflict')).toHaveLength(1)
   })
 
+  // Reported by an agent audit of the live page (reports/webmcp-audit-2026-08-28.md):
+  // a rebase that stopped on a conflict fell through to the unmatched response.
+  // The catalogue only knew the phrases git prints when you try to START a
+  // rebase while one is already in progress, not the ones it prints when a
+  // rebase HALTS, which is the far more common paste.
+  it('recognises a rebase that stopped on a conflict', () => {
+    const out = matchGitErrors(
+      [
+        'Auto-merging src/app.ts',
+        'CONFLICT (content): Merge conflict in src/app.ts',
+        'error: could not apply 1f0c3a9... refactor: extract the handler',
+        'hint: Resolve all conflicts manually, mark them as resolved with',
+        'hint: "git add/rm <conflicted_files>", then run "git rebase --continue".',
+        'hint: You can instead skip this commit: run "git rebase --skip".',
+        'hint: To abort and get back to the state before "git rebase", run "git rebase --abort".',
+        'Could not apply 1f0c3a9... refactor: extract the handler',
+      ].join('\n'),
+    )
+    const ids = out.map((m) => m.entry.id)
+    expect(ids).toContain('rebase_in_progress')
+    // The conflict itself is still reported: the paste carries both, and an
+    // agent that only hears "finish your rebase" will not know to resolve.
+    expect(ids).toContain('merge_conflict')
+  })
+
+  it('still recognises a rebase blocked because one is already running', () => {
+    const out = matchGitErrors(
+      'fatal: It seems that there is already a rebase-merge directory, and I wonder if you are in the middle of another rebase.',
+    )
+    expect(out.map((m) => m.entry.id)).toContain('rebase_in_progress')
+  })
+
+  it('recognises a halted cherry-pick without calling it a rebase', () => {
+    // The two print nearly the same thing, "error: could not apply" included.
+    // Keying on that phrase would have made every halted cherry-pick claim to
+    // be a rebase and hand out `git rebase --continue`, which does not apply.
+    const out = matchGitErrors(
+      [
+        'error: could not apply 9de4f21... fix: guard the null case',
+        'hint: After resolving the conflicts, mark them with',
+        'hint: "git add/rm <pathspec>", then run',
+        'hint: "git cherry-pick --continue".',
+        'hint: You can instead skip this commit with "git cherry-pick --skip".',
+      ].join('\n'),
+    )
+    const ids = out.map((m) => m.entry.id)
+    expect(ids).toContain('cherry_pick_in_progress')
+    expect(ids).not.toContain('rebase_in_progress')
+  })
+
+  it('does not call a halted rebase a cherry-pick either', () => {
+    const out = matchGitErrors(
+      'hint: Resolve all conflicts manually, then run "git rebase --continue".',
+    )
+    const ids = out.map((m) => m.entry.id)
+    expect(ids).toContain('rebase_in_progress')
+    expect(ids).not.toContain('cherry_pick_in_progress')
+  })
+
   it('returns nothing for output it does not know', () => {
     expect(matchGitErrors('Everything up-to-date')).toEqual([])
   })
@@ -237,6 +296,36 @@ describe('resolve_conflict tool', { timeout: ENGINE_LOAD_TIMEOUT_MS }, () => {
   it('rejects empty input', async () => {
     const r = await resolveConflictTool.execute({ content: '' }, { signal })
     expect(r.content[0].text).toContain('No content provided')
+  })
+})
+
+// An agent audit of the live page (reports/webmcp-audit-2026-08-28.md) read the
+// engine as "conservative on normal source files", concluding it "will often
+// defer to humans on non-generated code" and suggesting the policy be tuned for
+// symmetric trivial edits. That generalises from a single genuinely divergent
+// edit. Trivial patterns already resolve in a plain .ts file; what defers is the
+// case where the two sides really disagree, which is the entire product claim.
+// Pinned here so the next reader gets the measurement rather than the guess.
+describe('trivial patterns resolve in ordinary source files', { timeout: ENGINE_LOAD_TIMEOUT_MS }, () => {
+  const signal = new AbortController().signal
+  const M = (a: string[]) => a.join('\n')
+
+  const RESOLVES: Record<string, string> = {
+    same_change: M(['export function f() {', '<<<<<<< ours', '  return 42', '||||||| base', '  return 0', '=======', '  return 42', '>>>>>>> theirs', '}']),
+    whitespace_only: M(['export function f() {', '<<<<<<< ours', '    return 1', '||||||| base', '  return 1', '=======', '\treturn 1', '>>>>>>> theirs', '}']),
+    non_overlapping: M(['<<<<<<< ours', 'import { a } from "./a"', 'import { b } from "./b"', '||||||| base', 'import { b } from "./b"', '=======', 'import { b } from "./b"', 'import { c } from "./c"', '>>>>>>> theirs']),
+  }
+
+  it.each(Object.entries(RESOLVES))('resolves %s in src/app.ts', async (_name, body) => {
+    const r = await resolveConflictTool.execute({ content: body, filePath: 'src/app.ts' }, { signal })
+    expect(r.content[0].text).toContain('1 resolved deterministically, 0 left for you')
+  })
+
+  it('defers only when the two sides genuinely disagree', async () => {
+    const body = M(['<<<<<<< ours', 'const x = 1', '||||||| base', 'const x = 0', '=======', 'const x = 2', '>>>>>>> theirs'])
+    const r = await resolveConflictTool.execute({ content: body, filePath: 'src/app.ts' }, { signal })
+    expect(r.content[0].text).toContain('0 resolved deterministically, 1 left for you')
+    expect(r.content[0].text).toContain('NEEDS REVIEW')
   })
 })
 

--- a/website/.vitepress/theme/room.ts
+++ b/website/.vitepress/theme/room.ts
@@ -1,0 +1,168 @@
+/**
+ * The Merge Room: shared state that both the agent and the human act on.
+ *
+ * This is the part that makes /agent a workspace rather than a calculator.
+ * Tool handlers do not merely return text to the agent, they file a case here,
+ * and the page renders it. The agent's work is therefore visible as it happens,
+ * and the decisions it is not allowed to make queue up for a person.
+ *
+ * The split is the whole point: the engine settles hunks that carry no
+ * decision, and every hunk where the two branches genuinely disagree waits for
+ * a human. Nothing here ever picks a side on its own.
+ */
+import { ref, computed } from 'vue'
+
+export type Side = 'ours' | 'theirs'
+
+export interface HunkView {
+  /** 1-based, as shown to both the agent and the reader. */
+  index: number
+  /** Pattern name from the classifier, e.g. `same_change`. */
+  type: string
+  confidenceLabel: string
+  confidenceScore: number
+  /** Settled by the engine, with no decision to make. */
+  autoResolved: boolean
+  reason: string
+  ours: string[]
+  theirs: string[]
+  /** The engine's output when it settled this hunk. */
+  resolvedLines: string[] | null
+  /** A person's call. Only ever set for hunks the engine refused. */
+  decision: Side | null
+}
+
+/** Normalised at file time so reassembly never has to re-enter the engine. */
+export type Segment = { kind: 'text'; lines: string[] } | { kind: 'hunk'; index: number }
+
+export interface ConflictCase {
+  id: string
+  kind: 'conflict'
+  filePath: string
+  hunks: HunkView[]
+  segments: Segment[]
+  at: number
+}
+
+export interface ErrorCase {
+  id: string
+  kind: 'error'
+  /** Titles of the catalogue entries that matched, for the case header. */
+  titles: string[]
+  body: string
+  at: number
+}
+
+export type RoomCase = ConflictCase | ErrorCase
+
+export interface JournalEntry {
+  at: number
+  actor: 'agent' | 'you'
+  text: string
+}
+
+const cases = ref<RoomCase[]>([])
+const journal = ref<JournalEntry[]>([])
+
+let seq = 0
+const nextId = (prefix: string) => `${prefix}-${++seq}`
+
+function log(actor: JournalEntry['actor'], text: string) {
+  // Newest first: on a live demo the interesting line should not require a scroll.
+  journal.value = [{ at: Date.now(), actor, text }, ...journal.value].slice(0, 60)
+}
+
+export function fileConflict(input: {
+  filePath: string
+  hunks: HunkView[]
+  segments: Segment[]
+}): ConflictCase {
+  const c: ConflictCase = { id: nextId('conflict'), kind: 'conflict', at: Date.now(), ...input }
+  cases.value = [...cases.value, c]
+  const settled = input.hunks.filter((h) => h.autoResolved).length
+  const open = input.hunks.length - settled
+  log(
+    'agent',
+    `Filed ${c.id} (${input.filePath}): ${settled} settled, ${open} waiting on you.`,
+  )
+  return c
+}
+
+export function fileError(input: { titles: string[]; body: string }): ErrorCase {
+  const c: ErrorCase = { id: nextId('error'), kind: 'error', at: Date.now(), ...input }
+  cases.value = [...cases.value, c]
+  log('agent', `Filed ${c.id}: ${input.titles.join('; ') || 'no known git error matched'}.`)
+  return c
+}
+
+/** A person picks a side on a hunk the engine refused to settle. */
+export function decide(caseId: string, hunkIndex: number, side: Side): boolean {
+  const c = cases.value.find((x) => x.id === caseId)
+  if (!c || c.kind !== 'conflict') return false
+  const h = c.hunks.find((x) => x.index === hunkIndex)
+  if (!h || h.autoResolved) return false
+  h.decision = side
+  cases.value = [...cases.value]
+  log('you', `Took ${side} on ${caseId} hunk ${hunkIndex}.`)
+  return true
+}
+
+export function clearRoom() {
+  cases.value = []
+  journal.value = []
+  seq = 0
+}
+
+/**
+ * The merged file, or null while any hunk is still undecided. Engine output is
+ * used where the engine settled it, the person's side everywhere else.
+ */
+export function finalFile(c: ConflictCase): string | null {
+  const byIndex = new Map(c.hunks.map((h) => [h.index, h]))
+  const out: string[] = []
+  for (const seg of c.segments) {
+    if (seg.kind === 'text') {
+      out.push(...seg.lines)
+      continue
+    }
+    const h = byIndex.get(seg.index)
+    if (!h) return null
+    if (h.autoResolved) {
+      out.push(...(h.resolvedLines ?? []))
+    } else if (h.decision === 'ours') {
+      out.push(...h.ours)
+    } else if (h.decision === 'theirs') {
+      out.push(...h.theirs)
+    } else {
+      return null
+    }
+  }
+  return out.join('\n')
+}
+
+/** What the agent gets back from `list_cases`, and what the header counts. */
+export const summary = computed(() => {
+  let settled = 0
+  let waiting = 0
+  let decided = 0
+  for (const c of cases.value) {
+    if (c.kind !== 'conflict') continue
+    for (const h of c.hunks) {
+      if (h.autoResolved) settled++
+      else if (h.decision) decided++
+      else waiting++
+    }
+  }
+  return {
+    cases: cases.value.length,
+    conflicts: cases.value.filter((c) => c.kind === 'conflict').length,
+    errors: cases.value.filter((c) => c.kind === 'error').length,
+    hunksSettledByEngine: settled,
+    hunksDecidedByYou: decided,
+    hunksWaitingOnYou: waiting,
+  }
+})
+
+export const roomCases = cases
+export const roomJournal = journal
+export { log as journalLog }

--- a/website/.vitepress/theme/tools/git-errors.ts
+++ b/website/.vitepress/theme/tools/git-errors.ts
@@ -110,13 +110,35 @@ export const GIT_ERRORS: GitErrorEntry[] = [
   },
   {
     id: 'rebase_in_progress',
-    match: /rebase-merge directory|rebase-apply|rebase is in progress/i,
-    title: 'A rebase is still in progress',
-    cause: 'A rebase stopped, usually on a conflict, and was neither continued nor aborted.',
+    // Two distinct situations print different things, and only the second was
+    // covered here originally. A rebase that HALTS says "could not apply" and
+    // points at --continue / --skip / --abort; a rebase you try to START while
+    // another is unfinished says "rebase-merge directory". Keying on the
+    // rebase-specific commands rather than on "could not apply" matters:
+    // cherry-pick prints that phrase too, and would be mislabelled as a rebase.
+    match: /git rebase --(continue|skip|abort)|rebase-merge directory|rebase-apply|rebase is in progress/i,
+    title: 'A rebase is in progress and waiting on you',
+    cause:
+      'Either the rebase stopped part-way, usually on a conflict, and was never continued or aborted, or you tried to start a new one while an unfinished rebase was still open. Git will refuse most other operations until it is settled either way. Nothing is lost: the commits being replayed are still in the reflog.',
     fixes: [
-      { command: 'git rebase --continue', when: 'The conflict is resolved and staged.' },
-      { command: 'git rebase --skip', when: 'This particular commit is no longer needed.' },
-      { command: 'git rebase --abort', when: 'Return to where the branch was before the rebase started.' },
+      { command: 'git status', when: 'First. It names which commit is being applied and what is still unresolved.' },
+      { command: 'git rebase --continue', when: 'The conflicts are resolved and staged with `git add`. This replays the remaining commits.' },
+      { command: 'git rebase --skip', when: 'This particular commit is already upstream, or is no longer wanted. It is dropped from the result.' },
+      { command: 'git rebase --abort', when: 'Return the branch to exactly where it was before the rebase started.' },
+    ],
+  },
+  {
+    id: 'cherry_pick_in_progress',
+    // Same shape as the halted rebase above, and the same gap: keyed on the
+    // cherry-pick-specific commands so the two never claim each other's paste.
+    match: /git cherry-pick --(continue|skip|abort)|CHERRY_PICK_HEAD/i,
+    title: 'A cherry-pick is in progress and waiting on you',
+    cause:
+      'The cherry-pick stopped part-way, usually because the picked commit conflicts with the branch you are on. Git keeps the partial state until you finish or abandon it.',
+    fixes: [
+      { command: 'git status', when: 'First. It names the commit being picked and what is still unresolved.' },
+      { command: 'git cherry-pick --continue', when: 'The conflicts are resolved and staged.' },
+      { command: 'git cherry-pick --abort', when: 'Return to where the branch was before the pick.' },
     ],
   },
   {

--- a/website/.vitepress/theme/tools/index.ts
+++ b/website/.vitepress/theme/tools/index.ts
@@ -1,13 +1,19 @@
 /**
  * The tools this page exposes to agents.
  *
- * Both are read-only and run entirely in the visitor's tab: nothing is
- * uploaded, and there is no backend to upload it to. That is the point of
- * putting them here rather than behind an API.
+ * All read-only with respect to your machine: nothing is uploaded, nothing runs
+ * git, and there is no backend to reach. What they do write to is the Merge
+ * Room on the page itself, so an agent's work shows up in front of the person
+ * sitting there rather than disappearing into the transcript.
+ *
+ * Deliberately absent: any tool that picks a side on a conflicted hunk. The
+ * engine settles hunks that carry no decision; everything else queues for a
+ * human. That boundary is the product.
  */
 import type { WebMcpTool } from '../webmcp'
 import { text } from '../webmcp'
 import { matchGitErrors } from './git-errors'
+import { fileConflict, fileError, roomCases, summary, finalFile, type HunkView, type Segment } from '../room'
 
 /** Keep a single tool response from swallowing an agent's context window. */
 const MAX_CONTENT_CHARS = 20_000
@@ -20,7 +26,7 @@ function truncate(body: string): string {
 export const parseGitErrorTool: WebMcpTool = {
   name: 'parse_git_error',
   description:
-    'Explain a git command that failed. Paste the raw stderr or stdout of the failing command and get back the cause in plain language plus the specific commands that resolve it. Handles merge conflicts, rejected pushes, unrelated histories, detached HEAD, interrupted merges and rebases, authentication failures and other common git errors. Read-only: it never runs git and never touches the repository.',
+    'Explain a git command that failed, and file it into the Merge Room on this page so the person watching sees it. Paste the raw stderr or stdout of the failing command and get back the cause in plain language plus the specific commands that resolve it. Handles merge conflicts, rejected pushes, unrelated histories, detached HEAD, an interrupted merge, rebase or cherry-pick, authentication failures and other common git errors. Read-only: it never runs git and never touches the repository.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -38,15 +44,15 @@ export const parseGitErrorTool: WebMcpTool = {
 
     const matches = matchGitErrors(output)
     if (matches.length === 0) {
-      return text(
-        [
-          'No known git error matched this output.',
-          '',
-          'This catalogue covers the common failures (conflicts, rejected pushes, unrelated histories, detached HEAD, interrupted merge or rebase, authentication). An unmatched paste is usually either a tool wrapping git, or a genuine edge case worth reading the full output for.',
-          '',
-          'Useful next command: `git status` prints the repository state that most git errors are really about.',
-        ].join('\n'),
-      )
+      const body = [
+        'No known git error matched this output.',
+        '',
+        'This catalogue covers the common failures (conflicts, rejected pushes, unrelated histories, detached HEAD, an interrupted merge, rebase or cherry-pick, authentication). An unmatched paste is usually either a tool wrapping git, or a genuine edge case worth reading the full output for.',
+        '',
+        'Useful next command: `git status` prints the repository state that most git errors are really about.',
+      ].join('\n')
+      fileError({ titles: [], body })
+      return text(body)
     }
 
     const sections = matches.map(({ entry, matchedOn }) => {
@@ -70,14 +76,16 @@ export const parseGitErrorTool: WebMcpTool = {
         ? 'One known git error matched.'
         : `${matches.length} known git errors matched this output, listed in the order they should be dealt with.`
 
-    return text(truncate([header, ...sections].join('\n\n')))
+    const body = truncate([header, ...sections].join('\n\n'))
+    fileError({ titles: matches.map((m) => m.entry.title), body })
+    return text(body)
   },
 }
 
 export const resolveConflictTool: WebMcpTool = {
   name: 'resolve_conflict',
   description:
-    "Resolve a file that contains git conflict markers. Pass the full conflicted file content and get back the merged result, plus a per-hunk classification saying which conflicts were resolved deterministically and which still need a human decision. Hunks that carry no real decision (identical edits on both sides, pure reordering, whitespace, insertions at different positions, generated files) are resolved; genuinely overlapping edits are handed back untouched with the reason. No model is involved and nothing is guessed. Runs in the browser tab: the file content is never uploaded.",
+    "Resolve a file containing git conflict markers, and file it into the Merge Room on this page. Hunks that carry no real decision (identical edits on both sides, pure reordering, whitespace, insertions at different positions, generated files) are resolved deterministically. Hunks where the two branches genuinely disagree are NOT resolved: they queue for the person at the page to pick a side, and this tool cannot make that call. Returns a per-hunk classification with the pattern name, confidence score and reason for each. No model is involved and nothing is guessed. Runs in the browser tab: the file content is never uploaded.",
   inputSchema: {
     type: 'object',
     properties: {
@@ -106,26 +114,52 @@ export const resolveConflictTool: WebMcpTool = {
     const path = typeof filePath === 'string' && filePath.trim() !== '' ? filePath : 'unknown.txt'
 
     let result
+    let parsed
     try {
       // Loaded on demand, not at module scope. AgentPage is registered in the
       // shared theme entry, so a static import pulls the whole engine into the
       // chunk that every page of the site downloads. This way only a real call
       // to resolve_conflict pays for it.
-      const { resolve } = await import('@gitwand/core')
+      const { resolve, parseConflictMarkers } = await import('@gitwand/core')
       result = resolve(content, path)
+      parsed = parseConflictMarkers(content)
     } catch (err) {
       return text(`The resolver failed on this input: ${err instanceof Error ? err.message : String(err)}`)
     }
 
     const { stats, resolutions, mergedContent, validation } = result
 
-    const hunkLines = resolutions.map((r, i) => {
-      const status = r.autoResolved ? 'resolved' : 'NEEDS REVIEW'
-      const conf = r.hunk.confidence
-      return `  [${i + 1}] ${r.hunk.type} (${conf.label}, score ${conf.score}) — ${status}\n      ${r.resolutionReason}`
-    })
+    // resolve() walks the same segments in the same order, so the nth conflict
+    // segment is the nth resolution. Normalising here means reassembling the
+    // file after a human decision never has to re-enter the engine.
+    const hunks: HunkView[] = resolutions.map((r, i) => ({
+      index: i + 1,
+      type: r.hunk.type,
+      confidenceLabel: r.hunk.confidence.label,
+      confidenceScore: r.hunk.confidence.score,
+      autoResolved: r.autoResolved,
+      reason: r.resolutionReason,
+      ours: r.hunk.oursLines,
+      theirs: r.hunk.theirsLines,
+      resolvedLines: r.resolvedLines,
+      decision: null,
+    }))
 
-    const summary = [
+    let n = 0
+    const segments: Segment[] = parsed.segments.map((s) =>
+      s.type === 'text' ? { kind: 'text' as const, lines: s.lines } : { kind: 'hunk' as const, index: ++n },
+    )
+
+    const filed = fileConflict({ filePath: path, hunks, segments })
+
+    const hunkLines = hunks.map(
+      (h) =>
+        `  [${h.index}] ${h.type} (${h.confidenceLabel}, score ${h.confidenceScore}) — ${h.autoResolved ? 'resolved' : 'NEEDS REVIEW'}\n      ${h.reason}`,
+    )
+
+    const out = [
+      `Filed as ${filed.id} in the Merge Room on the page.`,
+      '',
       `${stats.totalConflicts} conflict${stats.totalConflicts === 1 ? '' : 's'} found in ${path}.`,
       `${stats.autoResolved} resolved deterministically, ${stats.remaining} left for you.`,
       '',
@@ -139,20 +173,58 @@ export const resolveConflictTool: WebMcpTool = {
         reasons.push(`conflict markers still present at line ${validation.residualMarkerLines.join(', ')}`)
       }
       if (validation.syntaxError) reasons.push(validation.syntaxError)
-      summary.push('', `Post-merge validation rejected this result: ${reasons.join('; ')}. Treat the merged output below as untrusted.`)
+      out.push('', `Post-merge validation rejected this result: ${reasons.join('; ')}. Treat the merged output below as untrusted.`)
     }
 
     if (mergedContent === null) {
-      summary.push(
+      out.push(
         '',
-        `${stats.remaining} hunk${stats.remaining === 1 ? '' : 's'} could not be resolved without a decision, so no merged file is returned. The conflict markers for those hunks are still in place. Resolve them by hand, or ask the user which side to take.`,
+        `${stats.remaining} hunk${stats.remaining === 1 ? '' : 's'} could not be resolved without a decision. Do not guess a side: the person at the page picks one in the Merge Room, and the merged file appears there once they have. Call list_cases to see what is still waiting.`,
       )
-      return text(truncate(summary.join('\n')))
+      return text(truncate(out.join('\n')))
     }
 
-    summary.push('', 'Merged file:', '', mergedContent)
-    return text(truncate(summary.join('\n')))
+    out.push('', 'Merged file:', '', mergedContent)
+    return text(truncate(out.join('\n')))
   },
 }
 
-export const TOOLS: WebMcpTool[] = [parseGitErrorTool, resolveConflictTool]
+export const listCasesTool: WebMcpTool = {
+  name: 'list_cases',
+  description:
+    'Read the current state of the Merge Room on this page: every conflict and git error filed so far, which hunks the engine settled, which are still waiting on a human decision, and which the human has already decided. Call this to see what is outstanding before deciding what to do next, or after asking the person to make a call. Takes no arguments.',
+  inputSchema: { type: 'object', properties: {} },
+  async execute() {
+    const s = summary.value
+    if (s.cases === 0) {
+      return text('The Merge Room is empty. Nothing has been filed yet.')
+    }
+
+    const lines: string[] = [
+      `${s.cases} case${s.cases === 1 ? '' : 's'} filed: ${s.conflicts} conflict${s.conflicts === 1 ? '' : 's'}, ${s.errors} git error${s.errors === 1 ? '' : 's'}.`,
+      `Hunks: ${s.hunksSettledByEngine} settled by the engine, ${s.hunksDecidedByYou} decided by the human, ${s.hunksWaitingOnYou} still waiting.`,
+      '',
+    ]
+
+    for (const c of roomCases.value) {
+      if (c.kind === 'error') {
+        lines.push(`${c.id}: git error — ${c.titles.join('; ') || 'unmatched'}`)
+        continue
+      }
+      const waiting = c.hunks.filter((h) => !h.autoResolved && !h.decision)
+      const final = finalFile(c)
+      lines.push(
+        `${c.id}: ${c.filePath} — ${c.hunks.length} hunk${c.hunks.length === 1 ? '' : 's'}, ` +
+          (waiting.length
+            ? `waiting on hunk ${waiting.map((h) => h.index).join(', ')} (${waiting.map((h) => h.type).join(', ')})`
+            : final
+              ? 'complete, merged file available on the page'
+              : 'complete'),
+      )
+    }
+
+    return text(truncate(lines.join('\n')))
+  },
+}
+
+export const TOOLS: WebMcpTool[] = [resolveConflictTool, parseGitErrorTool, listCasesTool]

--- a/website/PRODUCT.md
+++ b/website/PRODUCT.md
@@ -1,0 +1,56 @@
+# PRODUCT.md — GitWand website
+
+## Register
+
+**Hybrid, split by a hard boundary.** `/agent` is the surface this file was written for.
+
+- **Above the break: product.** The Merge Room is a real tool doing real work, in the browser, for whoever is standing there. Design serves the task.
+- **Below the break: brand.** Explanation, tool contracts, positioning. Design carries the argument.
+
+The break is deliberate and visible. The previous version interleaved the two, which is what made the page read as muddled: a diagnostic panel with a section heading of its own, sitting between the workspace and the copy, competing with both.
+
+Other site surfaces (`/`, `/conflict-engine`, `/features`) are brand.
+
+## What the product is
+
+GitWand resolves the Git merge conflicts that were never decisions, deterministically, and refuses the ones that were. Twelve patterns in a classifier registry, eight of which auto-apply, each resolution carrying a pattern name, a composite confidence score and a full decision trace. No model touches the code.
+
+`/agent` exposes that engine to browsing agents over the W3C WebMCP standard, as three page-registered tools. An agent files conflicts and Git failures into a shared room; the engine settles what carries no decision; every hunk where the two branches genuinely disagree waits for a person.
+
+## Users
+
+- **Primary, above the break:** a developer mid-incident, or an agent acting for one. They are in a task and want it over with. Density and legibility beat charm.
+- **Secondary, below the break:** someone evaluating whether this is real, including hackathon judges reading for three minutes and engineers deciding whether to install anything.
+
+## The one idea
+
+**A boundary, made visible.** What a machine may settle, and what only a person may decide. That line is the product, not a feature of it, so it is the page's primary visual structure rather than a message written on top of one.
+
+Everything follows from it: settled work is quiet and recedes, open work is the only thing carrying weight and colour, and the page is honest about which is which at a glance.
+
+## Brand personality
+
+Exact, unshowy, quietly confident. It states what it measured and declines to claim the rest. The tone is a good colleague's: direct, specific, no salesmanship. Where every competitor says the AI will handle it, this one says the opposite and shows its work.
+
+## Anti-references
+
+Confirmed with the user, all four:
+
+- **Not another SaaS template.** No hero-metric block (big number, small label, repeat). No grid of identical icon-heading-text cards. No gradient text.
+- **Not terminal-hacker.** No phosphor green on black, no fake blinking prompt, no monospace as a personality. Monospace is for code and identifiers only. This is the obvious trap for a Git tool and it is the first-order reflex.
+- **Not glass and haze.** No decorative backdrop-filter, no ambient halos. Effects earn a specific moment or they do not ship.
+- **Not timid.** The inverse risk, and the one the user named last: a correct page nobody remembers. Commit to the structural device and the type scale.
+
+Second-order check: for a Git tool that is *not* terminal-dark, the next reflex is editorial-typographic (display serif, ruled columns, mono metadata). Also rejected. The lane here is instrument-like: a measuring device, not a magazine.
+
+## Motion policy
+
+Concentrated on the two moments that carry meaning, per the user: a case arriving, and a hunk being decided. Nothing ambient, no page-load choreography, no scroll-triggered section reveals. 150-250ms, ease-out. Every transition has a `prefers-reduced-motion` alternative, and no content is gated behind a reveal.
+
+## Accessibility
+
+Body text ≥4.5:1, large text ≥3:1, verified rather than assumed. State is never carried by colour alone: settled, waiting and decided each have a word as well as a hue. Every control reachable and visible by keyboard.
+
+## Identity constraints
+
+The site has shipped brand colours; identity preservation wins over any fresh palette. Purple `#8B5CF6` / `#7C3AED` is the brand, green `#10B981` reads settled, amber `#fbbf24` reads waiting on you, ground is `#0c0c1a`. Inter for everything structural, JetBrains Mono for code and identifiers.

--- a/website/agent.md
+++ b/website/agent.md
@@ -1,22 +1,22 @@
 ---
 layout: page
-title: "GitWand for agents — WebMCP git tools, no install"
-description: "A WebMCP page that hands any browsing agent two read-only git tools. One explains a failing git command, the other resolves a conflicted file with GitWand's deterministic engine. Runs in the tab, no server, no API key."
+title: "GitWand Merge Room — a shared Git workspace for humans and agents"
+description: "A WebMCP workspace where a browsing agent files Git conflicts and failures into a shared room. The deterministic engine settles every hunk that carries no decision; the ones where branches genuinely disagree wait for a human. Runs in the tab, no server, no API key."
 head:
   - - meta
     - property: og:title
-      content: GitWand for agents — callable git tools over WebMCP
+      content: GitWand Merge Room — humans decide, agents accelerate
   - - meta
     - property: og:description
-      content: Two read-only git tools any agent can call straight from the page. Deterministic conflict resolution, no model in the loop, no install.
+      content: An agent files Git conflicts into a shared room, the engine settles what carries no decision, and you take the calls that matter. No model guesses at your code.
   - - script
     - type: application/ld+json
     - |
       {
         "@context": "https://schema.org",
         "@type": "WebAPI",
-        "name": "GitWand agent tools",
-        "description": "Read-only git tools exposed to browsing agents over the W3C WebMCP standard. Nothing is uploaded: the tools execute in the visitor's browser tab.",
+        "name": "GitWand Merge Room",
+        "description": "A shared Git workspace exposed to browsing agents over the W3C WebMCP standard. Agents file conflicts and failures into a room on the page; the deterministic engine settles the hunks that carry no decision and a human decides the rest. Nothing is uploaded: everything executes in the visitor's browser tab.",
         "documentation": "https://gitwand.app/agent",
         "termsOfService": "https://github.com/devlint/GitWand/blob/main/LICENSE",
         "provider": {
@@ -39,6 +39,16 @@ head:
             "@type": "Action",
             "name": "resolve_conflict",
             "description": "Resolve a file containing git conflict markers. Takes the full conflicted content and an optional file path, returns the merged result plus a per-hunk classification separating the conflicts that carried no decision from the ones needing a human. Deterministic patterns only, no model involved.",
+            "target": {
+              "@type": "EntryPoint",
+              "urlTemplate": "https://gitwand.app/agent",
+              "actionPlatform": "https://webmachinelearning.github.io/webmcp/"
+            }
+          },
+          {
+            "@type": "Action",
+            "name": "list_cases",
+            "description": "Read the current state of the Merge Room: every conflict and git error filed so far, which hunks the engine settled deterministically, which are still waiting on a human decision, and which the human has already decided. Takes no arguments.",
             "target": {
               "@type": "EntryPoint",
               "urlTemplate": "https://gitwand.app/agent",


### PR DESCRIPTION
Turns `/agent` from a page that lists tools into a workspace that humans and agents share, and restructures it so the two things it does stop competing.

Three commits, each standalone.

## The Merge Room

Tool handlers used to return text to the agent and leave the page untouched. Nothing an agent did was visible to the person sitting there, which is the wrong shape for a workspace and the wrong shape for this hackathon's first judging criterion: **WebMCP Leverage rewards an agent driving the app, not querying it.**

Handlers now file cases into live page state. Call `resolve_conflict` and a case appears, split into the hunks the engine settled and the ones waiting on a person. Call `parse_git_error` and the explanation is filed the same way. An activity log records both actors with timestamps.

**The boundary is enforced in the data, not promised in the copy.** `decide()` refuses on any hunk the engine already settled. There is deliberately no tool that picks a side, so an agent that wants a conflicted hunk resolved has to ask the human. `finalFile()` withholds the merged file until every open hunk has a decision, then assembles it from engine output, the human's choices, and the untouched text between them.

Adds a third tool, `list_cases`, so an agent can read the room back and see what it is waiting on. Without it, keeping state buys nothing.

## The redesign

The page mixed a working tool with a marketing surface, and gave the WebMCP diagnostic a section heading of its own, so three things competed for the same attention.

- **Above the break it is a tool.** Status collapses from a section into a one-line connection strip. The room comes first. The input sits with the tool it feeds.
- **Below a deliberate seam it argues**, on its own ground so the change of mode is unmistakable.
- **The room is a ledger, not a stack of cards.** Settled hunks recede; open ones are the only thing carrying weight; a decided hunk collapses to the side that was taken, with one click to change it. That last part was missing and mattered: a decided hunk kept both columns and both buttons, so the room stopped showing what was left. The whole story now fits one screen.
- **Three counts became one proportion rail.** Three big numbers with small labels is the hero-metric template, and it answered a question nobody asked.

Fixes four patterns the project's own design guidance bans and the page shipped anyway: gradient text on the h1, a tracked eyebrow above it, a grid of identical tool cards, and cards nested inside cards.

### Accessibility, measured

"Settled work recedes" was implemented as `opacity: 0.52`. That put settled rows' body text at **2.93:1** against the ground and the state tag at **3.41:1**, both under the 4.5 floor. Explicit dim colours give the same recession at 5.14 and 10.09. Every other string on the surface was measured; all clear 4.5. State is carried by a word as well as a hue, and motion is limited to two moments with a `prefers-reduced-motion` path.

## Halted rebase, from an agent audit

An agent audit of the live page found `parse_git_error` returning "No known git error matched" for a rebase stopped on a conflict. Confirmed with a failing test first.

The catalogue keyed on `rebase-merge directory`, which is what git prints when you try to **start** a rebase while one is unfinished. A rebase that **halts** prints none of those phrases: it says `could not apply` and points at `--continue` / `--skip` / `--abort`. The common case was the uncovered one.

Matching on `could not apply` would have been the obvious fix and the wrong one, because cherry-pick prints the same phrase and every halted cherry-pick would have been told to run `git rebase --continue`. Keyed on the rebase-specific commands instead, with cherry-pick given its own entry and both directions of that confusion covered by tests.

The audit's second finding does not hold and no change was made for it. It read the engine as "conservative on normal source files" and suggested loosening the policy for symmetric trivial edits. Measured in a plain `.ts` file: `same_change` resolves at 100, `whitespace_only` at 91, `non_overlapping` at 87. Only the genuinely divergent edit defers, which is the product rather than a limitation, and symmetric trivial edits already resolve. A test now records the measurement so the next reader gets the number instead of the intuition.

## Verification

- 2245 tests green across all five workspaces, 39 of them on this surface.
- Driven in a browser against the built site: filing shows 1 settled and 1 waiting, no merged file until the open hunk is decided, taking a side produces the right file with no markers left in it, the decided hunk collapses, and the rail and log follow.
- Contrast measured in-page rather than eyeballed.

## What this does not do

The rest of the site keeps the previous visual register. If `/agent` becomes the hackathon shopfront, that gap will show.

Adds `website/PRODUCT.md`, which records the register split, the anti-references and the one idea the layout is built around.
