### PR TITLE
fix(desktop): stop one unreadable file blocking every conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **One unreadable file made every conflict in the repo unresolvable.** Selecting a conflicted file opened the read-only diff instead of the merge editor, with no way to reach resolution at all: the sidebar listed N conflicts and the banner asked the user to resolve them, while nothing could be opened. `loadRealFiles` read every unmerged path inside a single `Promise.all`, and `read_file` is `std::fs::read_to_string`, which rejects any file that is not valid UTF-8. A minified build artifact or a Latin-1 source therefore rejected the whole batch, `openPath` caught it and called `loadDemoData()`, and the merge editor ended up holding fabricated demo paths, so the lookup for the real file returned null and `App.vue` fell through to `DiffViewer`. Each file now loads in isolation, and a failure degrades only itself. The demo set is also no longer used as an error handler for a real repository: replacing a user's conflicts with invented files hid the failure instead of reporting it.
+- **A conflicted file GitWand cannot decode now has a panel of its own.** It stays in the list, because git still counts it and the rebase will not continue until it is settled, and it offers the two side-picks plus opening it externally. Both picks go through `git checkout --ours/--theirs`, which operates on the raw bytes and never needs to decode the file.
+
 ## [3.10.0] - 2026-09-09
 
 ### Added

--- a/apps/desktop/src/App.vue
+++ b/apps/desktop/src/App.vue
@@ -4067,7 +4067,8 @@ onUnmounted(() => {
                   @apply-file-memory="(path, entry) => handleApplyFileMemory(path, entry)"
                   @resolve-tree-conflict="(path, choice) => handleResolveTreeConflict(path, choice)"
                   @reconstruct-conflict="(path) => handleReconstructConflict(path)"
-                  @keep-working-tree="(path) => handleKeepWorkingTree(path)" />
+                  @keep-working-tree="(path) => handleKeepWorkingTree(path)"
+                  @open-externally="(path) => handleOpenInEditor(path)" />
                 <FileHistoryViewer v-else-if="fileHistoryPath && repoFolderPath" :file-path="fileHistoryPath"
                   :cwd="repoFolderPath" @close="closeFileHistory"
                   @select-commit="(hash) => { closeFileHistory(); selectCommit(hash); viewMode = 'history'; }" />

--- a/apps/desktop/src/components/MergeEditor.vue
+++ b/apps/desktop/src/components/MergeEditor.vue
@@ -52,6 +52,8 @@ const emit = defineEmits<{
   resolveTreeConflict: [path: string, choice: "ours" | "theirs" | "delete"];
   reconstructConflict: [path: string];
   keepWorkingTree: [path: string];
+  /** Conflicted file GitWand cannot decode: hand it to the user's own editor. */
+  openExternally: [path: string];
 }>();
 
 // ─── Inline Edit State ──────────────────────────────────
@@ -831,8 +833,33 @@ useResizeObserver(contentEl, drawMinimap);
       </template>
     </div>
 
+    <!--
+      Unreadable conflict: git says the file is unmerged but its bytes could not
+      be decoded (read_file is read_to_string, so any non-UTF-8 file lands here).
+      There is no text to show hunks for, but the file still blocks the rebase,
+      so both side-picks are offered: they run `git checkout --ours/--theirs`,
+      which works on bytes and never needs to decode anything.
+    -->
+    <div v-if="file.loadError" class="me-tree-panel">
+      <h3 class="me-tree-title">{{ t('merge.unreadableTitle') }} — <span class="mono">{{ file.path }}</span></h3>
+      <p class="me-tree-explanation">{{ t('merge.unreadableExplanation') }}</p>
+      <div class="me-tree-actions">
+        <button class="me-bulk-btn" @click="emit('resolveTreeConflict', file.path, 'ours')">
+          {{ t('merge.unreadableKeepOurs') }}
+        </button>
+        <button class="me-bulk-btn" @click="emit('resolveTreeConflict', file.path, 'theirs')">
+          {{ t('merge.unreadableKeepTheirs') }}
+        </button>
+        <button class="me-bulk-btn" @click="emit('openExternally', file.path)">
+          {{ t('merge.unreadableOpenExternally') }}
+        </button>
+      </div>
+      <div class="me-tree-preview-label muted">{{ t('merge.unreadableReasonLabel') }}</div>
+      <pre class="me-tree-preview">{{ file.loadError }}</pre>
+    </div>
+
     <!-- Editor body: code + minimap -->
-    <div class="merge-body" v-if="!file.tree && !file.markerless">
+    <div class="merge-body" v-if="!file.tree && !file.markerless && !file.loadError">
       <div v-if="file.reconstructed" class="me-reconstructed-banner">
         <svg width="13" height="13" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M8 1a7 7 0 100 14A7 7 0 008 1zm.75 10.5h-1.5v-1.5h1.5v1.5zm0-3h-1.5V4.5h1.5V8.5z"/>

--- a/apps/desktop/src/composables/__tests__/useGitWand-conflict-load-isolation.test.ts
+++ b/apps/desktop/src/composables/__tests__/useGitWand-conflict-load-isolation.test.ts
@@ -1,0 +1,127 @@
+/**
+ * A conflicted file the app cannot read must not take the whole merge editor
+ * down with it.
+ *
+ * `loadRealFiles` reads every unmerged path inside one `Promise.all`, and
+ * `read_file` on the Rust side is `std::fs::read_to_string`, which rejects any
+ * file that is not valid UTF-8 (a minified build artifact, a Latin-1 source
+ * file). One rejection therefore rejects the whole batch, `openPath` catches
+ * it and calls `loadDemoData()`, and the merge editor ends up holding *demo*
+ * paths. `App.vue` renders `MergeEditor` only on
+ * `showingMergeEditor && mergeSelectedFile`, so the real conflicted path is no
+ * longer in `files`, the lookup returns null, and the view silently falls
+ * through to the read-only `DiffViewer`: the sidebar lists N conflicts that
+ * the user cannot open.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { readFileMock, CONFLICTED } = vi.hoisted(() => {
+  /** A perfectly ordinary content conflict, the kind the engine handles daily. */
+  const CONFLICTED = [
+    "<?php",
+    "return [",
+    "<<<<<<< HEAD",
+    "  'last_update' => '2026-09-09 12:22:00',",
+    "=======",
+    "  'last_update' => '2026-09-09 07:29:00',",
+    ">>>>>>> origin/master",
+    "];",
+  ].join("\n");
+  return {
+    CONFLICTED,
+    readFileMock: vi.fn(async (_cwd: string, path: string) => {
+      if (path === "public/build/bundle.js") {
+        throw new Error(
+          "Failed to read public/build/bundle.js: stream did not contain valid UTF-8",
+        );
+      }
+      return CONFLICTED;
+    }),
+  };
+});
+
+vi.mock("@/utils/backend", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/utils/backend")>();
+  return {
+    ...actual,
+    pickFolder: vi.fn(),
+    getConflictedFiles: vi.fn(async () => ["config/dendreo.php", "public/build/bundle.js"]),
+    readFile: readFileMock,
+    writeFile: vi.fn(),
+    readGitwandrc: vi.fn(async () => ""),
+    getTreeConflicts: vi.fn(async () => []),
+    reconstructConflict: vi.fn(async () => {
+      throw new Error("no recoverable stage");
+    }),
+    gitRepoState: vi.fn(async () => ({ state: "rebase", targetBranch: "feat/x" })),
+    resolveTreeConflict: vi.fn(),
+    gitStage: vi.fn(),
+  };
+});
+
+vi.mock("../../utils/coreEngine", () => ({
+  engine: async () => {
+    const core = await import("@gitwand/core");
+    return {
+      resolve: (c: string, p: string, o?: unknown) => core.resolve(c, p, o as never),
+      resolveAsync: (c: string, p: string, o?: unknown) => core.resolveAsync(c, p, o as never),
+      parseConflictMarkers: (c: string) => core.parseConflictMarkers(c),
+    };
+  },
+}));
+
+import { useGitWand } from "../useGitWand";
+
+describe("loadRealFiles: one unreadable conflicted file", () => {
+  beforeEach(() => {
+    readFileMock.mockClear();
+  });
+
+  it("still exposes the conflicted files it COULD read", async () => {
+    const gw = useGitWand();
+    await gw.openPath("/repo");
+
+    const paths = gw.files.value.map((f) => f.path);
+    expect(paths).toContain("config/dendreo.php");
+  });
+
+  it("never swaps a real repo's conflicts for demo data", async () => {
+    const gw = useGitWand();
+    await gw.openPath("/repo");
+
+    const paths = gw.files.value.map((f) => f.path);
+    // `loadDemoData()` seeds these fabricated paths. Showing them for a real
+    // repo is worse than showing nothing: they are not the user's files.
+    expect(paths).not.toContain("src/components/Header.tsx");
+  });
+
+  it("keeps the unreadable file in the list, so the editor matches git's count", async () => {
+    const gw = useGitWand();
+    await gw.openPath("/repo");
+
+    // Dropping it would desync the sidebar ("4 conflicts") from what the editor
+    // can open, and git will not let the rebase continue until it is settled.
+    const bad = gw.files.value.find((f) => f.path === "public/build/bundle.js");
+    expect(bad).toBeDefined();
+    expect(bad?.loadError).toMatch(/valid UTF-8/);
+  });
+
+  it("keeps the readable file free of any load error", async () => {
+    const gw = useGitWand();
+    await gw.openPath("/repo");
+
+    const ok = gw.files.value.find((f) => f.path === "config/dendreo.php");
+    expect(ok?.loadError).toBeUndefined();
+  });
+
+  it("keeps the readable file selectable, which is what gates the MergeEditor", async () => {
+    const gw = useGitWand();
+    await gw.openPath("/repo");
+    gw.selectFile("config/dendreo.php");
+
+    // App.vue renders MergeEditor on `showingMergeEditor && mergeSelectedFile`.
+    // A null here is exactly the silent fall-through to the read-only DiffViewer.
+    expect(gw.selectedFile.value).not.toBeNull();
+    expect(gw.selectedFile.value?.result.stats.totalConflicts).toBeGreaterThan(0);
+  });
+});

--- a/apps/desktop/src/composables/useGitWand.ts
+++ b/apps/desktop/src/composables/useGitWand.ts
@@ -92,6 +92,17 @@ export interface ConflictFile {
    * The ours/theirs content shown to the user is unchanged; only the base was added.
    */
   baseEnriched?: boolean;
+  /**
+   * Set when the file is genuinely unmerged but its content could not be loaded
+   * — `read_file` is `read_to_string`, so any file that is not valid UTF-8 (a
+   * minified build artifact, a Latin-1 source) fails here. The entry is kept in
+   * the list rather than dropped: git still counts it as a conflict, the rebase
+   * will not continue until it is settled, and the sidebar count has to keep
+   * matching what the editor offers. It renders a dedicated panel that resolves
+   * the file at the git level (`checkout --ours/--theirs`), which needs no
+   * decoding at all.
+   */
+  loadError?: string;
 }
 
 export interface GlobalStats {
@@ -438,7 +449,14 @@ export function useGitWand() {
     } catch (err: any) {
       console.error("openPath error:", err);
       error.value = err.message ?? "Erreur inconnue";
-      await loadDemoData();
+      // Deliberately NOT loadDemoData() here. The demo set is a first-run
+      // affordance; using it as an error handler silently replaced a real
+      // repo's conflicts with fabricated paths (src/components/Header.tsx et
+      // al), so the failure surfaced as "the merge editor shows files I have
+      // never seen" or, worse, as nothing at all. An empty list plus `error`
+      // is honest, and lets the caller show why.
+      files.value = [];
+      selectedPath.value = null;
     } finally {
       loading.value = false;
     }
@@ -582,8 +600,32 @@ export function useGitWand() {
     // resolution of the app's lifetime.
     const core = await engine();
 
+    // Per-file isolation is load-bearing, not defensive politeness. Every path
+    // below can reject — `readFile` on a non-UTF-8 file, a worker RPC, a
+    // reconstruct — and a single rejection inside `Promise.all` used to reject
+    // the whole batch, which `openPath` caught by swapping in demo data. The
+    // net effect was that one unreadable build artifact made *every* conflict
+    // in the repo unresolvable, because `selectedFile` could no longer find the
+    // real path and `App.vue` fell through to the read-only DiffViewer. A file
+    // that cannot be loaded now degrades to its own entry, and only its own.
     const loaded: ConflictFile[] = await Promise.all(
-      allPaths.map(async (filePath) => {
+      allPaths.map(async (filePath): Promise<ConflictFile> => {
+        try {
+          return await loadOneConflict(filePath);
+        } catch (err: any) {
+          console.warn(`[gitwand] could not load conflicted file ${filePath}`, err);
+          return {
+            path: filePath,
+            content: "",
+            result: await core.resolveAsync("", filePath, resolveOptionsWithLlm, aiEndpointProxy),
+            loadError: err?.message ?? String(err),
+          };
+        }
+      }),
+    );
+
+    async function loadOneConflict(filePath: string): Promise<ConflictFile> {
+      {
         const tc = treeMap.get(filePath);
         if (tc) {
           // Tree conflict: do not parse markers. Read working-tree content best-effort (for preview).
@@ -661,8 +703,8 @@ export function useGitWand() {
           } catch { /* not reconstructable → fall through to plain result */ }
         }
         return { path: filePath, content, result };
-      }),
-    );
+      }
+    }
 
     files.value = loaded;
     if (loaded.length > 0) {

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -785,6 +785,12 @@ const en = {
     markerlessExplanation: "Git records a conflict for this file, but the working copy has no conflict markers and matches neither side.",
     reconstructConflict: "Reconstruct conflict",
     keepWorkingTree: "Keep my version (stage as-is)",
+    unreadableTitle: "File cannot be read as text",
+    unreadableExplanation: "Git reports this file as conflicted, but its contents are not valid UTF-8 text, so there are no hunks to show. It is usually a build artifact or a binary. You can still settle it by taking one side wholesale, which operates on the raw bytes, or open it in your own editor.",
+    unreadableKeepOurs: "Keep our version",
+    unreadableKeepTheirs: "Keep their version",
+    unreadableOpenExternally: "Open in external editor",
+    unreadableReasonLabel: "Reason reported",
   },
 
   // ─── PR creation ────────────────────────────────────────

--- a/apps/desktop/src/locales/es.ts
+++ b/apps/desktop/src/locales/es.ts
@@ -773,6 +773,12 @@ const es: Locale = {
     markerlessExplanation: "Git registra un conflicto para este archivo, pero la copia de trabajo no tiene marcadores y no coincide con ningún lado.",
     reconstructConflict: "Reconstruir conflicto",
     keepWorkingTree: "Mantener mi versión (preparar tal cual)",
+    unreadableTitle: "El archivo no se puede leer como texto",
+    unreadableExplanation: "Git informa de un conflicto en este archivo, pero su contenido no es texto UTF-8 válido, así que no hay bloques que mostrar. Suele ser un artefacto de compilación o un binario. Aun así puedes resolverlo tomando un lado completo, lo que opera sobre los bytes en bruto, o abrirlo en tu propio editor.",
+    unreadableKeepOurs: "Mantener nuestra versión",
+    unreadableKeepTheirs: "Mantener su versión",
+    unreadableOpenExternally: "Abrir en un editor externo",
+    unreadableReasonLabel: "Motivo informado",
   },
 
   // ─── PR creation ────────────────────────────────────────

--- a/apps/desktop/src/locales/fr.ts
+++ b/apps/desktop/src/locales/fr.ts
@@ -778,6 +778,12 @@ const fr: Locale = {
     markerlessExplanation: "Git enregistre un conflit pour ce fichier, mais la copie de travail n'a pas de marqueurs et ne correspond à aucun des deux côtés.",
     reconstructConflict: "Reconstruire le conflit",
     keepWorkingTree: "Garder ma version (stager tel quel)",
+    unreadableTitle: "Fichier illisible en tant que texte",
+    unreadableExplanation: "Git signale ce fichier comme étant en conflit, mais son contenu n'est pas du texte UTF-8 valide : il n'y a donc aucun bloc à afficher. C'est le plus souvent un artefact de build ou un binaire. Vous pouvez quand même le régler en prenant un côté en entier, ce qui travaille sur les octets bruts, ou l'ouvrir dans votre propre éditeur.",
+    unreadableKeepOurs: "Garder notre version",
+    unreadableKeepTheirs: "Garder leur version",
+    unreadableOpenExternally: "Ouvrir dans l'éditeur externe",
+    unreadableReasonLabel: "Raison signalée",
   },
 
   // ─── PR creation ────────────────────────────────────────

--- a/apps/desktop/src/locales/pt-BR.ts
+++ b/apps/desktop/src/locales/pt-BR.ts
@@ -774,6 +774,12 @@ const ptBR: Locale = {
     markerlessExplanation: "O Git registra um conflito para este arquivo, mas a cópia de trabalho não tem marcadores e não corresponde a nenhum dos lados.",
     reconstructConflict: "Reconstruir conflito",
     keepWorkingTree: "Manter minha versão (preparar como está)",
+    unreadableTitle: "O arquivo não pode ser lido como texto",
+    unreadableExplanation: "O Git relata este arquivo como em conflito, mas o conteúdo não é texto UTF-8 válido, portanto não há blocos para exibir. Costuma ser um artefato de build ou um binário. Você ainda pode resolvê-lo escolhendo um lado inteiro, o que opera sobre os bytes brutos, ou abri-lo no seu próprio editor.",
+    unreadableKeepOurs: "Manter nossa versão",
+    unreadableKeepTheirs: "Manter a versão deles",
+    unreadableOpenExternally: "Abrir no editor externo",
+    unreadableReasonLabel: "Motivo relatado",
   },
 
   // ─── PR creation ────────────────────────────────────────

--- a/apps/desktop/src/locales/zh-CN.ts
+++ b/apps/desktop/src/locales/zh-CN.ts
@@ -763,6 +763,12 @@ const zhCN: Locale = {
     markerlessExplanation: "Git 为此文件记录了冲突，但工作副本没有冲突标记，且与任何一方都不匹配。",
     reconstructConflict: "重建冲突",
     keepWorkingTree: "保留我的版本（直接暂存）",
+    unreadableTitle: "无法以文本方式读取该文件",
+    unreadableExplanation: "Git 报告此文件存在冲突，但其内容不是有效的 UTF-8 文本，因此没有可显示的区块。这通常是构建产物或二进制文件。你仍然可以整体保留其中一方来解决它（该操作直接作用于原始字节），或在你自己的编辑器中打开它。",
+    unreadableKeepOurs: "保留我方版本",
+    unreadableKeepTheirs: "保留对方版本",
+    unreadableOpenExternally: "在外部编辑器中打开",
+    unreadableReasonLabel: "报告的原因",
   },
 
   pr: {


### PR DESCRIPTION
Reported from a real rebase: the conflict list showed 4 files and the banner asked for them to be resolved, but selecting any of them opened the read-only diff instead of the merge editor. There was no route to resolution at all.

## Root cause

Not a UI problem. A cascade:

```
a conflicted file fails to read
  └─ Promise.all in loadRealFiles rejects            useGitWand.ts:585,602
      └─ openPath catches → loadDemoData()           useGitWand.ts:438
          └─ files holds fabricated demo paths
              └─ selectedFile(real path) → null      useGitWand.ts:378
                  └─ MergeEditor v-if fails → DiffViewer v-else   App.vue:4063,4082
```

`read_file` is `std::fs::read_to_string` (`files.rs:23`), which rejects any file that is not valid UTF-8. The reported repo had `public/build/peppol-embed.js` and `public/build/manifest.json` among its conflicts. One of those rejected the whole batch and took down `config/dendreo.php` with it, a one-line conflict the engine resolves on its own.

That accounts for every detail of the report, including why the sidebar still showed the right count: it reads `git status`, a different source from the one the merge editor uses.

## Changes

- **Per-file isolation.** A path that fails to load degrades only its own entry.
- **`loadDemoData()` is no longer an error handler for a real repository.** It is a first-run affordance; using it on failure silently replaced the user's conflicts with invented paths, which hid the failure instead of reporting it. Now: empty list plus `error`.
- **A dedicated panel for a file that cannot be decoded.** It stays in the list, because git still counts it and the rebase will not continue until it is settled, and dropping it would desync the sidebar count from what the editor can open. It offers both side-picks and open-externally. The picks reuse `resolve_tree_conflict`, i.e. `git checkout --ours/--theirs`, which operates on raw bytes and never decodes. No new backend command, no new dev-server route, no parity surface.

## Tests

Every test was watched failing first. The assertion that proves the diagnosis is `src/components/Header.tsx` appearing in the file list: that path only exists in the demo data.

- `useGitWand-conflict-load-isolation.test.ts`, 5 cases: the readable file survives an unreadable sibling, no demo substitution, the unreadable file keeps its entry with a reason, the readable one carries no error, and the readable one stays selectable (which is literally the `MergeEditor` gate).
- 1123/1123 desktop tests, `vue-tsc` clean.
- 6 `merge.*` keys translated in all 5 locales (2287 keys each). The repo carries no `// TODO: translate` markers, so these are real translations rather than English placeholders.

## Manual QA

Driven in a real browser via `pnpm dev:web`, on a real paused rebase with two conflicts, one readable and one unreadable:

- the readable conflict opens in the merge editor **while the unreadable sibling is present**, which is exactly the case that used to fail
- the panel renders correctly in both English and French
- "keep our version" was clicked and verified against git: the file disappeared from `git diff --name-only --diff-filter=U`, leaving only the other conflict

## Worth knowing

**This bug cannot be reproduced under `pnpm dev:web`.** The dev-server uses `readFileSync(path, "utf-8")`, which never throws and substitutes `U+FFFD`, so a non-UTF-8 file loads fine there and the cascade never fires. That Rust/Node divergence is why the bug survived manual QA, and it is filed separately as #185 rather than folded in here. The QA above uses `chmod 000`, a failure mode both backends share.

While running the suite I also hit nondeterministic failures on a clean `main`; filed as #186. They are unrelated to this change, and I verified that by stashing the work and re-running against an untouched tree.