### PR TITLE
ci: publish gitwand-bin to the AUR on release (#100)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -442,3 +442,96 @@ jobs:
             --submit `
             --token $env:WINGET_TOKEN
           Write-Host "::notice::Submitted Devlint.GitWand $version to microsoft/winget-pkgs"
+
+  # Publish gitwand-bin to the Arch User Repository.
+  #
+  # Original work by @t1gu1 in #100, rebased onto the current release.yml and
+  # hardened before landing (secret guard, pinned action, PKGBUILD test).
+  publish-aur:
+    name: Publish to AUR
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # The AUR secrets can only be created by the repo owner (they require an
+      # AUR account and an SSH key uploaded to it). Without this guard the job
+      # would fail every release until they exist, which is how a distribution
+      # nicety turns into a broken pipeline. Same shape as the Homebrew job
+      # above: absent credentials skip the step, they do not fail the release.
+      - name: Check AUR credentials
+        id: creds
+        env:
+          AUR_SSH_PRIVATE_KEY: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          AUR_USERNAME: ${{ secrets.AUR_USERNAME }}
+          AUR_EMAIL: ${{ secrets.AUR_EMAIL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AUR_SSH_PRIVATE_KEY:-}" ] || [ -z "${AUR_USERNAME:-}" ] || [ -z "${AUR_EMAIL:-}" ]; then
+            echo "::warning::AUR_USERNAME / AUR_EMAIL / AUR_SSH_PRIVATE_KEY not all set — skipping AUR publish."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download the .deb from the release
+        if: steps.creds.outputs.ready == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          # The release matrix can report success moments before the asset is
+          # finalised on the release, so retry rather than fail on a race.
+          for attempt in 1 2 3; do
+            if gh release download "$GITHUB_REF_NAME" \
+                --pattern "GitWand_${VERSION}_amd64.deb" \
+                --dir . --repo "$GITHUB_REPOSITORY"; then
+              break
+            fi
+            echo "::warning::.deb not yet available on $GITHUB_REF_NAME (attempt $attempt/3) — sleeping 15s"
+            sleep 15
+          done
+          [ -s "GitWand_${VERSION}_amd64.deb" ] || {
+            echo "::error::GitWand_${VERSION}_amd64.deb missing from release $GITHUB_REF_NAME after retries"
+            exit 1
+          }
+
+      - name: Generate PKGBUILD
+        if: steps.creds.outputs.ready == 'true'
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          SHA256_DEB=$(sha256sum "GitWand_${VERSION}_amd64.deb" | awk '{print $1}')
+          SHA256_LICENSE=$(sha256sum LICENSE | awk '{print $1}')
+          sed -e "s/#VERSION#/${VERSION}/g" \
+              -e "s/#SHA256_DEB#/${SHA256_DEB}/g" \
+              -e "s/#SHA256_LICENSE#/${SHA256_LICENSE}/g" \
+              scripts/PKGBUILD.template > PKGBUILD
+          # A placeholder left unsubstituted would publish a PKGBUILD that can
+          # never validate its sources. Cheaper to catch here than on the AUR.
+          if grep -q '#[A-Z_]*#' PKGBUILD; then
+            echo "::error::PKGBUILD still contains unsubstituted placeholders:"
+            grep -n '#[A-Z_]*#' PKGBUILD
+            exit 1
+          fi
+          echo "--- generated PKGBUILD ---"
+          cat PKGBUILD
+
+      - name: Publish to the AUR
+        if: steps.creds.outputs.ready == 'true'
+        # Pinned to the v4.2.0 commit, not a moving tag: this action receives
+        # the AUR SSH private key, so a retagged upstream would silently get
+        # our credentials. Bump deliberately, with a diff.
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050
+        with:
+          pkgname: gitwand-bin
+          pkgbuild: ./PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ github.ref_name }}"
+          # Have makepkg actually build the package before it is published.
+          # Publishing a PKGBUILD nobody ever built is how Arch users end up
+          # reporting the breakage for us.
+          test: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **GitWand is published to the Arch User Repository as `gitwand-bin`.** A release now generates a `PKGBUILD` from the `.deb` it just built and pushes it to the AUR, so Arch users can install with any AUR helper instead of unpacking a Debian package by hand. Original work by [@t1gu1](https://github.com/t1gu1) in #100. The publish step is skipped with a warning when the AUR credentials are absent rather than failing the release, the third-party action is pinned to a commit rather than a moving tag because it receives the AUR SSH private key, and `makepkg` builds the package before it is published: verified end to end in an Arch container, where the generated `PKGBUILD` builds, installs, and puts `gitwand-desktop` and the licence where they belong.
+
 - **CI now checks that the packaged `.deb` actually starts.** Nothing did: `rust-check` compiles, `bundle-smoke` proves the bundler still produces a package, and neither ever ran the result. A new job installs the built `.deb` on **ubuntu-24.04** (Linux Mint 22's base, deliberately not the 22.04 it is built on) and launches it headless, failing unless the process is still alive after 20 seconds, since a GUI app has no success exit code. It captures the output a real GUI launch throws away: the `.desktop` entry ships `Terminal=false`, which is why #139 arrived with no diagnostics at all and sat unresolvable for a month.
 
 ### Fixed

--- a/scripts/PKGBUILD.template
+++ b/scripts/PKGBUILD.template
@@ -1,0 +1,29 @@
+# Maintainer: Laurent Guitton <laurent@devlint.fr>
+# Contributor: GitWand Release Bot <actions@github.com>
+
+pkgname=gitwand-bin
+pkgver=#VERSION#
+pkgrel=1
+pkgdesc="Automatic Git merge conflict resolution desktop client"
+arch=('x86_64')
+url="https://github.com/devlint/GitWand"
+license=('MIT')
+depends=('webkit2gtk-4.1' 'gtk3' 'libayatana-appindicator' 'xdotool' 'nss' 'libxtst')
+provides=('gitwand')
+conflicts=('gitwand')
+source_x86_64=(
+  "https://github.com/devlint/GitWand/releases/download/v${pkgver}/GitWand_${pkgver}_amd64.deb"
+  "LICENSE::https://raw.githubusercontent.com/devlint/GitWand/v${pkgver}/LICENSE"
+)
+sha256sums_x86_64=(
+  '#SHA256_DEB#'
+  '#SHA256_LICENSE#'
+)
+
+package() {
+  # Extract the Debian data file
+  bsdtar -xf data.tar.* -C "${pkgdir}"
+  
+  # Install the license file
+  install -Dm644 LICENSE -t "${pkgdir}/usr/share/licenses/${pkgname}/"
+}

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -12,7 +12,7 @@ GitWand is available as a desktop app, a CLI tool, and a VS Code extension. Inst
 Download the latest release for your platform:
 
 - **macOS** — `.dmg` (Universal: Apple Silicon + Intel)
-- **Linux** — `.AppImage` or `.deb`
+- **Linux** — `.AppImage` or `.deb` (also available in the AUR as `gitwand-bin`)
 - **Windows** — `.msi` or `.exe`
 
 👉 [Download from GitHub Releases](https://github.com/devlint/GitWand/releases)


### PR DESCRIPTION
Supersedes #100, whose branch was 228 commits behind and conflicted on `release.yml`. All the substance is [@t1gu1](https://github.com/t1gu1)'s; the commit credits them as co-author. Thanks for it, and sorry it sat.

## Why it stalled

Not the code. The job needs `AUR_USERNAME`, `AUR_EMAIL` and `AUR_SSH_PRIVATE_KEY`, which require an AUR account and an SSH key uploaded to it. Only the repo owner can create those, so an external contributor could not finish it.

`gitwand-bin` is still unclaimed on the AUR (no `gitwand*` package exists), so nothing has been lost by the delay.

## What I changed before landing it

**Secret guard.** As written the job would have **failed every release** until the credentials existed. That is the trap in "merge now, configure later", and it is why this could not just be merged. Absent credentials now skip the publish with a warning, matching the Homebrew job directly above it.

**Pinned the action.** `KSXGitHub/github-actions-deploy-aur` receives the AUR SSH private key. `@v3` is a moving tag: a retagged upstream silently gets those credentials. Now pinned to the v4.2.0 commit `084b0d9`. v3 was stale anyway; v4's inputs are compatible.

**The package is now built before it is published.** `test: true` runs makepkg, and the generated PKGBUILD is rejected if any `#PLACEHOLDER#` survived substitution. Publishing a PKGBUILD nobody ever built is how Arch users end up reporting our breakage for us.

## Verified, not reasoned about

In an `archlinux` container, against the real shipped `GitWand_3.10.1_amd64.deb`:

| Step | Result |
|---|---|
| `makepkg --clean --cleanbuild --nodeps` | exit 0, produced `gitwand-bin-3.10.1-1-x86_64.pkg.tar.zst` |
| `pacman -U` | installs cleanly |
| Contents | `/usr/bin/gitwand-desktop`, `GitWand.desktop`, icons |
| Licence | `/usr/share/licenses/gitwand-bin/LICENSE` |

So the contributor's `package()` is correct: makepkg unpacks the `.deb` into `data.tar.*` and `bsdtar` does the rest. `license=('MIT')` also matches the repo's actual licence.

## What's still needed from the maintainer

This is mergeable as-is and inert until the credentials exist:

1. Register on https://aur.archlinux.org/
2. `ssh-keygen -f ~/.ssh/aur_key -t ed25519 -C "<email>"`, upload `aur_key.pub` to the AUR profile
3. Add `AUR_USERNAME`, `AUR_EMAIL`, `AUR_SSH_PRIVATE_KEY` as repository secrets

The next tagged release then publishes `gitwand-bin` automatically. Until then, every release logs `AUR_USERNAME / AUR_EMAIL / AUR_SSH_PRIVATE_KEY not all set — skipping AUR publish.` and carries on.