### PR TITLE
feat(desktop): add --no-ff option to branch merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **No-fast-forward merge option** (#177). The "Merge into current…" popover gets an "Always create a merge commit" checkbox — forces `git merge --no-ff` so merging a fast-forwardable branch still records an explicit merge commit, matching teams whose workflow requires one. Off by default; the existing fast-forward behavior is unchanged.
 - **CLI update notice.** A global `npm install -g @gitwand/cli` never auto-updates, unlike `npx @gitwand/cli` or the desktop app's own updater. `gitwand` now checks the npm registry at most once every 24h (cached locally) and prints a one-line notice when a newer version is published. Only runs in an interactive terminal, never in CI or piped output, and any failure (offline, registry down, unwritable home dir) is silent.
 
 ### Changed

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -2223,16 +2223,18 @@ async function handleRequest(req, res) {
       }
     }
 
-    // POST /api/git-merge  { cwd, branch }
+    // POST /api/git-merge  { cwd, branch, noFf? }
     if (url.pathname === "/api/git-merge" && req.method === "POST") {
-      const { cwd, branch } = await readBody(req);
+      const { cwd, branch, noFf } = await readBody(req);
       if (!cwd || !branch) return jsonResponse(req, res, { success: false, message: "Missing cwd or branch" }, 400);
       try {
         const resolvedCwd = resolve(cwd);
-        const stdout = execSync(`git merge "${branch}" 2>&1`, {
+        // --no-ff always creates a merge commit, which otherwise opens an
+        // editor for the commit message; --no-edit keeps it non-interactive.
+        const args = noFf ? ["merge", branch, "--no-ff", "--no-edit"] : ["merge", branch];
+        const stdout = execFileSync(GIT, args, {
           cwd: resolvedCwd,
           encoding: "utf-8",
-          shell: true,
         });
         return jsonResponse(req, res, { success: true, message: stdout.trim() || "Merge completed" });
       } catch (err) {

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -494,16 +494,27 @@ pub(crate) async fn git_fetch(cwd: String) -> Result<GitPushPullResult, String> 
 }
 
 #[tauri::command]
-pub(crate) async fn git_merge(cwd: String, branch: String) -> Result<GitPushPullResult, String> {
+pub(crate) async fn git_merge(
+    cwd: String,
+    branch: String,
+    no_ff: Option<bool>,
+) -> Result<GitPushPullResult, String> {
     let _repo = repo_lock::write(&cwd);
     let _t0 = Instant::now();
+    let mut args: Vec<&str> = vec!["merge", &branch];
+    if no_ff.unwrap_or(false) {
+        // --no-ff always creates a merge commit, which otherwise opens an
+        // editor for the commit message; --no-edit keeps it non-interactive.
+        args.push("--no-ff");
+        args.push("--no-edit");
+    }
     let output = git_cmd()
-        .args(["merge", &branch])
+        .args(&args)
         .current_dir(&cwd)
         .output()
         .map_err(|e| format!("Failed to run git merge: {}", e))?;
     record_cmd(
-        &format!("git merge {}", branch),
+        &format!("git {}", args.join(" ")),
         &cwd,
         _t0.elapsed().as_millis() as u64,
         output.status.code().unwrap_or(-1),
@@ -5354,5 +5365,123 @@ mod snapshot_hook_tests {
         // of snapshots — what matters is that we reached it at all.
         assert!(list_snapshots_inner(&repo.cwd()).unwrap().is_empty());
         let _ = res;
+    }
+}
+
+#[cfg(test)]
+mod merge_no_ff_tests {
+    use super::*;
+    use crate::git::cmd::git_binary;
+    use std::path::PathBuf;
+    use std::process::Command;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    struct TempRepo {
+        path: PathBuf,
+    }
+    impl Drop for TempRepo {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+    impl TempRepo {
+        fn new() -> Self {
+            let n = COUNTER.fetch_add(1, Ordering::SeqCst);
+            let pid = std::process::id();
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let dir =
+                std::env::temp_dir().join(format!("gitwand-noff-test-{}-{}-{}", pid, n, nanos));
+            std::fs::create_dir_all(&dir).unwrap();
+            let repo = TempRepo { path: dir };
+            repo.git_ok(&["init", "-q", "-b", "main"]);
+            repo.git_ok(&["config", "user.name", "Test"]);
+            repo.git_ok(&["config", "user.email", "test@example.com"]);
+            repo.git_ok(&["config", "commit.gpgsign", "false"]);
+            repo
+        }
+        fn cwd(&self) -> String {
+            self.path.to_str().unwrap().to_string()
+        }
+        fn git(&self, args: &[&str]) -> std::process::Output {
+            Command::new(git_binary())
+                .args(args)
+                .current_dir(&self.path)
+                .output()
+                .unwrap_or_else(|e| panic!("git {:?} spawn: {}", args, e))
+        }
+        fn git_ok(&self, args: &[&str]) {
+            let out = self.git(args);
+            assert!(
+                out.status.success(),
+                "git {:?} failed: {}",
+                args,
+                String::from_utf8_lossy(&out.stderr)
+            );
+        }
+        fn write(&self, rel: &str, content: &str) {
+            std::fs::write(self.path.join(rel), content).unwrap();
+        }
+        fn commit_all(&self, msg: &str) {
+            self.git_ok(&["add", "-A"]);
+            self.git_ok(&["commit", "-q", "-m", msg]);
+        }
+        fn parent_count_of_head(&self) -> usize {
+            let out = self.git(&["rev-list", "--parents", "-n", "1", "HEAD"]);
+            let line = String::from_utf8_lossy(&out.stdout);
+            line.trim().split_whitespace().count().saturating_sub(1)
+        }
+    }
+
+    /// `feature` branches off `main` and gets one extra commit; `main` gets
+    /// none, so merging `feature` into `main` is fast-forwardable.
+    fn make_fast_forwardable(repo: &TempRepo) {
+        repo.write("a.txt", "base\n");
+        repo.commit_all("base");
+        repo.git_ok(&["checkout", "-q", "-b", "feature"]);
+        repo.write("a.txt", "feature change\n");
+        repo.commit_all("feature commit");
+        repo.git_ok(&["checkout", "-q", "main"]);
+    }
+
+    #[test]
+    fn no_ff_true_creates_merge_commit_even_when_fast_forward_possible() {
+        let repo = TempRepo::new();
+        make_fast_forwardable(&repo);
+
+        let result =
+            tauri::async_runtime::block_on(git_merge(repo.cwd(), "feature".to_string(), Some(true)))
+                .expect("merge must succeed");
+
+        assert!(result.success, "merge failed: {}", result.message);
+        assert_eq!(
+            repo.parent_count_of_head(),
+            2,
+            "--no-ff must produce a merge commit with 2 parents even on a fast-forwardable branch"
+        );
+    }
+
+    #[test]
+    fn no_ff_false_fast_forwards_when_possible() {
+        let repo = TempRepo::new();
+        make_fast_forwardable(&repo);
+
+        let result = tauri::async_runtime::block_on(git_merge(
+            repo.cwd(),
+            "feature".to_string(),
+            Some(false),
+        ))
+        .expect("merge must succeed");
+
+        assert!(result.success, "merge failed: {}", result.message);
+        assert_eq!(
+            repo.parent_count_of_head(),
+            1,
+            "default merge must fast-forward (1 parent) when possible"
+        );
     }
 }

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -5453,9 +5453,12 @@ mod merge_no_ff_tests {
         let repo = TempRepo::new();
         make_fast_forwardable(&repo);
 
-        let result =
-            tauri::async_runtime::block_on(git_merge(repo.cwd(), "feature".to_string(), Some(true)))
-                .expect("merge must succeed");
+        let result = tauri::async_runtime::block_on(git_merge(
+            repo.cwd(),
+            "feature".to_string(),
+            Some(true),
+        ))
+        .expect("merge must succeed");
 
         assert!(result.success, "merge failed: {}", result.message);
         assert_eq!(

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -5433,7 +5433,7 @@ mod merge_no_ff_tests {
         fn parent_count_of_head(&self) -> usize {
             let out = self.git(&["rev-list", "--parents", "-n", "1", "HEAD"]);
             let line = String::from_utf8_lossy(&out.stdout);
-            line.trim().split_whitespace().count().saturating_sub(1)
+            line.split_whitespace().count().saturating_sub(1)
         }
     }
 

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -645,9 +645,9 @@ watch(repoError, (val) => {
 });
 
 /** Wrap the raw merge to capture the merged branch name for the cleanup modal. */
-async function doMerge(branch: string) {
+async function doMerge(branch: string, noFf: boolean = false) {
   lastMergedBranch.value = branch;
-  await doMergeRaw(branch);
+  await doMergeRaw(branch, noFf);
 }
 
 // ─── Merge success modal ──────────────────────────────────

--- a/apps/desktop/src/components/AppHeader.vue
+++ b/apps/desktop/src/components/AppHeader.vue
@@ -140,7 +140,7 @@ const emit = defineEmits<{
   openRenameModal: [];
   /** User chose "Delete current branch" in BranchMenu — open the modal. */
   openDeleteModal: [];
-  mergeBranch: [name: string];
+  mergeBranch: [name: string, noFf: boolean];
   loadBranches: [];
   // ── Other overlays ───────────────────────────────────────────
   openRebase: [];
@@ -165,10 +165,12 @@ const emit = defineEmits<{
 // ─── Merge-into picker popover (triggered by BranchMenu) ──────────
 const showMergePopover = ref(false);
 const mergeFilter = ref("");
+const mergeNoFf = ref(false);
 
 function openMergePopover() {
   showMergePopover.value = true;
   mergeFilter.value = "";
+  mergeNoFf.value = false;
   emit("loadBranches");
 }
 
@@ -185,7 +187,7 @@ const mergeBranches = computed(() => {
 });
 
 function handleMerge(name: string) {
-  emit("mergeBranch", name);
+  emit("mergeBranch", name, mergeNoFf.value);
   closeMergePopover();
 }
 
@@ -581,6 +583,10 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
                   @keydown.escape="closeMergePopover"
                 />
               </div>
+              <label class="mp-no-ff" :title="t('header.mergeNoFfTooltip')">
+                <input type="checkbox" v-model="mergeNoFf" />
+                <span>{{ t('header.mergeNoFf') }}</span>
+              </label>
               <div v-if="branchesLoading" class="mp-loading">
                 <div class="mp-spinner"></div>
               </div>
@@ -867,6 +873,18 @@ onUnmounted(() => document.removeEventListener("click", onDocClick, true));
 .mp-header {
   padding: var(--space-4) var(--space-5);
   border-bottom: 1px solid var(--color-border);
+}
+
+.mp-no-ff {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-5);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+  border-bottom: 1px solid var(--color-border);
+  cursor: pointer;
+  user-select: none;
 }
 
 .mp-filter {

--- a/apps/desktop/src/composables/useGitRepo.ts
+++ b/apps/desktop/src/composables/useGitRepo.ts
@@ -1082,11 +1082,11 @@ export function useGitRepo(opts: { confirm?: ConfirmFn } = {}) {
 
   // ─── Merge ──────────────────────────────────────────────
 
-  async function mergeBranch(branchName: string) {
+  async function mergeBranch(branchName: string, noFf: boolean = false) {
     if (!folderPath.value || !branchName) return;
     isMerging.value = true;
     try {
-      const result = await gitMerge(folderPath.value, branchName);
+      const result = await gitMerge(folderPath.value, branchName, noFf);
       // Force: a fast-forward merge moves refs without a new merge commit.
       await refresh(true);
 

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -60,6 +60,8 @@ const en = {
     merge: "Merge",
     mergeTooltip: "Merge a branch into the current branch",
     mergeFilterPlaceholder: "Branch to merge\u2026",
+    mergeNoFf: "Always create a merge commit",
+    mergeNoFfTooltip: "Skip fast-forward even when possible (--no-ff)",
     // Stats
     file: "file",
     files: "files",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -59,6 +59,8 @@ const es: Locale = {
     syncTooltip: "Recuperar ramas remotas y hacer pull",
     merge: "Merge",
     mergeTooltip: "Hacer merge de una rama en la rama actual",
+    mergeNoFf: "Crear siempre un commit de fusión",
+    mergeNoFfTooltip: "Omitir el fast-forward incluso si es posible (--no-ff)",
     mergeFilterPlaceholder: "Rama a fusionar…",
     // Stats
     file: "archivo",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -53,6 +53,8 @@ const fr: Locale = {
     syncTooltip: "Récupérer les branches distantes et pull",
     merge: "Merge",
     mergeTooltip: "Merger une branche dans la branche courante",
+    mergeNoFf: "Toujours créer un commit de merge",
+    mergeNoFfTooltip: "Ignorer le fast-forward même si possible (--no-ff)",
     mergeFilterPlaceholder: "Branche à merger\u2026",
     // Stats
     file: "fichier",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -60,6 +60,8 @@ const ptBR: Locale = {
     syncTooltip: "Buscar branches remotos e fazer pull",
     merge: "Merge",
     mergeTooltip: "Fazer merge de um branch no branch atual",
+    mergeNoFf: "Sempre criar um commit de merge",
+    mergeNoFfTooltip: "Pular o fast-forward mesmo quando possível (--no-ff)",
     mergeFilterPlaceholder: "Branch para mesclar…",
     // Stats
     file: "arquivo",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -66,6 +66,8 @@ const zhCN: Locale = {
     syncTooltip: "获取远程分支并拉取",
     merge: "合并",
     mergeTooltip: "将其他分支合并到当前分支",
+    mergeNoFf: "始终创建合并提交",
+    mergeNoFfTooltip: "即使可以快进合并也跳过（--no-ff）",
     mergeFilterPlaceholder: "要合并的分支…",
     file: "个文件",
     files: "个文件",

--- a/apps/desktop/src/utils/__tests__/backend-merge.test.ts
+++ b/apps/desktop/src/utils/__tests__/backend-merge.test.ts
@@ -1,0 +1,58 @@
+/**
+ * `gitMerge` — no-fast-forward option (#177).
+ *
+ * Locks in that the `noFf` flag is forwarded to both the Tauri IPC call
+ * and the dev-server HTTP body, and defaults to false when omitted.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const devFetch = vi.fn();
+const tauriInvoke = vi.fn();
+let tauri = false;
+
+vi.mock("../backend-core", () => ({
+  isTauri: () => tauri,
+  devFetch: (...args: unknown[]) => devFetch(...args),
+  tauriInvoke: (...args: unknown[]) => tauriInvoke(...args),
+  DEV_SERVER: "http://localhost:3001",
+  IPC_TIMEOUT: { NETWORK: 30000, DEFAULT: 10000 },
+  devTerminalOpen: vi.fn(),
+}));
+
+function mockRes(json: unknown) {
+  return { ok: true, status: 200, json: async () => json };
+}
+
+describe("gitMerge", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    devFetch.mockReset();
+    tauriInvoke.mockReset();
+    tauri = false;
+  });
+
+  it("forwards noFf=true to the Tauri IPC call", async () => {
+    tauri = true;
+    tauriInvoke.mockResolvedValue({ success: true, message: "done" });
+    const { gitMerge } = await import("../backend");
+
+    await gitMerge("/repo", "feature", true);
+
+    expect(tauriInvoke).toHaveBeenCalledWith("git_merge", { cwd: "/repo", branch: "feature", noFf: true });
+  });
+
+  it("defaults noFf to false when omitted, over dev-server HTTP", async () => {
+    tauri = false;
+    devFetch.mockResolvedValue(mockRes({ success: true, message: "done" }));
+    const { gitMerge } = await import("../backend");
+
+    await gitMerge("/repo", "feature");
+
+    expect(devFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/git-merge"),
+      expect.objectContaining({
+        body: JSON.stringify({ cwd: "/repo", branch: "feature", noFf: false }),
+      }),
+    );
+  });
+});

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -934,16 +934,17 @@ export async function gitFetch(cwd: string): Promise<GitPushPullResult> {
 }
 
 /**
- * Merge a branch into the current branch.
+ * Merge a branch into the current branch. `noFf` forces `--no-ff` (#177),
+ * always creating a merge commit even when a fast-forward is possible.
  */
-export async function gitMerge(cwd: string, branch: string): Promise<GitPushPullResult> {
+export async function gitMerge(cwd: string, branch: string, noFf: boolean = false): Promise<GitPushPullResult> {
   if (isTauri()) {
-    return tauriInvoke<GitPushPullResult>("git_merge", { cwd, branch });
+    return tauriInvoke<GitPushPullResult>("git_merge", { cwd, branch, noFf });
   }
   const res = await devFetch(`${DEV_SERVER}/api/git-merge`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ cwd, branch }),
+    body: JSON.stringify({ cwd, branch, noFf }),
   });
   return res.json();
 }


### PR DESCRIPTION
## Summary
- Adds a "no fast-forward" option to the branch-merge UI, requested in #177: an "Always create a merge commit" checkbox in the merge-into-current popover, off by default.
- Threaded through the full stack: `AppHeader.vue` → `App.vue` → `useGitRepo.mergeBranch` → `backend.ts:gitMerge` → Rust `git_merge` (`--no-ff --no-edit`) and its `dev-server.mjs` mirror.
- While touching the dev-server merge route, switched it from shell-interpolated `execSync` to `execFileSync` with an args array, closing a pre-existing shell-injection risk on the branch name.
- i18n keys added to all 5 locales.

## Test plan
- [x] `cargo test --lib` — 252 passed, including 2 new real-git-repo tests locking in that `--no-ff` produces a 2-parent merge commit on a fast-forwardable branch, and that the default path still fast-forwards
- [x] `pnpm exec vitest run` — 1060 passed, including 2 new tests for the `noFf` param on `gitMerge`
- [x] `vue-tsc --noEmit` — clean
- [x] `cargo clippy --lib` — clean
- [x] Manual QA via `pnpm dev:web` in a real browser against two real temp git repos: checkbox checked → verified 2-parent merge commit via `git rev-list --parents`; unchecked → verified unchanged fast-forward (regression check)

Fixes #177