### PR TITLE
fix(desktop): list untracked folders file-by-file in WIP Changes (#181)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A brand-new folder showed no folder and no files in WIP Changes until it was staged** (#181). Both status implementations ran git's default `--untracked-files=normal`, which collapses a never-staged directory into a single `newfolder/` entry; the sidebar tree renders such a trailing-slash path as one opaque leaf row, with no chevron, no file count and nothing inside. Staging turned it into per-file entries, which is why the folder only appeared afterwards. The libgit2 fast path now sets `recurse_untracked_dirs`, and `git_status_cli` plus the dev-server route pass `--untracked-files=all`, so an untracked directory is listed file by file from the start, like every other change. The explicit flag also aligns the CLI path with the libgit2 one, which reported untracked files regardless of a repo-local `status.showUntrackedFiles`. Untracked *nested git repos* are still reported as a single `nestedrepo/` entry (git never expands those); the flat-list layout used to label that row with an empty string and now shows the directory name, sharing its label helpers with the tree layout.
+
 ### Security
 
 - Cleared 39 open Dependabot alerts (all `high`/`medium`, one `low`) via `pnpm update -r` across the monorepo, all resolved within existing semver ranges — no direct dependency needed a major-version bump. Most of the chain came from `@modelcontextprotocol/sdk` (`packages/mcp`, a published runtime dependency): `hono`, `@hono/node-server`, `express`, `express-rate-limit`, `body-parser`, `qs`, `ip-address`, `ajv`/`ajv-formats`, `undici`, `fast-uri`. The rest came from `@vscode/vsce` (dev-only VSIX packaging, `packages/vscode`): `cheerio`, `@textlint/linter-formatter` → `js-yaml`, `azure-devops-node-api` → `typed-rest-client`. A Linux-only `glib` alert (transitive via `tauri`'s GTK stack) is not yet actionable — no newer version is reachable within the current `tauri`/`tao`/`gtk-rs` dependency graph; tracked for the next `tauri` bump.

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -1413,7 +1413,10 @@ async function handleRequest(req, res) {
         const resolvedCwd = resolve(cwd);
         // Discrete args so the optional pathspec can be passed after `--`
         // without string interpolation (v2.21.0 monorepo scope).
-        const statusArgs = ["status", "--porcelain=v2", "--branch"];
+        // `--untracked-files=all` mirrors git_status_cli / the libgit2 fast
+        // path (issue #181): git's default collapses a never-staged directory
+        // into a single `newfolder/` entry the sidebar tree cannot expand.
+        const statusArgs = ["status", "--porcelain=v2", "--branch", "--untracked-files=all"];
         if (pathspec) statusArgs.push("--", pathspec);
         const stdout = execFileSync(GIT, statusArgs, {
           cwd: resolvedCwd,

--- a/apps/desktop/src-tauri/src/commands/read.rs
+++ b/apps/desktop/src-tauri/src/commands/read.rs
@@ -220,6 +220,14 @@ type FileStatusesResult =
 fn libgit2_file_statuses(repo: &git2::Repository) -> FileStatusesResult {
     let mut opts = git2::StatusOptions::new();
     opts.include_untracked(true)
+        // List every file inside a brand-new directory instead of the
+        // directory itself (issue #181). Without this, libgit2 reports
+        // `newfolder/` as a single entry, like git's default
+        // `--untracked-files=normal`, and the sidebar tree renders it as one
+        // opaque leaf row, so the folder's contents only became visible once
+        // staged. `git_status_cli` passes `--untracked-files=all` for the
+        // same reason.
+        .recurse_untracked_dirs(true)
         .include_ignored(false)
         .renames_head_to_index(true)
         .renames_index_to_workdir(true)
@@ -361,6 +369,13 @@ pub(crate) fn git_status_cli(cwd: String, pathspec: Option<String>) -> Result<Gi
         "status".to_string(),
         "--porcelain=v2".to_string(),
         "--branch".to_string(),
+        // Recurse into untracked directories (issue #181). git's default
+        // (`normal`) collapses a never-staged directory into a single
+        // `newfolder/` entry, which the sidebar tree cannot expand. Passing
+        // the flag explicitly also aligns this path with the libgit2 fast
+        // path, which reports untracked files regardless of a repo-local
+        // `status.showUntrackedFiles`.
+        "--untracked-files=all".to_string(),
     ];
     if let Some(ref p) = pathspec {
         let p = p.trim();
@@ -2670,6 +2685,49 @@ mod pathspec_tests {
             has_a,
             "unscoped status should show all changes: {:?}",
             all_paths
+        );
+    }
+
+    // ── Untracked directories (issue #181) ────────────────────
+    //
+    // git's default `--untracked-files=normal` collapses a brand-new
+    // directory into a single `newfolder/` entry. The sidebar tree builder
+    // renders such a trailing-slash path as one opaque leaf row, so neither
+    // the folder nor the files inside it were visible until the user staged
+    // them. Both status implementations must therefore recurse into
+    // untracked directories.
+
+    #[test]
+    fn git_status_lists_files_inside_untracked_directory() {
+        let repo = TempRepo::new();
+        repo.write("root.txt", "root");
+        repo.commit_all("root");
+
+        // Brand-new, never-staged directory, with a nested subdirectory.
+        repo.write("newfolder/a.txt", "a");
+        repo.write("newfolder/sub/b.txt", "b");
+
+        let expected = vec![
+            "newfolder/a.txt".to_string(),
+            "newfolder/sub/b.txt".to_string(),
+        ];
+
+        let cli = git_status_cli(repo.cwd(), None).expect("git_status_cli failed");
+        let mut cli_untracked = cli.untracked.clone();
+        cli_untracked.sort();
+        assert_eq!(
+            cli_untracked, expected,
+            "CLI: untracked dir should be listed file-by-file, got {:?}",
+            cli.untracked
+        );
+
+        let lg2 = git_status_libgit2(&repo.cwd()).expect("git_status_libgit2 failed");
+        let mut lg2_untracked = lg2.untracked.clone();
+        lg2_untracked.sort();
+        assert_eq!(
+            lg2_untracked, expected,
+            "libgit2: untracked dir should be listed file-by-file, got {:?}",
+            lg2.untracked
         );
     }
 

--- a/apps/desktop/src/components/RepoSidebar.vue
+++ b/apps/desktop/src/components/RepoSidebar.vue
@@ -16,7 +16,13 @@ import { useCommitTemplates } from "../composables/useCommitTemplates";
 import { useArchivedBranches } from "../composables/useArchivedBranches";
 import { usePinnedBranches } from "../composables/usePinnedBranches";
 import { useAiPromptPresets } from "../composables/useAiPromptPresets";
-import { buildFileTree, flattenTree, type TreeRow } from "../composables/useFileTree";
+import {
+  buildFileTree,
+  flattenTree,
+  leafName,
+  parentDir,
+  type TreeRow,
+} from "../composables/useFileTree";
 import type { CommitTemplate } from "../composables/useSettings";
 import { gitBranchMerged } from "../utils/backend";
 import { loadSettings } from "../composables/useSettings";
@@ -735,13 +741,14 @@ function statusColor(status: string): string {
   return map[status] ?? "var(--color-text-muted)";
 }
 
+// Shared with the tree layout so both render an untracked directory entry
+// (`nestedrepo/`) with the same label instead of a blank one (issue #181).
 function fileName(path: string): string {
-  return path.split("/").pop() ?? path;
+  return leafName(path);
 }
 
 function fileDir(path: string): string {
-  const parts = path.split("/");
-  return parts.length > 1 ? parts.slice(0, -1).join("/") + "/" : "";
+  return parentDir(path);
 }
 
 const totalChanges = computed(() => props.files.length);

--- a/apps/desktop/src/composables/__tests__/useFileTree.test.ts
+++ b/apps/desktop/src/composables/__tests__/useFileTree.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildFileTree, flattenTree } from "../useFileTree";
+import { buildFileTree, flattenTree, leafName, parentDir } from "../useFileTree";
 import type { RepoFileEntry } from "../useGitRepo";
 
 function file(path: string): RepoFileEntry {
@@ -53,6 +53,21 @@ describe("buildFileTree / flattenTree", () => {
       "a",
       "a/b",
     ]);
+  });
+
+  it("labels a trailing-slash entry with its directory name, not an empty string", () => {
+    // With `--untracked-files=all` the only remaining trailing-slash entries
+    // are untracked *nested git repos*, which git never expands. The flat
+    // list layout used to render them with a blank name (issue #181):
+    // "nestedrepo/".split("/").pop() === "".
+    expect(leafName("nestedrepo/")).toBe("nestedrepo/");
+    expect(parentDir("nestedrepo/")).toBe("");
+    expect(leafName("libs/nestedrepo/")).toBe("nestedrepo/");
+    expect(parentDir("libs/nestedrepo/")).toBe("libs/");
+    // Plain files are unaffected.
+    expect(leafName("src/a.ts")).toBe("a.ts");
+    expect(parentDir("src/a.ts")).toBe("src/");
+    expect(parentDir("README.md")).toBe("");
   });
 
   it("is generic over any PathLike entry (e.g. commit diffs)", () => {

--- a/apps/desktop/src/composables/useFileTree.ts
+++ b/apps/desktop/src/composables/useFileTree.ts
@@ -42,11 +42,25 @@ function newNode<T extends PathLike>(name: string, path: string): FolderNode<T> 
   return { name, path, folders: new Map(), files: [], count: 0 };
 }
 
-/** The display leaf of a path. Untracked directory entries keep their trailing "/". */
-function leafName(path: string): string {
+/**
+ * The display leaf of a path. Untracked directory entries keep their trailing
+ * "/": since `--untracked-files=all` (issue #181) those are only untracked
+ * *nested git repos*, which git never expands.
+ *
+ * Exported because the sidebar's flat-list layout needs the same labels as the
+ * tree layout: `"nestedrepo/".split("/").pop()` is the empty string, which used
+ * to render as a nameless row.
+ */
+export function leafName(path: string): string {
   const segs = path.split("/").filter(Boolean);
   const leaf = segs[segs.length - 1] ?? path;
   return path.endsWith("/") ? `${leaf}/` : leaf;
+}
+
+/** The parent directory of a path, slash-terminated, or "" at the root. */
+export function parentDir(path: string): string {
+  const segs = path.split("/").filter(Boolean);
+  return segs.length > 1 ? `${segs.slice(0, -1).join("/")}/` : "";
 }
 
 /** Build a nested folder tree from a flat list of entries. */

--- a/apps/desktop/tests/parity/fixtures.mjs
+++ b/apps/desktop/tests/parity/fixtures.mjs
@@ -112,9 +112,11 @@ export function fixtureCursorOriginRemote() {
 
 /**
  * Fixture « dirty » : 3 commits, un fichier modifié non stagé, un nouveau
- * fichier untracked, un fichier stagé.
+ * fichier untracked, un fichier stagé, et un *dossier* entièrement untracked.
  *
- * Couvre les sections `unstaged`, `staged`, `untracked` de git_status.
+ * Couvre les sections `unstaged`, `staged`, `untracked` de git_status, dont
+ * la récursion dans les dossiers jamais stagés (issue #181 : sans
+ * `--untracked-files=all`, git ne remonte que `newdir/`).
  */
 export function fixtureDirty() {
   const cwd = mkTempRepo("gw-dirty-");
@@ -129,6 +131,10 @@ export function fixtureDirty() {
   execFileSync("git", ["-C", cwd, "add", "--", "c.txt"]);
   // d.txt untracked
   writeFileSync(join(cwd, "d.txt"), "delta\n", "utf-8");
+  // newdir/ : dossier jamais stagé, avec un sous-dossier
+  mkdirSync(join(cwd, "newdir", "sub"), { recursive: true });
+  writeFileSync(join(cwd, "newdir", "e.txt"), "epsilon\n", "utf-8");
+  writeFileSync(join(cwd, "newdir", "sub", "f.txt"), "zeta\n", "utf-8");
 
   return cwd;
 }

--- a/apps/desktop/tests/parity/git-status.test.mjs
+++ b/apps/desktop/tests/parity/git-status.test.mjs
@@ -15,7 +15,7 @@
  * On s'attend à une égalité structurelle après normalisation (camelCase).
  */
 
-import { describe, it, beforeAll, afterAll } from "vitest";
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import { startDevServer } from "./dev-server-runner.mjs";
 import { assertParity } from "./harness.mjs";
 import { fixtureClean, fixtureDirty } from "./fixtures.mjs";
@@ -43,10 +43,19 @@ describe("parity: git-status", () => {
 
   it("fixtureDirty → staged + unstaged + untracked cohabitent", async () => {
     const cwd = fixtureDirty();
-    await assertParity(dev, {
+    const { rust, node } = await assertParity(dev, {
       command: "git-status",
       args: { cwd },
       httpPath: `/api/git-status?cwd=${encodeURIComponent(cwd)}`,
     });
+
+    // Issue #181 : un dossier jamais stagé doit remonter fichier par fichier,
+    // et non comme une entrée `newdir/` unique. La parité seule ne suffit pas
+    // ici : les deux backends pourraient être d'accord et tous les deux faux.
+    for (const side of [rust, node]) {
+      expect(side.untracked).toContain("newdir/e.txt");
+      expect(side.untracked).toContain("newdir/sub/f.txt");
+      expect(side.untracked).not.toContain("newdir/");
+    }
   });
 });


### PR DESCRIPTION
Closes #181.

## Root cause

The tree view is not at fault, what `git status` reports is. Both status implementations ran git's default `--untracked-files=normal`, which collapses a never-staged directory into a single `newfolder/` entry:

```
$ git status --porcelain=v2          $ git status --porcelain=v2 -uall
? newfolder/                         ? newfolder/a.txt
                                     ? newfolder/sub/b.txt
```

`buildFileTree` treats a trailing-slash path as a **leaf**, never as a folder node (`useFileTree.ts:57`), hence one opaque row with no chevron, no count and nothing inside. Staging emits per-file entries (`A.`) and the tree appears, which is exactly the symptom described in the issue.

Three call sites were affected: the libgit2 fast path (`read.rs`, missing `recurse_untracked_dirs`), the CLI fallback `git_status_cli`, and the dev-server's `/api/git-status` route.

## Changes

- **libgit2**: `recurse_untracked_dirs(true)`.
- **`git_status_cli` and the dev-server**: an explicit `--untracked-files=all`. Welcome side effect, the CLI path now matches the libgit2 one, which already reported untracked files regardless of a repo-local `status.showUntrackedFiles`.
- **`RepoSidebar`**: in the flat-list layout a trailing-slash entry was labelled with an empty string (`"nestedrepo/".split("/").pop() === ""`). `fileName` / `fileDir` now share `leafName` / `parentDir` with the tree layout. That case survives this fix for untracked nested git repos, which git never expands, even with `-uall`.

## Tests

- `git_status_lists_files_inside_untracked_directory` covers both Rust implementations. It failed before the fix: `got ["newfolder/"]`.
- The parity fixture `fixtureDirty` gains an untracked directory with a subdirectory, plus per-side assertions: parity alone would pass with both backends agreeing and both wrong.
- Verified: `cargo test --lib` 253/253, `pnpm test:parity` 28/28 (the Node HTTP route included), desktop `pnpm test` 1061/1061, `vue-tsc` clean, `cargo fmt` and `clippy` clean.
- Manual check under `pnpm dev:web` on a fresh two-level folder: full tree before staging, identical after staging.

## Worth knowing

With `-uall`, a large untracked directory that is not ignored, a `dist/` missing from `.gitignore` for instance, now shows its files instead of one row. That is what VS Code and other clients do, and the counter becomes honest, but the 2s poll enumerates more paths. Measured negligible on this repo: 0.06s versus 0.08s.

Side finding, out of scope here and tracked in #183: the fallback mechanism for directory entries (`isDirectory` / `newFiles` on `git_diff`) exists only in `dev-server.mjs`, not on the Rust side, where `GitDiff` has no such fields. Clicking such a row therefore shows nothing in the packaged app while it works under `dev:web`. After this PR that path is only reachable for untracked nested repos.
