### PR TITLE
ci: check that the packaged .deb actually launches (#139)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -396,3 +396,71 @@ jobs:
             apps/desktop/src-tauri/target/ci/bundle/**/*.deb
             apps/desktop/src-tauri/target/ci/bundle/**/*.AppImage
           if-no-files-found: warn
+
+  # Does the packaged .deb actually start?
+  #
+  # Issue #139 ("Cannot open the App | deb | Linux Mint 22"): a user installed
+  # the .deb and the app never appeared. Nothing in CI covered that. rust-check
+  # compiles, bundle-smoke proves the bundler still produces a package, and
+  # neither one ever runs the thing. The gap is the same shape as the rest of
+  # #188: a green pipeline that never asserts the effect users care about.
+  #
+  # Deliberately on ubuntu-24.04, not the 22.04 the bundle is built on: Linux
+  # Mint 22 is Ubuntu 24.04 (noble), and "builds on jammy, refuses to start on
+  # noble" is exactly the failure class #139 reports. Running it on the build
+  # distro would test nothing.
+  #
+  # `.desktop` ships `Terminal=false`, so a GUI launch discards stderr and the
+  # user sees nothing at all — which is why #139 arrived with no diagnostics
+  # and sat for a month. This job captures that output.
+  deb-launch-smoke:
+    name: .deb installs and launches (ubuntu-24.04)
+    needs: bundle-smoke
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download the .deb built by bundle-smoke
+        uses: actions/download-artifact@v4
+        with:
+          name: bundle-smoke-ubuntu-22.04
+          path: bundle
+
+      - name: Install it the way a user would
+        run: |
+          set -euxo pipefail
+          # Same third-party apt source removal as every other Linux step here:
+          # Google's Chrome repo served a mismatched index on 2026-09-09 and
+          # took down every Ubuntu job in the repo (issue #188).
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.list \
+                     /etc/apt/sources.list.d/google-chrome-*.list \
+                     /etc/apt/sources.list.d/*google*.sources
+          sudo apt-get update
+          DEB=$(find bundle -name '*.deb' | head -1)
+          [ -n "$DEB" ] || { echo "::error::bundle-smoke produced no .deb to test"; exit 1; }
+          echo "testing $DEB"
+          # `apt-get install ./file.deb` resolves declared dependencies from the
+          # noble archives, which is what a user double-clicking the file gets.
+          sudo apt-get install -y "./$DEB"
+          sudo apt-get install -y xvfb
+
+      - name: Launch it headless and require it to stay up
+        run: |
+          set -uo pipefail
+          export RUST_BACKTRACE=full
+          # A GUI app has no "success" exit code: staying alive IS the success.
+          # `timeout` returns 124 when it has to kill a still-running process,
+          # so 124 is what we want and anything else means it died on its own.
+          set +e
+          timeout 20 xvfb-run -a -s "-screen 0 1280x800x24" \
+            gitwand-desktop > launch.log 2>&1
+          code=$?
+          set -e
+          echo "--- captured output ---"
+          cat launch.log || true
+          echo "--- exit code: $code ---"
+          if [ "$code" = "124" ]; then
+            echo "::notice::gitwand-desktop was still running after 20s — it starts."
+            exit 0
+          fi
+          echo "::error::gitwand-desktop exited on its own with code $code instead of staying up."
+          echo "::error::That is issue #139's symptom: the .deb installs and the app never appears."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CI now checks that the packaged `.deb` actually starts.** Nothing did: `rust-check` compiles, `bundle-smoke` proves the bundler still produces a package, and neither ever ran the result. A new job installs the built `.deb` on **ubuntu-24.04** (Linux Mint 22's base, deliberately not the 22.04 it is built on) and launches it headless, failing unless the process is still alive after 20 seconds, since a GUI app has no success exit code. It captures the output a real GUI launch throws away: the `.desktop` entry ships `Terminal=false`, which is why #139 arrived with no diagnostics at all and sat unresolvable for a month.
+
 ### Fixed
 
 - **The dev-server accepted files the packaged app refuses.** `read_file` is `std::fs::read_to_string` in Rust, which rejects anything that is not valid UTF-8, while the dev-server's `readFileSync(path, "utf-8")` silently substituted `U+FFFD` and returned success. The two "worked" differently, which is worse than one of them failing: a non-UTF-8 file among a repository's conflicts made every conflict unresolvable in the packaged app while the same repository loaded fine under `pnpm dev:web`, so the bug could not be reproduced in the environment used for manual QA. The dev-server now decodes strictly and returns the same error string, and a new `tests/parity/read-file.test.mjs` asserts the two backends **refuse** the same input for the same reason, not merely that they accept the same input.


### PR DESCRIPTION
Refs #139.

## What I found

I could not reproduce #139 with the current build. In a real `ubuntu:24.04` container (Linux Mint 22's base), the shipped `GitWand_3.10.1_amd64.deb`:

- installs cleanly, dependencies resolving from the noble archives
- launches under `xvfb` and is still running 20s later, with no output and no abort

So the v3.6.1 software-rendering work (`WEBKIT_DISABLE_COMPOSITING_MODE`, `WEBKIT_DISABLE_DMABUF_RENDERER`, `LIBGL_ALWAYS_SOFTWARE`, `GDK_BACKEND=x11`) appears to hold on Mint 22's base, and the report predates it. **That is evidence, not proof**: a container with xvfb does not exercise Wayland, the host's AppArmor `restrict_unprivileged_userns` (Ubuntu 24.04 restricts the user namespaces WebKitGTK's sandbox wants), or real GPU/EGL negotiation. I have said as much on the issue rather than closing it on my own evidence.

## What this PR changes

The reason #139 sat for a month is not that it was hard. It is that **no diagnostics ever arrived**, and none could: the `.desktop` entry ships `Terminal=false`, so a user launching from the menu sees nothing at all, and the maintainer's request for `RUST_BACKTRACE=full` output went unanswered.

Meanwhile nothing in CI ever ran the packaged app. `rust-check` compiles it, `bundle-smoke` proves the bundler still emits a package, and neither one starts it.

New job `deb-launch-smoke`:

- takes the `.deb` `bundle-smoke` already uploads
- installs it the way a user does (`apt-get install ./file.deb`, so declared deps resolve)
- runs it headless on **ubuntu-24.04**, deliberately not the 22.04 it is built on — Mint 22 is noble, and "builds on jammy, refuses to start on noble" is exactly the reported failure class, so testing on the build distro would test nothing
- requires the process to still be alive after 20s. A GUI app has no success exit code, so staying up is the assertion: `timeout` returns 124 when it kills a live process, and anything else means it died
- prints the captured output either way, which is precisely what a GUI launch throws away

## Verified both directions

A check that cannot fail is not a check, so I ran the exact script in a real `ubuntu:24.04` container:

| Case | Exit | Result |
|---|---|---|
| Shipped v3.10.1 binary | 124 | pass |
| Stub aborting like an EGL failure (`EGL_BAD_PARAMETER. Aborting...`) | 134 | **fail**, output captured |

## Why it belongs with the #188 work

Same shape: the pipeline was green while never asserting the thing users depend on. `bundle-smoke` answers "did the bundler run", not "does the app open". This job answers the second question, which is the one #139 is about.