### PR TITLE
fix(desktop): handle git_diff on a directory in the packaged app (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A panel for an untracked nested Git repository** (#183). A folder carrying its own `.git` is the one directory entry `git status` still reports as a single row, because git refuses to look inside it. Selecting it now explains why its contents are not tracked from here and offers the two things the app can act on: open it as its own repo tab, or add it to `.gitignore`. Its files are deliberately not listed, because `git ls-files --others` answers with the directory itself, so a file row would just reopen the same panel.
+
+### Changed
+
+- **`git_diff` is now covered by the parity suite.** It was absent from `parity_probe.rs`, which is why four drifts between the Rust backend and the dev-server accumulated unnoticed in a single command; three of the four above were found by the new `tests/parity/git-diff.test.mjs` rather than reported. Every git-read command the frontend consumes should have this coverage.
+
 ### Fixed
 
 - **A brand-new folder showed no folder and no files in WIP Changes until it was staged** (#181). Both status implementations ran git's default `--untracked-files=normal`, which collapses a never-staged directory into a single `newfolder/` entry; the sidebar tree renders such a trailing-slash path as one opaque leaf row, with no chevron, no file count and nothing inside. Staging turned it into per-file entries, which is why the folder only appeared afterwards. The libgit2 fast path now sets `recurse_untracked_dirs`, and `git_status_cli` plus the dev-server route pass `--untracked-files=all`, so an untracked directory is listed file by file from the start, like every other change. The explicit flag also aligns the CLI path with the libgit2 one, which reported untracked files regardless of a repo-local `status.showUntrackedFiles`. Untracked *nested git repos* are still reported as a single `nestedrepo/` entry (git never expands those); the flat-list layout used to label that row with an empty string and now shows the directory name, sharing its label helpers with the tree layout.
+- **`git_diff` on a directory path did nothing in the packaged app** (#183). The branch that turns an untracked directory into a file list existed only in the Node dev-server, and `GitDiff` carried no `isDirectory` / `newFiles` fields on the Rust side, although `backend.ts` had declared them for releases. Clicking such an entry therefore worked under `pnpm dev:web` and showed an empty panel in the shipped app. The Rust `git_diff` gained the branch, guarded by `safe_repo_path`, which also short-circuits the `--no-index` fallback that was spawning two git processes for nothing on a directory path.
+- **"Add to .gitignore" threw in the packaged app.** `backend.ts` has invoked a `git_add_to_gitignore` Tauri command since the context-menu action shipped, and no such command was ever registered: only the dev-server route existed. It is now implemented in Rust with the dev-server's semantics (create if absent, never duplicate an entry, always leave a trailing newline) plus a refusal for a multi-line entry, which would otherwise write rules the user never asked for. The same guard was mirrored into the dev-server route.
+- **A phantom context line at the end of every diff under `dev:web`.** The dev-server's diff parser classified context lines with `!line.startsWith("\\")`, which lets through the empty string `split("\n")` leaves after the trailing newline. This is verbatim the gotcha `AGENTS.md` documents; the Rust parser (`strip_prefix(' ')`) never had it.
+- **An unmodified tracked file rendered as an all-green whole-file addition under `dev:web`.** The dev-server ran its `--no-index` fallback for any path whose `git diff` came back empty, including a tracked file with nothing to show. It now checks `ls-files --error-unmatch` first, the guard the Rust implementation has always had.
+- The folder panel hardcoded `Nouveau dossier` and `fichier(s)` in French, in violation of the i18n rule. Six `diff.*` keys now cover it and the nested-repo panel, translated in all 5 locales.
 
 ### Security
 

--- a/apps/desktop/dev-server.mjs
+++ b/apps/desktop/dev-server.mjs
@@ -1625,14 +1625,26 @@ async function handleRequest(req, res) {
         // ── Directory: list new files inside instead of diffing ──────────
         if (path.endsWith("/")) {
           const absDir = join(resolvedCwd, path);
-          let newFiles = [];
+          let raw = [];
           try {
-            const r = spawnSync("git", ["ls-files", "--others", "--exclude-standard", absDir], {
+            const r = spawnSync(GIT, ["ls-files", "--others", "--exclude-standard", "--", absDir], {
               cwd: resolvedCwd, encoding: "utf-8",
             });
-            newFiles = (r.stdout || "").trim().split("\n").filter(Boolean);
+            raw = (r.stdout || "").trim().split("\n").filter(Boolean);
           } catch { /* ignore */ }
-          return jsonResponse(req, res, { path, hunks: [], isDirectory: true, newFiles });
+          // Two independent signals, either is enough: an own `.git` (a
+          // directory for a plain clone, a file for a worktree or an absorbed
+          // submodule), or git answering with the directory instead of its
+          // contents. Mirrors `git_diff_directory` in read.rs (issue #183);
+          // `nestedRepo` is omitted when false, as the Rust side skips None.
+          const nested = existsSync(join(absDir, ".git")) || (raw.length === 1 && raw[0] === path);
+          return jsonResponse(req, res, {
+            path,
+            hunks: [],
+            isDirectory: true,
+            newFiles: nested ? [] : raw,
+            ...(nested ? { nestedRepo: true } : {}),
+          });
         }
 
         const args = staged ? ["diff", "--cached", "--", path] : ["diff", "--", path];
@@ -1644,9 +1656,20 @@ async function handleRequest(req, res) {
         } catch { stdout = ""; }
 
         // ── New untracked file: fall back to --no-index diff (all lines green) ──
+        //
+        // Guard: only for genuinely UNTRACKED files, mirroring the Rust
+        // `git_diff`. A tracked file whose change is already staged also
+        // yields an empty unstaged `git diff`; without the check the fallback
+        // renders the entire file as an addition instead of showing no
+        // unstaged change. Drift found by tests/parity/git-diff (issue #183).
         if (!stdout.trim() && !staged) {
           const absFile = join(resolvedCwd, path);
-          if (existsSync(absFile) && !statSync(absFile).isDirectory()) {
+          const tracked =
+            spawnSync(GIT, ["ls-files", "--error-unmatch", "--", path], {
+              cwd: resolvedCwd,
+              encoding: "utf-8",
+            }).status === 0;
+          if (!tracked && existsSync(absFile) && !statSync(absFile).isDirectory()) {
             const r = spawnSync("git", ["diff", "--no-index", "--", "/dev/null", absFile], {
               cwd: resolvedCwd, encoding: "utf-8",
             });
@@ -1692,11 +1715,17 @@ async function handleRequest(req, res) {
                 newLineNo: null,
               });
               oldLineNo++;
-            } else if (!line.startsWith("\\")) {
-              const content = line.length > 0 ? line.substring(1) : "";
+              // Context lines start with a single space. Testing
+              // `!startsWith("\\")` instead lets the empty string that
+              // `split("\n")` leaves after the trailing newline through, which
+              // appended a phantom context line to every diff, and the Rust
+              // parser (`strip_prefix(' ')`) never did. This is the gotcha
+              // AGENTS.md documents; drift found by tests/parity/git-diff
+              // (issue #183).
+            } else if (line.startsWith(" ")) {
               currentHunk.lines.push({
                 type: "context",
-                content,
+                content: line.substring(1),
                 oldLineNo,
                 newLineNo,
               });
@@ -2579,6 +2608,12 @@ async function handleRequest(req, res) {
     if (url.pathname === "/api/git-gitignore" && req.method === "POST") {
       const { cwd, path: filePath } = await readBody(req);
       if (!cwd || !filePath) return jsonResponse(req, res, { error: "Missing cwd or path" }, 400);
+      // Mirrors the guard in the Rust `git_add_to_gitignore` (issue #183): the
+      // entry becomes one line of a config file, so a newline inside it would
+      // silently add rules the user never asked for.
+      if (/[\r\n]/.test(filePath)) {
+        return jsonResponse(req, res, { error: "gitignore entry must be a single line" }, 400);
+      }
       try {
         const resolvedCwd = resolve(cwd);
         const gitignorePath = join(resolvedCwd, ".gitignore");

--- a/apps/desktop/src-tauri/examples/parity_probe.rs
+++ b/apps/desktop/src-tauri/examples/parity_probe.rs
@@ -33,7 +33,7 @@
 // proc-macro de Tauri génère une aide `__cmd__<name>` qui entre en conflit si
 // la fn elle-même est `pub`. Voir le bloc "Parity probe re-exports" dans lib.rs.
 use gitwand_desktop_lib::{
-    git_branches_parity, git_commit_submodule_changes_parity, git_log_parity,
+    git_branches_parity, git_commit_submodule_changes_parity, git_diff_parity, git_log_parity,
     git_remote_info_parity, git_stash_list_parity, git_status_libgit2_parity, git_status_parity,
     git_submodule_branches_parity, scan_secrets_parity, snapshot_create_parity,
     snapshot_list_parity, snapshot_prune_parity, snapshot_restore_parity,
@@ -46,7 +46,7 @@ fn main() -> ExitCode {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
         eprintln!("usage: parity-probe <command>");
-        eprintln!("commands: git-status, git-status-fast, git-log, git-branches, git-stash-list, git-submodule-branches, git-commit-submodule-changes, scan-secrets");
+        eprintln!("commands: git-status, git-status-fast, git-diff, git-log, git-branches, git-stash-list, git-submodule-branches, git-commit-submodule-changes, scan-secrets");
         return ExitCode::from(2);
     }
 
@@ -103,6 +103,21 @@ fn main() -> ExitCode {
                 Err(code) => return code,
             };
             to_json(git_status_libgit2_parity(cwd))
+        }
+        "git-diff" => {
+            let cwd = match must_str("cwd") {
+                Ok(v) => v,
+                Err(code) => return code,
+            };
+            let path = match must_str("path") {
+                Ok(v) => v,
+                Err(code) => return code,
+            };
+            let staged = input
+                .get("staged")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            to_json(git_diff_parity(cwd, path, staged))
         }
         "git-log" => {
             let cwd = match must_str("cwd") {

--- a/apps/desktop/src-tauri/src/commands/ops.rs
+++ b/apps/desktop/src-tauri/src/commands/ops.rs
@@ -771,6 +771,45 @@ pub(crate) async fn git_interactive_rebase(
     Err(format!("git rebase -i failed: {}", msg))
 }
 
+// ─── .gitignore ────────────────────────────────────────────────
+
+/// Append `path` to the repo's `.gitignore`, once.
+///
+/// `backend.ts` has invoked this command since the context-menu action
+/// shipped, but only the Node dev-server route existed, so the action worked
+/// under `dev:web` and threw in the packaged app (issue #183). Semantics
+/// mirror `/api/git-gitignore`: create the file if absent, skip an entry that
+/// is already there, and always leave a trailing newline.
+#[tauri::command]
+pub(crate) async fn git_add_to_gitignore(cwd: String, path: String) -> Result<(), String> {
+    let entry = path.trim().to_string();
+    if entry.is_empty() {
+        return Err("gitignore entry must not be empty".to_string());
+    }
+    // The entry becomes one line of a config file. A newline inside it would
+    // silently add rules the user never asked for.
+    if entry.contains('\n') || entry.contains('\r') {
+        return Err("gitignore entry must be a single line".to_string());
+    }
+
+    let _repo = repo_lock::write(&cwd);
+    let file = safe_repo_path(&cwd, ".gitignore")?;
+    let existing = std::fs::read_to_string(&file).unwrap_or_default();
+
+    if existing.lines().any(|l| l == entry) {
+        return Ok(());
+    }
+
+    let mut next = existing;
+    if !next.is_empty() && !next.ends_with('\n') {
+        next.push('\n');
+    }
+    next.push_str(&entry);
+    next.push('\n');
+
+    std::fs::write(&file, next).map_err(|e| format!("Failed to write .gitignore: {}", e))
+}
+
 // ─── Git discard ───────────────────────────────────────────────
 
 #[tauri::command]
@@ -4456,6 +4495,68 @@ mod tree_conflict_tests {
         repo.git_ok(&["checkout", "-q", "feature"]);
         // Merge main into feature — conflicts, returns non-zero; ignore status.
         let _ = repo.git(&["merge", "--no-edit", "main"]);
+    }
+
+    // ── .gitignore append (issue #183) ────────────────────────
+    //
+    // `backend.ts` has invoked a `git_add_to_gitignore` Tauri command since
+    // the context-menu action shipped, but no such command existed: only the
+    // Node dev-server had the route. The action therefore worked under
+    // dev:web and threw in the packaged app. Semantics mirror
+    // `/api/git-gitignore`: append once, keep a trailing newline, never
+    // duplicate an entry.
+
+    #[test]
+    fn gitignore_append_creates_the_file_when_absent() {
+        let repo = TempRepo::new();
+        tauri::async_runtime::block_on(git_add_to_gitignore(repo.cwd(), "build/".to_string()))
+            .expect("git_add_to_gitignore failed");
+
+        let content = std::fs::read_to_string(repo.path.join(".gitignore")).unwrap();
+        assert_eq!(content, "build/\n");
+    }
+
+    #[test]
+    fn gitignore_append_does_not_duplicate_an_existing_entry() {
+        let repo = TempRepo::new();
+        repo.write(".gitignore", "node_modules/\nbuild/\n");
+
+        tauri::async_runtime::block_on(git_add_to_gitignore(repo.cwd(), "build/".to_string()))
+            .expect("git_add_to_gitignore failed");
+
+        let content = std::fs::read_to_string(repo.path.join(".gitignore")).unwrap();
+        assert_eq!(content, "node_modules/\nbuild/\n", "entry already present");
+    }
+
+    #[test]
+    fn gitignore_append_separates_from_a_file_with_no_trailing_newline() {
+        let repo = TempRepo::new();
+        repo.write(".gitignore", "node_modules/");
+
+        tauri::async_runtime::block_on(git_add_to_gitignore(repo.cwd(), "build/".to_string()))
+            .expect("git_add_to_gitignore failed");
+
+        let content = std::fs::read_to_string(repo.path.join(".gitignore")).unwrap();
+        assert_eq!(content, "node_modules/\nbuild/\n");
+    }
+
+    #[test]
+    fn gitignore_append_rejects_a_path_carrying_a_newline() {
+        let repo = TempRepo::new();
+        let err = tauri::async_runtime::block_on(git_add_to_gitignore(
+            repo.cwd(),
+            "build/\n*.key".to_string(),
+        ))
+        .expect_err("a multi-line entry must be refused");
+        assert!(
+            err.contains("single line"),
+            "error should explain the constraint, got: {}",
+            err
+        );
+        assert!(
+            !repo.path.join(".gitignore").exists(),
+            "nothing should be written on refusal"
+        );
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/commands/read.rs
+++ b/apps/desktop/src-tauri/src/commands/read.rs
@@ -737,6 +737,15 @@ fn compute_main_commit_count(cwd: &str, branch: &str) -> i32 {
 #[tauri::command]
 pub(crate) async fn git_diff(cwd: String, path: String, staged: bool) -> Result<GitDiff, String> {
     let _repo = repo_lock::read(&cwd);
+    // A trailing slash means the sidebar handed us an untracked *directory*
+    // entry, which has no diff. List what is inside instead so the UI can
+    // render a folder panel. Mirrors `/api/git-diff` in dev-server.mjs, whose
+    // behavior the Rust side used to lack entirely (issue #183); it also
+    // short-circuits the `--no-index` fallback below, which spawns two git
+    // processes for nothing on a directory path.
+    if path.ends_with('/') {
+        return git_diff_directory(&cwd, path);
+    }
     let mut cmd = git_cmd();
     if staged {
         cmd.arg("diff").arg("--cached");
@@ -811,6 +820,53 @@ pub(crate) async fn git_diff(cwd: String, path: String, staged: bool) -> Result<
         status,
         old_path: None,
         truncated_from_bytes,
+        is_directory: None,
+        new_files: None,
+        nested_repo: None,
+    })
+}
+
+/// `git_diff` for a directory path: the untracked files inside it.
+///
+/// A directory carrying its own `.git` is reported as a nested repo with no
+/// file list. Git never looks inside one, so `ls-files --others` answers with
+/// the directory itself; listing that would hand the UI a row which reopens
+/// this very panel. Since `git status --untracked-files=all` (issue #181), a
+/// nested repo is in fact the only directory entry the sidebar can still
+/// produce.
+fn git_diff_directory(cwd: &str, path: String) -> Result<GitDiff, String> {
+    let dir = safe_repo_path(cwd, &path)?;
+
+    let raw: Vec<String> = git_cmd()
+        .args(["ls-files", "--others", "--exclude-standard", "--"])
+        .arg(&dir)
+        .current_dir(cwd)
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| {
+            String::from_utf8_lossy(&o.stdout)
+                .lines()
+                .filter(|l| !l.trim().is_empty())
+                .map(|l| l.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Two independent signals, either is enough: an own `.git` (a directory
+    // for a plain clone, a file for a worktree or an absorbed submodule), or
+    // git answering with the directory instead of its contents.
+    let nested = dir.join(".git").exists() || raw == [path.clone()];
+
+    Ok(GitDiff {
+        path,
+        hunks: Vec::new(),
+        status: None,
+        old_path: None,
+        truncated_from_bytes: None,
+        is_directory: Some(true),
+        new_files: Some(if nested { Vec::new() } else { raw }),
+        nested_repo: if nested { Some(true) } else { None },
     })
 }
 
@@ -1156,6 +1212,10 @@ pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, 
                     // Truncation is only meaningful for the per-file diff
                     // command. Set None unconditionally here.
                     truncated_from_bytes: None,
+                    // Directory entries only reach the single-file `git_diff`.
+                    is_directory: None,
+                    new_files: None,
+                    nested_repo: None,
                 });
             }
             current_status = None;
@@ -1266,6 +1326,9 @@ pub(crate) async fn git_show(cwd: String, hash: String) -> Result<Vec<GitDiff>, 
             status: current_status.take(),
             old_path: current_old_path.take(),
             truncated_from_bytes: None, // see P2.4 note above
+            is_directory: None,
+            new_files: None,
+            nested_repo: None,
         });
     }
 
@@ -2729,6 +2792,111 @@ mod pathspec_tests {
             "libgit2: untracked dir should be listed file-by-file, got {:?}",
             lg2.untracked
         );
+    }
+
+    // ── git_diff on a directory path (issue #183) ─────────────
+    //
+    // The sidebar can hand `git_diff` a path ending in "/" (an untracked
+    // directory entry from `git status`). Only the Node dev-server handled
+    // that: it listed the files inside and answered `isDirectory: true`, which
+    // `DiffViewer` renders as a "new folder" panel. Rust returned an ordinary
+    // empty diff, so the packaged app showed nothing where dev:web worked.
+
+    #[test]
+    fn git_diff_on_an_untracked_directory_lists_the_files_inside() {
+        let repo = TempRepo::new();
+        repo.write("root.txt", "root");
+        repo.commit_all("root");
+        repo.write("newfolder/a.txt", "a");
+        repo.write("newfolder/sub/b.txt", "b");
+
+        let diff =
+            tauri::async_runtime::block_on(git_diff(repo.cwd(), "newfolder/".to_string(), false))
+                .expect("git_diff on a directory failed");
+
+        assert_eq!(
+            diff.is_directory,
+            Some(true),
+            "should be flagged a directory"
+        );
+        assert_eq!(
+            diff.nested_repo, None,
+            "a plain folder is not a nested repo"
+        );
+        assert!(diff.hunks.is_empty(), "a directory has no hunks");
+        let mut files = diff.new_files.clone().unwrap_or_default();
+        files.sort();
+        assert_eq!(
+            files,
+            vec![
+                "newfolder/a.txt".to_string(),
+                "newfolder/sub/b.txt".to_string()
+            ],
+            "expected the files inside the directory, got {:?}",
+            diff.new_files
+        );
+    }
+
+    // A nested git repo is the one directory entry that survives
+    // `--untracked-files=all`: git refuses to look inside it. `git ls-files
+    // --others` then answers with the directory itself, so listing its
+    // "contents" would hand the UI a row that reopens the same panel. It is
+    // reported as a nested repo instead, with no file list.
+
+    #[test]
+    fn git_diff_on_an_untracked_nested_repo_reports_it_as_nested() {
+        let repo = TempRepo::new();
+        repo.write("root.txt", "root");
+        repo.commit_all("root");
+
+        // A second, independent repo living inside the working tree.
+        let inner = repo.path.join("inner");
+        std::fs::create_dir_all(&inner).unwrap();
+        let out = Command::new(git_binary())
+            .args(["init", "-q", "-b", "main"])
+            .current_dir(&inner)
+            .output()
+            .expect("git init (inner) failed to spawn");
+        assert!(out.status.success(), "git init (inner) failed");
+        std::fs::write(inner.join("c.txt"), "c").unwrap();
+
+        let diff =
+            tauri::async_runtime::block_on(git_diff(repo.cwd(), "inner/".to_string(), false))
+                .expect("git_diff on a nested repo failed");
+
+        assert_eq!(
+            diff.is_directory,
+            Some(true),
+            "should be flagged a directory"
+        );
+        assert_eq!(
+            diff.nested_repo,
+            Some(true),
+            "should be flagged a nested repo"
+        );
+        assert!(
+            diff.new_files.clone().unwrap_or_default().is_empty(),
+            "a nested repo's files belong to the other repo, got {:?}",
+            diff.new_files
+        );
+    }
+
+    // Guard against the directory branch swallowing ordinary files: a real
+    // file must still produce hunks.
+
+    #[test]
+    fn git_diff_on_a_file_is_unaffected_by_the_directory_branch() {
+        let repo = TempRepo::new();
+        repo.write("a.txt", "one\n");
+        repo.commit_all("a");
+        repo.write("a.txt", "two\n");
+
+        let diff = tauri::async_runtime::block_on(git_diff(repo.cwd(), "a.txt".to_string(), false))
+            .expect("git_diff on a file failed");
+
+        assert_eq!(diff.is_directory, None, "a file is not a directory");
+        assert_eq!(diff.nested_repo, None);
+        assert!(!diff.hunks.is_empty(), "expected hunks for a modified file");
     }
 
     // ── Remote branch existence without configured upstream ───────

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -224,6 +224,13 @@ pub fn git_log_parity(
     ))
 }
 
+/// Parity entry point for `git_diff`. Exposed because the directory branch
+/// (an untracked folder, or a nested repo) lived only in the Node dev-server
+/// for several releases and nothing compared the two (issue #183).
+pub fn git_diff_parity(cwd: String, path: String, staged: bool) -> Result<types::GitDiff, String> {
+    tauri::async_runtime::block_on(commands::read::git_diff(cwd, path, staged))
+}
+
 pub fn git_branches_parity(cwd: String) -> Result<Vec<types::GitBranch>, String> {
     tauri::async_runtime::block_on(commands::ops::git_branches(cwd, None))
 }
@@ -467,6 +474,7 @@ pub fn run() {
             commands::read::git_repo_state,
             commands::ops::git_rebase_action,
             commands::ops::git_interactive_rebase,
+            commands::ops::git_add_to_gitignore,
             commands::ops::git_discard,
             commands::read::git_show,
             commands::ops::git_branches,

--- a/apps/desktop/src-tauri/src/types.rs
+++ b/apps/desktop/src-tauri/src/types.rs
@@ -105,6 +105,19 @@ pub struct GitDiff {
     pub old_path: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "truncatedFromBytes")]
     pub truncated_from_bytes: Option<u64>,
+    /// Set when the requested path is a directory rather than a file (an
+    /// untracked directory entry from `git status`). There is no diff to show;
+    /// the UI renders a folder panel instead. See issue #183.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "isDirectory")]
+    pub is_directory: Option<bool>,
+    /// The untracked files inside that directory, repo-relative.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "newFiles")]
+    pub new_files: Option<Vec<String>>,
+    /// Set when the directory carries its own `.git`. Git never looks inside
+    /// such a directory, so `new_files` is empty and the UI shows a dedicated
+    /// panel rather than a file list that leads nowhere.
+    #[serde(skip_serializing_if = "Option::is_none", rename = "nestedRepo")]
+    pub nested_repo: Option<bool>,
 }
 
 // ─── Git log types ─────────────────────────────────────────────────

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -1052,6 +1052,15 @@ function handleOpenSubmodule(path: string) {
   openTab(abs);
 }
 
+/**
+ * An untracked nested repository, opened as its own tab (issue #183). Same
+ * treatment as a submodule, minus the trailing slash `git status` puts on a
+ * directory entry, which `openTab` must not see in the path it keys tabs by.
+ */
+function handleOpenNestedRepo(path: string) {
+  handleOpenSubmodule(path.replace(/\/+$/, ""));
+}
+
 // ─── Folder opening ─────────────────────────────────────
 async function handleOpenFolder() {
   const path = await pickFolder();
@@ -3852,6 +3861,8 @@ onUnmounted(() => {
                   @update:diff-mode="onDiffModeChange" @open-file-history="openFileHistory"
                   @open-in-editor="handleOpenInEditor" @stage-patch="stagePatch"
                   @select-dir-file="(path) => repoSelectFile(path, false)"
+                  @open-repo-tab="handleOpenNestedRepo"
+                  @add-to-gitignore="addToGitignore"
                   @dismiss-finding="(id) => commitReview.dismiss(id)" />
               </div>
 

--- a/apps/desktop/src/components/DiffViewer.vue
+++ b/apps/desktop/src/components/DiffViewer.vue
@@ -52,6 +52,10 @@ const emit = defineEmits<{
   "stage-patch": [patch: string];
   /** Emitted when user clicks a file inside a new untracked directory */
   "select-dir-file": [path: string];
+  /** Emitted when user wants to open a nested repository as its own tab */
+  "open-repo-tab": [path: string];
+  /** Emitted when user wants to add a path to .gitignore */
+  "add-to-gitignore": [path: string];
   /**
    * Emitted whenever the per-hunk/line selection changes. Used by hosts
    * (like SplitCommitModal) that need to observe selection without needing
@@ -826,17 +830,41 @@ function onDiffScroll() {
 
     <!-- New untracked directory: list its files -->
     <div class="diff-new-dir" v-else-if="diff?.isDirectory">
+      <!--
+        A directory carrying its own .git: git never looks inside it, so there
+        is no file list to show and none of the usual staging actions apply.
+        Name the situation and offer the two things the app can actually do
+        about it (issue #183).
+      -->
+      <div class="diff-nested-repo" v-if="diff.nestedRepo">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+          <path d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
+            stroke="var(--color-accent)" stroke-width="1.5" fill="rgba(139,92,246,0.08)"/>
+          <circle cx="12" cy="13" r="2.2" stroke="var(--color-accent)" stroke-width="1.5"/>
+        </svg>
+        <span class="diff-nested-repo-title">{{ t('diff.nestedRepo') }}</span>
+        <span class="mono diff-nested-repo-path">{{ diff.path }}</span>
+        <p class="diff-nested-repo-hint muted">{{ t('diff.nestedRepoHint') }}</p>
+        <div class="diff-nested-repo-actions">
+          <button type="button" class="diff-nested-repo-open" @click="emit('open-repo-tab', diff.path)">
+            {{ t('diff.nestedRepoOpen') }}
+          </button>
+          <button type="button" class="diff-nested-repo-ignore" @click="emit('add-to-gitignore', diff.path)">
+            {{ t('diff.nestedRepoIgnore') }}
+          </button>
+        </div>
+      </div>
       <!-- Dir header -->
-      <div class="diff-dir-header">
+      <div class="diff-dir-header" v-if="!diff.nestedRepo">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <path d="M3 7a2 2 0 012-2h4l2 2h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"
             stroke="var(--color-accent)" stroke-width="1.5" fill="rgba(139,92,246,0.08)"/>
         </svg>
-        <span class="diff-dir-header-title">Nouveau dossier</span>
-        <span class="diff-dir-header-count muted">{{ diff.newFiles?.length ?? 0 }} fichier{{ (diff.newFiles?.length ?? 0) > 1 ? 's' : '' }}</span>
+        <span class="diff-dir-header-title">{{ t('diff.newFolder') }}</span>
+        <span class="diff-dir-header-count muted">{{ t('diff.newFolderCount', diff.newFiles?.length ?? 0) }}</span>
       </div>
       <!-- File list -->
-      <ul class="diff-dir-files" v-if="diff.newFiles?.length">
+      <ul class="diff-dir-files" v-if="!diff.nestedRepo && diff.newFiles?.length">
         <li
           v-for="f in diff.newFiles"
           :key="f"
@@ -1367,6 +1395,61 @@ function onDiffScroll() {
   flex-direction: column;
   height: 100%;
   overflow: hidden;
+}
+
+/*
+ * Nested repository panel (issue #183). A directory carrying its own .git has
+ * no file list and no staging actions, so this replaces both with the two
+ * things the app can do about it.
+ */
+.diff-nested-repo {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  margin: auto;
+  padding: 24px 28px;
+  max-width: 460px;
+  text-align: center;
+}
+
+.diff-nested-repo-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.diff-nested-repo-path {
+  font-size: 12px;
+  color: var(--color-text-muted);
+  word-break: break-all;
+}
+
+.diff-nested-repo-hint {
+  font-size: 12px;
+  line-height: 1.5;
+  margin: 4px 0 0;
+}
+
+.diff-nested-repo-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.diff-nested-repo-actions button {
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.diff-nested-repo-actions button:hover {
+  border-color: var(--color-accent);
 }
 
 .diff-dir-header {

--- a/apps/desktop/src/components/__tests__/DiffViewer-nested-repo.test.ts
+++ b/apps/desktop/src/components/__tests__/DiffViewer-nested-repo.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+/**
+ * Issue #183 — the folder panel in `DiffViewer`, for the two shapes a
+ * directory path can take: a plain untracked folder, whose files are listed,
+ * and an untracked nested git repo, which git never looks inside.
+ *
+ * Mounted with the native `createApp` (no @vue/test-utils dep), mirroring
+ * `DiffViewer-findings.test.ts`.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { createApp, nextTick, type App } from "vue";
+import DiffViewer from "../DiffViewer.vue";
+import type { GitDiff } from "../../utils/backend";
+
+/** What the backend returns for a plain untracked folder. */
+function folderDiff(): GitDiff {
+  return {
+    path: "newfolder/",
+    hunks: [],
+    isDirectory: true,
+    newFiles: ["newfolder/a.txt", "newfolder/sub/b.txt"],
+  };
+}
+
+/** What the backend returns for an untracked nested git repo. */
+function nestedRepoDiff(): GitDiff {
+  return {
+    path: "libs/inner/",
+    hunks: [],
+    isDirectory: true,
+    nestedRepo: true,
+    newFiles: [],
+  };
+}
+
+interface MountResult {
+  app: App;
+  container: HTMLDivElement;
+  vm: any;
+}
+
+function mountDiff(props: Record<string, unknown>): MountResult {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const app = createApp(DiffViewer as any, props);
+  const vm = app.mount(container);
+  return { app, container, vm };
+}
+
+function unmount({ app, container }: MountResult) {
+  app.unmount();
+  if (container.parentNode) container.parentNode.removeChild(container);
+}
+
+describe("DiffViewer — untracked directory panel", () => {
+  let mounted: MountResult | null = null;
+
+  afterEach(() => {
+    if (mounted) unmount(mounted);
+    mounted = null;
+  });
+
+  it("lists the files of a plain untracked folder", async () => {
+    mounted = mountDiff({ diff: folderDiff(), filePath: "newfolder/", diffMode: "inline" });
+    await nextTick();
+
+    expect(mounted.container.querySelectorAll(".diff-dir-file").length).toBe(2);
+    expect(mounted.container.querySelector(".diff-nested-repo")).toBeNull();
+  });
+
+  it("shows the nested-repo panel instead of an empty file list", async () => {
+    mounted = mountDiff({ diff: nestedRepoDiff(), filePath: "libs/inner/", diffMode: "inline" });
+    await nextTick();
+
+    const panel = mounted.container.querySelector(".diff-nested-repo");
+    expect(panel).not.toBeNull();
+    // The path is what identifies which folder the panel is about.
+    expect(panel!.textContent).toContain("libs/inner/");
+    // No file rows: those files belong to the other repo, and a row for the
+    // directory itself would just reopen this panel.
+    expect(mounted.container.querySelectorAll(".diff-dir-file").length).toBe(0);
+  });
+
+  it("emits open-repo-tab with the directory path", async () => {
+    let opened: string | null = null;
+    mounted = mountDiff({
+      diff: nestedRepoDiff(),
+      filePath: "libs/inner/",
+      diffMode: "inline",
+      onOpenRepoTab: (path: string) => {
+        opened = path;
+      },
+    });
+    await nextTick();
+
+    mounted.container.querySelector<HTMLButtonElement>(".diff-nested-repo-open")!.click();
+    expect(opened).toBe("libs/inner/");
+  });
+
+  it("emits add-to-gitignore with the directory path", async () => {
+    let ignored: string | null = null;
+    mounted = mountDiff({
+      diff: nestedRepoDiff(),
+      filePath: "libs/inner/",
+      diffMode: "inline",
+      onAddToGitignore: (path: string) => {
+        ignored = path;
+      },
+    });
+    await nextTick();
+
+    mounted.container.querySelector<HTMLButtonElement>(".diff-nested-repo-ignore")!.click();
+    expect(ignored).toBe("libs/inner/");
+  });
+
+  it("renders no hardcoded French copy in the folder panel", async () => {
+    // The panel used to hardcode "Nouveau dossier" and "fichier(s)", which
+    // AGENTS.md forbids: every user-visible string needs a locale key.
+    mounted = mountDiff({ diff: folderDiff(), filePath: "newfolder/", diffMode: "inline" });
+    await nextTick();
+
+    const text = mounted.container.querySelector(".diff-new-dir")!.textContent ?? "";
+    expect(text).not.toContain("Nouveau dossier");
+    expect(text).not.toContain("fichier");
+  });
+});

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -342,6 +342,13 @@ const en = {
 
   // ─── DiffViewer ─────────────────────────────────────────
   diff: {
+    newFolder: "New folder",
+    newFolderCount: "{0} file(s)",
+    nestedRepo: "Nested Git repository",
+    nestedRepoHint:
+      "This folder has its own .git, so Git does not track its contents from here. Add it as a submodule, ignore it, or remove its .git to track the files.",
+    nestedRepoOpen: "Open in a new tab",
+    nestedRepoIgnore: "Add to .gitignore",
     noDiff: "No diff available for this file",
     noDiffHint: "New or binary file",
     selectFile: "Select a file to view the diff",

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -330,6 +330,13 @@ const es: Locale = {
 
   // ─── DiffViewer ─────────────────────────────────────────
   diff: {
+    newFolder: "Carpeta nueva",
+    newFolderCount: "{0} archivo(s)",
+    nestedRepo: "Repositorio Git anidado",
+    nestedRepoHint:
+      "Esta carpeta tiene su propio .git, por lo que Git no rastrea su contenido desde aqu\u00ed. A\u00f1\u00e1dela como subm\u00f3dulo, ign\u00f3rala, o elimina su .git para rastrear los archivos.",
+    nestedRepoOpen: "Abrir en una pesta\u00f1a nueva",
+    nestedRepoIgnore: "A\u00f1adir a .gitignore",
     noDiff: "No hay diff disponible para este archivo",
     noDiffHint: "Archivo nuevo o binario",
     selectFile: "Selecciona un archivo para ver el diff",

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -335,6 +335,13 @@ const fr: Locale = {
 
   // ─── DiffViewer ─────────────────────────────────────────
   diff: {
+    newFolder: "Nouveau dossier",
+    newFolderCount: "{0} fichier(s)",
+    nestedRepo: "D\u00e9p\u00f4t Git imbriqu\u00e9",
+    nestedRepoHint:
+      "Ce dossier poss\u00e8de son propre .git, Git ne suit donc pas son contenu depuis ici. Ajoutez-le en sous-module, ignorez-le, ou supprimez son .git pour suivre les fichiers.",
+    nestedRepoOpen: "Ouvrir dans un nouvel onglet",
+    nestedRepoIgnore: "Ajouter \u00e0 .gitignore",
     noDiff: "Pas de diff disponible pour ce fichier",
     noDiffHint: "Fichier nouveau ou binaire",
     selectFile: "S\u00e9lectionnez un fichier pour voir le diff",

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -331,6 +331,13 @@ const ptBR: Locale = {
 
   // ─── DiffViewer ─────────────────────────────────────────
   diff: {
+    newFolder: "Nova pasta",
+    newFolderCount: "{0} arquivo(s)",
+    nestedRepo: "Reposit\u00f3rio Git aninhado",
+    nestedRepoHint:
+      "Esta pasta tem o pr\u00f3prio .git, ent\u00e3o o Git n\u00e3o rastreia o conte\u00fado dela a partir daqui. Adicione-a como subm\u00f3dulo, ignore-a, ou remova o .git dela para rastrear os arquivos.",
+    nestedRepoOpen: "Abrir em uma nova aba",
+    nestedRepoIgnore: "Adicionar ao .gitignore",
     noDiff: "Nenhum diff disponível para este arquivo",
     noDiffHint: "Arquivo novo ou binário",
     selectFile: "Selecione um arquivo para ver o diff",

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -331,6 +331,13 @@ const zhCN: Locale = {
   },
 
   diff: {
+    newFolder: "\u65b0\u6587\u4ef6\u5939",
+    newFolderCount: "{0} \u4e2a\u6587\u4ef6",
+    nestedRepo: "\u5d4c\u5957 Git \u4ed3\u5e93",
+    nestedRepoHint:
+      "\u8be5\u6587\u4ef6\u5939\u6709\u81ea\u5df1\u7684 .git\uff0c\u56e0\u6b64 Git \u4e0d\u4f1a\u4ece\u8fd9\u91cc\u8ddf\u8e2a\u5176\u5185\u5bb9\u3002\u53ef\u4ee5\u5c06\u5b83\u6dfb\u52a0\u4e3a\u5b50\u6a21\u5757\u3001\u5ffd\u7565\u5b83\uff0c\u6216\u5220\u9664\u5b83\u7684 .git \u4ee5\u8ddf\u8e2a\u8fd9\u4e9b\u6587\u4ef6\u3002",
+    nestedRepoOpen: "\u5728\u65b0\u6807\u7b7e\u9875\u4e2d\u6253\u5f00",
+    nestedRepoIgnore: "\u6dfb\u52a0\u5230 .gitignore",
     noDiff: "此文件没有可用的差异",
     noDiffHint: "新文件或二进制文件",
     selectFile: "选择文件以查看差异",

--- a/apps/desktop/src/utils/backend.ts
+++ b/apps/desktop/src/utils/backend.ts
@@ -516,6 +516,12 @@ export interface GitDiff {
   /** List of new files inside the directory (when isDirectory=true) */
   newFiles?: string[];
   /**
+   * True when the directory carries its own `.git`. Git never looks inside
+   * one, so `newFiles` is empty and the UI shows a dedicated panel rather
+   * than a file list that leads back to this same directory (issue #183).
+   */
+  nestedRepo?: boolean;
+  /**
    * P2.4 — When set, the raw `git diff` output exceeded the backend's
    * truncation threshold (5 MB). Hunks were parsed from the truncated
    * prefix. The value is the *original* byte size, suitable for showing

--- a/apps/desktop/tests/parity/fixtures.mjs
+++ b/apps/desktop/tests/parity/fixtures.mjs
@@ -226,3 +226,34 @@ export function fixtureSubmodule() {
 
   return { cwd, subPath: "libs/inner" };
 }
+
+/**
+ * Fixture "untracked dirs": one never-staged folder with a subfolder, plus a
+ * nested git repo living inside the working tree.
+ *
+ * Covers the two shapes `git_diff` can be handed a directory path for
+ * (issue #183): a plain folder, whose files git lists, and a nested repo,
+ * which git refuses to look inside.
+ */
+export function fixtureUntrackedDirs() {
+  const cwd = mkTempRepo("gw-untracked-dirs-");
+  commitFile(cwd, "README.md", "# Parity Fixture\n", "initial commit", 0);
+  commitFile(cwd, "tracked.txt", "tracked\n", "add tracked.txt", 1);
+
+  // README.md modified, unstaged: a real diff to compare against.
+  // tracked.txt is left untouched: tracked with nothing to show.
+  writeFileSync(join(cwd, "README.md"), "# Parity Fixture\nmodified\n", "utf-8");
+
+  // newdir/: plain untracked folder, one level of nesting.
+  mkdirSync(join(cwd, "newdir", "sub"), { recursive: true });
+  writeFileSync(join(cwd, "newdir", "e.txt"), "epsilon\n", "utf-8");
+  writeFileSync(join(cwd, "newdir", "sub", "f.txt"), "zeta\n", "utf-8");
+
+  // inner/: an independent repo. git never lists its contents from here.
+  const inner = join(cwd, "inner");
+  mkdirSync(inner, { recursive: true });
+  execFileSync("git", ["init", "--initial-branch=main", "--quiet", inner]);
+  writeFileSync(join(inner, "c.txt"), "gamma\n", "utf-8");
+
+  return cwd;
+}

--- a/apps/desktop/tests/parity/git-diff.test.mjs
+++ b/apps/desktop/tests/parity/git-diff.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * Parity tests: `git_diff` (Rust) vs `/api/git-diff` (Node dev-server), for
+ * the case where the requested path is a *directory* rather than a file.
+ *
+ * Run: `pnpm --filter @gitwand/desktop test:parity`
+ *
+ * Prerequisite: the Rust probe must be built at least once
+ *   cargo build --example parity-probe
+ * (see README.md in this folder).
+ *
+ * Why this file exists: the directory branch lived only in the dev-server for
+ * several releases, so clicking an untracked folder worked under `dev:web` and
+ * showed an empty panel in the packaged app (issue #183). Parity coverage is
+ * what turns that class of drift into a red test instead of a bug report.
+ */
+
+import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { startDevServer } from "./dev-server-runner.mjs";
+import { assertParity } from "./harness.mjs";
+import { fixtureUntrackedDirs } from "./fixtures.mjs";
+
+describe("parity: git-diff on a directory", () => {
+  /** @type {Awaited<ReturnType<typeof startDevServer>>} */
+  let dev;
+
+  beforeAll(async () => {
+    dev = await startDevServer();
+  }, 15_000);
+
+  afterAll(async () => {
+    await dev?.stop();
+  });
+
+  it("a plain untracked folder lists the files inside it", async () => {
+    const cwd = fixtureUntrackedDirs();
+    const { rust, node } = await assertParity(dev, {
+      command: "git-diff",
+      args: { cwd, path: "newdir/", staged: false },
+      httpPath: `/api/git-diff?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent("newdir/")}`,
+    });
+
+    for (const side of [rust, node]) {
+      expect(side.isDirectory).toBe(true);
+      expect(side.hunks).toEqual([]);
+      expect([...side.newFiles].sort()).toEqual(["newdir/e.txt", "newdir/sub/f.txt"]);
+      expect(side.nestedRepo).toBeUndefined();
+    }
+  });
+
+  it("a nested git repo is reported as such, with no file list", async () => {
+    const cwd = fixtureUntrackedDirs();
+    const { rust, node } = await assertParity(dev, {
+      command: "git-diff",
+      args: { cwd, path: "inner/", staged: false },
+      httpPath: `/api/git-diff?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent("inner/")}`,
+    });
+
+    for (const side of [rust, node]) {
+      expect(side.isDirectory).toBe(true);
+      expect(side.nestedRepo).toBe(true);
+      // Its files belong to the other repo. Offering them here would produce
+      // a row that reopens this same panel.
+      expect(side.newFiles ?? []).toEqual([]);
+    }
+  });
+
+  it("a modified file still produces a real diff", async () => {
+    const cwd = fixtureUntrackedDirs();
+    const { rust, node } = await assertParity(dev, {
+      command: "git-diff",
+      args: { cwd, path: "README.md", staged: false },
+      httpPath: `/api/git-diff?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent("README.md")}`,
+    });
+
+    for (const side of [rust, node]) {
+      expect(side.isDirectory).toBeUndefined();
+      expect(side.nestedRepo).toBeUndefined();
+      expect(side.hunks.length).toBeGreaterThan(0);
+    }
+  });
+
+  // Regression for a second drift this file caught: the dev-server ran its
+  // `--no-index` fallback on any path with an empty `git diff`, so a tracked
+  // file with nothing to show came back as an all-green whole-file addition.
+  // The Rust side has always guarded that with `ls-files --error-unmatch`.
+  it("a tracked file with no change reports no hunks on either side", async () => {
+    const cwd = fixtureUntrackedDirs();
+    const { rust, node } = await assertParity(dev, {
+      command: "git-diff",
+      args: { cwd, path: "tracked.txt", staged: false },
+      httpPath: `/api/git-diff?cwd=${encodeURIComponent(cwd)}&path=${encodeURIComponent("tracked.txt")}`,
+    });
+
+    expect(rust.hunks).toEqual([]);
+    expect(node.hunks).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #183.

## The defect

The branch that turns an untracked directory path into a file list existed only in the Node dev-server, and `GitDiff` carried no `isDirectory` / `newFiles` fields on the Rust side even though `backend.ts` had declared them for releases. Clicking such an entry worked under `pnpm dev:web` and showed an empty panel in the shipped app.

`git_diff` now branches on the trailing slash, guarded by `safe_repo_path`, which also short-circuits the `--no-index` fallback that was spawning two git processes for nothing on a directory path.

## The nested-repo panel

A directory carrying its own `.git` is not listed as files, because `git ls-files --others` answers with the directory itself:

```
$ git ls-files --others --exclude-standard .../inner
inner/
```

A file row built from that would call `git_diff("inner/")` and reopen the same panel. It is reported as `nestedRepo` instead, and `DiffViewer` renders a panel that names the situation and offers the two actions the app can actually perform: open it as its own repo tab (the same treatment as a submodule, via `openTab`), or add it to `.gitignore`. "Add as submodule" was deliberately left out: `git submodule add` needs a URL, and a hand-init'd nested repo usually has no remote.

Since #182 switches `git status` to `--untracked-files=all`, a nested repo is the only directory entry the sidebar can still produce. The plain-folder branch is kept anyway, because the dev-server has it and any divergence is a fresh drift.

## What the parity coverage bought

`git_diff` was absent from `parity_probe.rs`, which is how four drifts accumulated unnoticed in one command. Three of them fell out of the new `tests/parity/git-diff.test.mjs` on its first run rather than out of a bug report:

- **`git_add_to_gitignore` was never registered as a Tauri command.** `backend.ts` has invoked it since the context-menu action shipped, so "Add to .gitignore" has been throwing in the packaged app the whole time, and the new button would have inherited that. Implemented in Rust with the dev-server's semantics (create if absent, never duplicate, always leave a trailing newline) plus a refusal for a multi-line entry, which would otherwise write rules nobody asked for. The same guard was mirrored into the dev-server route.
- **A phantom context line on every diff under `dev:web`.** The parser classified context lines with `!line.startsWith("\\")`, which lets through the empty string `split("\n")` leaves after the trailing newline. That is verbatim the gotcha `AGENTS.md` documents; the Rust parser (`strip_prefix(' ')`) never had it.
- **An unmodified tracked file rendered as an all-green whole-file addition under `dev:web`.** The `--no-index` fallback ran for any path whose `git diff` came back empty. It now checks `ls-files --error-unmatch` first, the guard the Rust side has always had.

## i18n

The folder panel hardcoded `Nouveau dossier` and `fichier(s)` in French, against the i18n rule. Six `diff.*` keys now cover it and the nested-repo panel, translated in all 5 locales rather than left as English placeholders, since the repo carries no `// TODO: translate` markers today.

## Tests

Every test was watched failing first.

- Rust, real temp repos: a plain untracked folder lists its files, a nested repo reports `nestedRepo` with no list, a file path is unaffected by the new branch, and four cases for the `.gitignore` append including the multi-line refusal.
- Parity: `tests/parity/git-diff.test.mjs`, four cases over a new `fixtureUntrackedDirs`, with per-side assertions rather than parity alone, which would pass with both backends agreeing and both wrong.
- `DiffViewer-nested-repo.test.ts`: five cases over the mounted component, including both emits and a guard against the French copy coming back.
- Verified: `cargo test --lib` 259/259, `pnpm test:parity` 32/32, desktop `pnpm test` 1065/1065, `vue-tsc` clean, `cargo fmt` and `clippy` clean.
- Manual check under `pnpm dev:web`: folder panel, nested panel, both buttons, and the diff of a new file with no trailing phantom row.

## Review notes

- Branched off `main`, so it reviews independently of #182. The two touch `tests/parity/fixtures.mjs` in different places; whichever lands second may need a trivial rebase.
- In list layout a nested-repo row still shows a blank name. That label fix lives in #182, not here.
